### PR TITLE
Implement project admin commands. Fixes #8

### DIFF
--- a/annif/annif.py
+++ b/annif/annif.py
@@ -33,11 +33,11 @@ projectIndexConf = {
         }
 
 
-def parseIndexname(projectid):
+def parse_indexname(projectid):
     return "{0}-{1}".format(annif.config['INDEX_NAME'], projectid)
 
 
-def listOrphanIndices():
+def list_orphan_indices():
     indices = [x.split()[2] for x in cat.indices().split('\n') if len(x) > 0]
     return [x for x in indices if x.startswith(annif.config['INDEX_NAME'])]
 
@@ -55,7 +55,7 @@ def init():
     # When the repository is initialized, check also if any orphaned indices
     # (= indices starting with INDEX_NAME) are found and remove them.
 
-    for i in listOrphanIndices():
+    for i in list_orphan_indices():
         index.delete(i)
 
     print('Initialized project index \'{0}\'.'.format(
@@ -65,7 +65,7 @@ def init():
 
 
 @annif.cli.command('list-projects')
-def listprojects():
+def list_projects():
     """
     List available projects.
 
@@ -86,13 +86,14 @@ def listprojects():
         doc_type='project',
         body=doc)['hits']['hits']]
 
-    for p in projects:
-        formatted += template.format(p['name'], p['language'], p['analyzer'])
+    for proj in projects:
+        formatted += template.format(proj['name'], proj['language'],
+                                     proj['analyzer'])
 
     print(formatted)
 
 
-def formatResult(result):
+def format_result(result):
     template = "{0:<15}{1}\n"
     content = result['hits']['hits'][0]
     formatted = template.format('Project ID:', content['_source']['name'])
@@ -103,7 +104,7 @@ def formatResult(result):
 
 @annif.cli.command('show-project')
 @click.argument('projectid')
-def showProject(projectid):
+def show_project(projectid):
     """
     Show project information.
 
@@ -118,7 +119,7 @@ def showProject(projectid):
                        body={'query': {'match': {'name': projectid}}})
 
     if (result['hits']['hits']):
-        print(formatResult(result))
+        print(format_result(result))
     else:
         print("No projects found with id \'{0}\'.".format(projectid))
 
@@ -127,7 +128,7 @@ def showProject(projectid):
 @click.argument('projectid')
 @click.option('--language')
 @click.option('--analyzer')
-def createProject(projectid, language, analyzer):
+def create_project(projectid, language, analyzer):
     """
     Create a new project.
 
@@ -139,7 +140,7 @@ def createProject(projectid, language, analyzer):
     PUT /projects/<projectId>
     """
 
-    proj_indexname = parseIndexname(projectid)
+    proj_indexname = parse_indexname(projectid)
 
     if not projectid or not language or not analyzer:
         print('Usage: annif create-project <projectId> --language <lang> '
@@ -160,7 +161,7 @@ def createProject(projectid, language, analyzer):
 
 @annif.cli.command('drop-project')
 @click.argument('projectid')
-def dropProject(projectid):
+def drop_project(projectid):
     """
     Delete a project.
     USAGE: annif drop-project <projectid>
@@ -176,13 +177,13 @@ def dropProject(projectid):
     print(result)
 
     # Then delete the project index
-    result = index.delete(index=parseIndexname(projectid))
+    result = index.delete(index=parse_indexname(projectid))
     print(result)
 
 
 @annif.cli.command('list-subjects')
 @click.argument('projectid')
-def listSubjects(projectid):
+def list_subjects(projectid):
     """
     Show all subjects for a project.
 
@@ -198,7 +199,7 @@ def listSubjects(projectid):
 @annif.cli.command('show-subject')
 @click.argument('projectid')
 @click.argument('subjectid')
-def showSubject(projectid, subjectid):
+def show_subject(projectid, subjectid):
     """
     Show information about a subject.
 
@@ -214,7 +215,7 @@ def showSubject(projectid, subjectid):
 @annif.cli.command('create-subject')
 @click.argument('projectid')
 @click.argument('subjectid')
-def createSubject(projectid, subjectid):
+def create_subject(projectid, subjectid):
     """
     Create a new subject, or update an existing one.
 
@@ -243,7 +244,7 @@ def load(projectid, directory, clear):
 @annif.cli.command('drop-subject')
 @click.argument('projectid')
 @click.argument('subjectid')
-def dropSubject(projectid, subjectid):
+def drop_subject(projectid, subjectid):
     """
     Delete a subject.
 

--- a/annif/annif.py
+++ b/annif/annif.py
@@ -159,7 +159,7 @@ def create_project(projectid, language, analyzer):
     if not projectid or not language or not analyzer:
         print('Usage: annif create-project <projectId> --language <lang> '
               '--analyzer <analyzer>')
-    elif index.exists(proj_indexname):
+    elif index.exists(format_index_name(projectid)):
         print('Index \'{0}\' already exists.'
                 .format(format_index_name(projectid)))
     else:

--- a/annif/annif.py
+++ b/annif/annif.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 import click
-import sys
 from flask import Flask
 from elasticsearch import Elasticsearch
 from elasticsearch.client import IndicesClient, CatClient
@@ -140,7 +139,7 @@ def createProject(projectid, language, analyzer):
     """
     proj_indexname = parseIndexname(projectid)
 
-    if (not projectid or not language or not analyzer):
+    if not projectid or not language or not analyzer:
         print('Usage: annif create-project <projectId> --language <lang> '
               '--analyzer <analyzer>')
 
@@ -152,10 +151,10 @@ def createProject(projectid, language, analyzer):
         index.create(index=proj_indexname)
 
         # Add the details of the new project to the 'master' index
-        resp = es.create(index=annif.config['INDEX_NAME'], doc_type='project',
-                         id=projectid,
-                         body={'name': projectid, 'language': language,
-                               'analyzer': analyzer})
+        es.create(index=annif.config['INDEX_NAME'],
+                  doc_type='project', id=projectid,
+                  body={'name': projectid, 'language': language,
+                        'analyzer': analyzer})
         print('Successfully created project \'{0}\'.'.format(projectid))
 
 

--- a/annif/annif.py
+++ b/annif/annif.py
@@ -93,10 +93,6 @@ def listprojects():
 
 
 def formatResult(result):
-
-    def formatRow(key, value):
-        return str('{:15}'.format("" + key + ":") + str(value) + "\n")
-
     template = "{0:<15}{1}\n"
     content = result['hits']['hits'][0]
     formatted = template.format('Project ID:', content['_source']['name'])

--- a/annif/annif.py
+++ b/annif/annif.py
@@ -156,8 +156,6 @@ def create_project(projectid, language, analyzer):
     PUT /projects/<projectId>
     """
 
-    proj_indexname = format_index_name(projectid)
-
     if not projectid or not language or not analyzer:
         print('Usage: annif create-project <projectId> --language <lang> '
               '--analyzer <analyzer>')

--- a/annif/annif.py
+++ b/annif/annif.py
@@ -100,6 +100,16 @@ def list_projects():
 
 
 def format_result(result):
+    """
+    A helper function for show_project. Takes a dict containing project
+    information as returned by ES client and returns a human-readable
+    string representation formatted as follows:
+
+    Project ID:    testproj
+    Language:      fi
+    Analyzer       finglish
+
+    """
     template = "{0:<15}{1}\n"
     content = result['hits']['hits'][0]
     formatted = template.format('Project ID:', content['_source']['name'])
@@ -152,10 +162,11 @@ def create_project(projectid, language, analyzer):
         print('Usage: annif create-project <projectId> --language <lang> '
               '--analyzer <analyzer>')
     elif index.exists(proj_indexname):
-        print('Index \'{0}\' already exists.'.format(proj_indexname))
+        print('Index \'{0}\' already exists.'
+                .format(format_index_name(projectid)))
     else:
         # Create an index for the project
-        index.create(index=proj_indexname)
+        index.create(index=format_index_name(projectid))
 
         # Add the details of the new project to the 'master' index
         es.create(index=annif.config['INDEX_NAME'],

--- a/annif/annif.py
+++ b/annif/annif.py
@@ -74,11 +74,19 @@ def listprojects():
     doc = {'size': 1000, 'query': {'match_all': {}}}
     results = es.search(index=annif.config['INDEX_NAME'], doc_type='project',
                         body=doc)
+
     projects = [x['_source'] for x in results['hits']['hits']]
-    print("Currently available projects:\n")
-    for i, p in enumerate(projects):
-        print("{0}. {1} (language: {2}, analyzer: {3})"
-               .format(1+i, p['name'], p['language'], p['analyzer']))
+
+    def parseRow(col1, col2, col3):
+        return "{0: <15}{1: <15}{2: <15}\n".format(col1, col2, col3)
+
+    parsed = parseRow("Project ID", "Language", "Analyzer")
+    parsed += str("-" * len(parsed) + "\n")
+
+    for p in projects:
+        parsed += parseRow(p['name'], p['language'], p['analyzer'])
+
+    print(parsed)
 
 
 @annif.cli.command('show-project')
@@ -95,7 +103,7 @@ def showProject(projectid):
     """
 
     def parseRow(key, value):
-        return str('{:20}'.format("" + key + ":") + str(value) + "\n")
+        return str('{:15}'.format("" + key + ":") + str(value) + "\n")
 
     result = es.search(index=annif.config['INDEX_NAME'],
                        doc_type='project',
@@ -103,10 +111,10 @@ def showProject(projectid):
 
     if (result['hits']['hits']):
         content = result['hits']['hits'][0]
-        parsed = "details about project \'{0}\':\n\n".format(content['_source']['name'])
-        parsed += parseRow('project name', content['_source']['name'])
-        parsed += parseRow('project language', content['_source']['language'])
-        parsed += parseRow('project analyzer', content['_source']['analyzer'])
+        parsed = ""
+        parsed += parseRow('Project ID', content['_source']['name'])
+        parsed += parseRow('Language', content['_source']['language'])
+        parsed += parseRow('Analyzer', content['_source']['analyzer'])
         print(parsed)
     else:
         print("No projects found with id \'{0}\'.".format(projectid))

--- a/annif/annif.py
+++ b/annif/annif.py
@@ -107,8 +107,6 @@ def showProject(projectid):
         parsed += parseRow('project name', content['_source']['name'])
         parsed += parseRow('project language', content['_source']['language'])
         parsed += parseRow('project analyzer', content['_source']['analyzer'])
-        parsed += parseRow('index', content['_index'])
-        parsed += parseRow('score', content['_score'])
         print(parsed)
     else:
         print("No projects found with id \'{0}\'.".format(projectid))

--- a/annif/annif.py
+++ b/annif/annif.py
@@ -75,35 +75,34 @@ def listprojects():
     """
 
     doc = {'size': 1000, 'query': {'match_all': {}}}
-    results = es.search(index=annif.config['INDEX_NAME'], doc_type='project',
-                        body=doc)
 
-    projects = [x['_source'] for x in results['hits']['hits']]
+    template = "{0: <15}{1: <15}{2: <15}\n"
 
-    def formatRow(col1, col2, col3):
-        return "{0: <15}{1: <15}{2: <15}\n".format(col1, col2, col3)
+    formatted = template.format("Project ID", "Language", "Analyzer")
+    formatted += str("-" * len(formatted) + "\n")
 
-    parsed = formatRow("Project ID", "Language", "Analyzer")
-    parsed += str("-" * len(parsed) + "\n")
+    projects = [x['_source'] for x in es.search(
+        index=annif.config['INDEX_NAME'],
+        doc_type='project',
+        body=doc)['hits']['hits']]
 
     for p in projects:
-        parsed += formatRow(p['name'], p['language'], p['analyzer'])
+        formatted += template.format(p['name'], p['language'], p['analyzer'])
 
-    print(parsed)
+    print(formatted)
 
 
-def parseResult(result):
+def formatResult(result):
 
     def formatRow(key, value):
         return str('{:15}'.format("" + key + ":") + str(value) + "\n")
 
+    template = "{0:<15}{1}\n"
     content = result['hits']['hits'][0]
-    parsed = ""
-    parsed += formatRow('Project ID', content['_source']['name'])
-    parsed += formatRow('Language', content['_source']['language'])
-    parsed += formatRow('Analyzer', content['_source']['analyzer'])
-
-    return parsed
+    formatted = template.format('Project ID:', content['_source']['name'])
+    formatted += template.format('Language:', content['_source']['language'])
+    formatted += template.format('Analyzer', content['_source']['analyzer'])
+    return formatted
 
 
 @annif.cli.command('show-project')
@@ -123,7 +122,7 @@ def showProject(projectid):
                        body={'query': {'match': {'name': projectid}}})
 
     if (result['hits']['hits']):
-        print(parseResult(result))
+        print(formatResult(result))
     else:
         print("No projects found with id \'{0}\'.".format(projectid))
 

--- a/annif/annif.py
+++ b/annif/annif.py
@@ -80,28 +80,28 @@ def listprojects():
 
     projects = [x['_source'] for x in results['hits']['hits']]
 
-    def parseRow(col1, col2, col3):
+    def formatRow(col1, col2, col3):
         return "{0: <15}{1: <15}{2: <15}\n".format(col1, col2, col3)
 
-    parsed = parseRow("Project ID", "Language", "Analyzer")
+    parsed = formatRow("Project ID", "Language", "Analyzer")
     parsed += str("-" * len(parsed) + "\n")
 
     for p in projects:
-        parsed += parseRow(p['name'], p['language'], p['analyzer'])
+        parsed += formatRow(p['name'], p['language'], p['analyzer'])
 
     print(parsed)
 
 
 def parseResult(result):
 
-    def parseRow(key, value):
+    def formatRow(key, value):
         return str('{:15}'.format("" + key + ":") + str(value) + "\n")
 
     content = result['hits']['hits'][0]
     parsed = ""
-    parsed += parseRow('Project ID', content['_source']['name'])
-    parsed += parseRow('Language', content['_source']['language'])
-    parsed += parseRow('Analyzer', content['_source']['analyzer'])
+    parsed += formatRow('Project ID', content['_source']['name'])
+    parsed += formatRow('Language', content['_source']['language'])
+    parsed += formatRow('Analyzer', content['_source']['analyzer'])
 
     return parsed
 

--- a/annif/annif.py
+++ b/annif/annif.py
@@ -33,7 +33,7 @@ projectIndexConf = {
         }
 
 
-def parse_indexname(projectid):
+def format_index_name(projectid):
     """
     Return an index name formatted like annif-project.
     """
@@ -146,7 +146,7 @@ def create_project(projectid, language, analyzer):
     PUT /projects/<projectId>
     """
 
-    proj_indexname = parse_indexname(projectid)
+    proj_indexname = format_index_name(projectid)
 
     if not projectid or not language or not analyzer:
         print('Usage: annif create-project <projectId> --language <lang> '
@@ -183,7 +183,7 @@ def drop_project(projectid):
     print(result)
 
     # Then delete the project index
-    result = index.delete(index=parse_indexname(projectid))
+    result = index.delete(index=format_index_name(projectid))
     print(result)
 
 

--- a/annif/annif.py
+++ b/annif/annif.py
@@ -140,24 +140,22 @@ def createProject(projectid, language, analyzer):
     """
     proj_indexname = parseIndexname(projectid)
 
-    if not projectid or not language or not analyzer:
+    if (not projectid or not language or not analyzer):
         print('Usage: annif create-project <projectId> --language <lang> '
               '--analyzer <analyzer>')
-        sys.exit(1)
 
-    if index.exists(proj_indexname):
+    elif index.exists(proj_indexname):
         print('Index \'{0}\' already exists.'.format(proj_indexname))
-        sys.exit(1)
 
-    # Create an index for the project
-    index.create(index=proj_indexname)
+    else:
+        # Create an index for the project
+        index.create(index=proj_indexname)
 
-    # Add the details of the new project to the 'master' index
-    resp = es.create(index=annif.config['INDEX_NAME'], doc_type='project',
-                     id=projectid,
-                     body={'name': projectid, 'language': language,
-                           'analyzer': analyzer})
-    if (resp['created']):
+        # Add the details of the new project to the 'master' index
+        resp = es.create(index=annif.config['INDEX_NAME'], doc_type='project',
+                         id=projectid,
+                         body={'name': projectid, 'language': language,
+                               'analyzer': analyzer})
         print('Successfully created project \'{0}\'.'.format(projectid))
 
 

--- a/annif/annif.py
+++ b/annif/annif.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import click
+import sys
 from flask import Flask
 from elasticsearch import Elasticsearch
 from elasticsearch.client import IndicesClient, CatClient
@@ -140,23 +141,24 @@ def createProject(projectid, language, analyzer):
     proj_indexname = parseIndexname(projectid)
 
     if not projectid or not language or not analyzer:
-        print('Usage: annif create-project <projectId> --language <lang>'
+        print('Usage: annif create-project <projectId> --language <lang> '
               '--analyzer <analyzer>')
+        sys.exit(1)
 
-    elif index.exists(proj_indexname):
+    if index.exists(proj_indexname):
         print('Index \'{0}\' already exists.'.format(proj_indexname))
+        sys.exit(1)
 
-    else:
-        # Create an index for the project
-        index.create(index=proj_indexname)
+    # Create an index for the project
+    index.create(index=proj_indexname)
 
-        # Add the details of the new project to the 'master' index
-        resp = es.create(index=annif.config['INDEX_NAME'], doc_type='project',
-                         id=projectid,
-                         body={'name': projectid, 'language': language,
-                               'analyzer': analyzer})
-        if (resp['created']):
-            print('Successfully created project \'{0}\'.'.format(projectid))
+    # Add the details of the new project to the 'master' index
+    resp = es.create(index=annif.config['INDEX_NAME'], doc_type='project',
+                     id=projectid,
+                     body={'name': projectid, 'language': language,
+                           'analyzer': analyzer})
+    if (resp['created']):
+        print('Successfully created project \'{0}\'.'.format(projectid))
 
 
 @annif.cli.command('drop-project')

--- a/annif/annif.py
+++ b/annif/annif.py
@@ -75,8 +75,10 @@ def listprojects():
     results = es.search(index=annif.config['INDEX_NAME'], doc_type='project',
                         body=doc)
     projects = [x['_source'] for x in results['hits']['hits']]
-    for p in projects:
-        print(p)
+    print("Currently available projects:\n")
+    for i, p in enumerate(projects):
+        print("{0}. {1} (language: {2}, analyzer: {3})"
+               .format(1+i, p['name'], p['language'], p['analyzer']))
 
 
 @annif.cli.command('show-project')
@@ -91,10 +93,25 @@ def showProject(projectid):
 
     GET /projects/<projectId>
     """
+
+    def parseRow(key, value):
+        return str('{:20}'.format("" + key + ":") + str(value) + "\n")
+
     result = es.search(index=annif.config['INDEX_NAME'],
                        doc_type='project',
                        body={'query': {'match': {'name': projectid}}})
-    print(result)
+
+    if (result['hits']['hits']):
+        content = result['hits']['hits'][0]
+        parsed = "details about project \'{0}\':\n\n".format(content['_source']['name'])
+        parsed += parseRow('project name', content['_source']['name'])
+        parsed += parseRow('project language', content['_source']['language'])
+        parsed += parseRow('project analyzer', content['_source']['analyzer'])
+        parsed += parseRow('index', content['_index'])
+        parsed += parseRow('score', content['_score'])
+        print(parsed)
+    else:
+        print("No projects found with id \'{0}\'.".format(projectid))
 
 
 @annif.cli.command('create-project')

--- a/annif/annif.py
+++ b/annif/annif.py
@@ -7,7 +7,7 @@ from elasticsearch.client import IndicesClient, CatClient
 
 es = Elasticsearch()
 index = IndicesClient(es)
-cat = CatClient(es)
+CAT = CatClient(es)
 
 annif = Flask(__name__)
 
@@ -34,11 +34,17 @@ projectIndexConf = {
 
 
 def parse_indexname(projectid):
+    """
+    Return an index name formatted like annif-project.
+    """
     return "{0}-{1}".format(annif.config['INDEX_NAME'], projectid)
 
 
 def list_orphan_indices():
-    indices = [x.split()[2] for x in cat.indices().split('\n') if len(x) > 0]
+    """
+    Returns a list containing names of orphaned indices.
+    """
+    indices = [x.split()[2] for x in CAT.indices().split('\n') if len(x) > 0]
     return [x for x in indices if x.startswith(annif.config['INDEX_NAME'])]
 
 
@@ -118,7 +124,7 @@ def show_project(projectid):
                        doc_type='project',
                        body={'query': {'match': {'name': projectid}}})
 
-    if (result['hits']['hits']):
+    if result['hits']['hits']:
         print(format_result(result))
     else:
         print("No projects found with id \'{0}\'.".format(projectid))

--- a/tests/test_annif.py
+++ b/tests/test_annif.py
@@ -25,7 +25,7 @@ def test_start():
 
 def test_init():
     result = runner.invoke(annif.init)
-    assert index.exists('annif')
+    assert index.exists(annif.annif.config['INDEX_NAME'])
     assert result.exit_code == 0
 
 
@@ -35,21 +35,26 @@ def test_listprojects():
     assert runner.invoke(annif.listprojects, ['moi']).exit_code != 0
     assert runner.invoke(
             annif.listprojects, ['moi', '--debug', 'y']).exit_code != 0
-    output = runner.invoke(annif.listprojects).output
-
-
-def test_showProject():
-    pass
+    result = runner.invoke(annif.listprojects)
 
 
 def test_createProject():
+    assert not index.exists(annif.parseIndexname(TEMP_PROJECT))
     result = runner.invoke(annif.createProject, [TEMP_PROJECT, '--language',
         'en', '--analyzer', 'english'])
+    assert index.exists(annif.parseIndexname(TEMP_PROJECT))
+    assert result.exit_code == 0
+
+
+def test_showProject():
+    result = runner.invoke(annif.showProject, [TEMP_PROJECT])
     assert result.exit_code == 0
 
 
 def test_dropProject():
+    assert index.exists(annif.parseIndexname(TEMP_PROJECT))
     result = runner.invoke(annif.dropProject, [TEMP_PROJECT])
+    assert not index.exists(annif.parseIndexname(TEMP_PROJECT))
     assert result.exit_code == 0
 
 

--- a/tests/test_annif.py
+++ b/tests/test_annif.py
@@ -34,7 +34,7 @@ def test_init():
     assert result.exit_code == 0
 
 
-def test_listprojects():
+def test_list_projects():
     # The listprojects function does not accept any arguments, it should fail
     # if such are provided.
     assert runner.invoke(annif.list_projects, ['moi']).exit_code != 0
@@ -45,25 +45,25 @@ def test_listprojects():
 
 
 def test_create_project():
-    assert not index.exists(annif.parse_indexname(TEMP_PROJECT))
+    assert not index.exists(annif.format_index_name(TEMP_PROJECT))
     result = runner.invoke(annif.create_project,
                            [TEMP_PROJECT, '--language', 'en', '--analyzer',
                             'english'])
-    assert index.exists(annif.parse_indexname(TEMP_PROJECT))
+    assert index.exists(annif.format_index_name(TEMP_PROJECT))
     assert result.exit_code == 0
     # Creating a project should not succeed if an insufficient amount of args
     # are provided.
     FAILED_PROJECT = 'wow'
-    assert not index.exists(annif.parse_indexname(FAILED_PROJECT))
+    assert not index.exists(annif.format_index_name(FAILED_PROJECT))
     result = runner.invoke(annif.create_project,
                            [FAILED_PROJECT, '--language', 'en'])
-    assert not index.exists(annif.parse_indexname(FAILED_PROJECT))
+    assert not index.exists(annif.format_index_name(FAILED_PROJECT))
     result = runner.invoke(annif.create_project,
                            [FAILED_PROJECT, '--analyzer', 'english'])
-    assert not index.exists(annif.parse_indexname(FAILED_PROJECT))
+    assert not index.exists(annif.format_index_name(FAILED_PROJECT))
 
 
-def test_showproject():
+def test_show_project():
     result = runner.invoke(annif.show_project, [TEMP_PROJECT])
     assert result.exit_code == 0
     # Test should not fail even if the user queries for a non-existent project.
@@ -71,18 +71,18 @@ def test_showproject():
     assert failed_result.exit_code == 0
 
 
-def test_dropproject():
-    assert index.exists(annif.parse_indexname(TEMP_PROJECT))
+def test_drop_project():
+    assert index.exists(annif.format_index_name(TEMP_PROJECT))
     result = runner.invoke(annif.drop_project, [TEMP_PROJECT])
-    assert not index.exists(annif.parse_indexname(TEMP_PROJECT))
+    assert not index.exists(annif.format_index_name(TEMP_PROJECT))
     assert result.exit_code == 0
 
 
-def test_listSubjects():
+def test_list_subjects():
     pass
 
 
-def test_showSubject():
+def test_show_subject():
     pass
 
 
@@ -90,7 +90,7 @@ def test_load():
     pass
 
 
-def dropSubject():
+def test_drop_subject():
     pass
 
 

--- a/tests/test_annif.py
+++ b/tests/test_annif.py
@@ -37,44 +37,44 @@ def test_init():
 def test_listprojects():
     # The listprojects function does not accept any arguments, it should fail
     # if such are provided.
-    assert runner.invoke(annif.listprojects, ['moi']).exit_code != 0
+    assert runner.invoke(annif.list_projects, ['moi']).exit_code != 0
     assert runner.invoke(
-            annif.listprojects, ['moi', '--debug', 'y']).exit_code != 0
-    result = runner.invoke(annif.listprojects)
+            annif.list_projects, ['moi', '--debug', 'y']).exit_code != 0
+    result = runner.invoke(annif.list_projects)
     assert result.exit_code == 0
 
 
-def test_createProject():
-    assert not index.exists(annif.parseIndexname(TEMP_PROJECT))
-    result = runner.invoke(annif.createProject,
+def test_create_project():
+    assert not index.exists(annif.parse_indexname(TEMP_PROJECT))
+    result = runner.invoke(annif.create_project,
                            [TEMP_PROJECT, '--language', 'en', '--analyzer',
                             'english'])
-    assert index.exists(annif.parseIndexname(TEMP_PROJECT))
+    assert index.exists(annif.parse_indexname(TEMP_PROJECT))
     assert result.exit_code == 0
     # Creating a project should not succeed if an insufficient amount of args
     # are provided.
     FAILED_PROJECT = 'wow'
-    assert not index.exists(annif.parseIndexname(FAILED_PROJECT))
-    result = runner.invoke(annif.createProject,
+    assert not index.exists(annif.parse_indexname(FAILED_PROJECT))
+    result = runner.invoke(annif.create_project,
                            [FAILED_PROJECT, '--language', 'en'])
-    assert not index.exists(annif.parseIndexname(FAILED_PROJECT))
-    result = runner.invoke(annif.createProject,
+    assert not index.exists(annif.parse_indexname(FAILED_PROJECT))
+    result = runner.invoke(annif.create_project,
                            [FAILED_PROJECT, '--analyzer', 'english'])
-    assert not index.exists(annif.parseIndexname(FAILED_PROJECT))
+    assert not index.exists(annif.parse_indexname(FAILED_PROJECT))
 
 
-def test_showProject():
-    result = runner.invoke(annif.showProject, [TEMP_PROJECT])
+def test_showproject():
+    result = runner.invoke(annif.show_project, [TEMP_PROJECT])
     assert result.exit_code == 0
     # Test should not fail even if the user queries for a non-existent project.
-    failed_result = runner.invoke(annif.showProject, ['nonexistent'])
+    failed_result = runner.invoke(annif.show_project, ['nonexistent'])
     assert failed_result.exit_code == 0
 
 
-def test_dropProject():
-    assert index.exists(annif.parseIndexname(TEMP_PROJECT))
-    result = runner.invoke(annif.dropProject, [TEMP_PROJECT])
-    assert not index.exists(annif.parseIndexname(TEMP_PROJECT))
+def test_dropproject():
+    assert index.exists(annif.parse_indexname(TEMP_PROJECT))
+    result = runner.invoke(annif.drop_project, [TEMP_PROJECT])
+    assert not index.exists(annif.parse_indexname(TEMP_PROJECT))
     assert result.exit_code == 0
 
 
@@ -83,10 +83,6 @@ def test_listSubjects():
 
 
 def test_showSubject():
-    pass
-
-
-def createSubject():
     pass
 
 

--- a/tests/test_annif.py
+++ b/tests/test_annif.py
@@ -16,6 +16,11 @@ runner = CliRunner()
 
 # Generate a random project name to use in tests
 TEMP_PROJECT = ''.join(random.choice('abcdefghiklmnopqrstuvwxyz') for _ in range(8))
+TEMP_INDEX = TEMP_PROJECT[:7]
+
+# Set a random name for the project index, so as not to mess up possible
+# production indices.
+annif.annif.config['INDEX_NAME'] = TEMP_INDEX
 
 
 # A dummy test for setup purposes
@@ -48,6 +53,9 @@ def test_createProject():
 
 def test_showProject():
     result = runner.invoke(annif.showProject, [TEMP_PROJECT])
+    assert result.exit_code == 0
+    # Test should not fail even if the user queries for a non-existent project.
+    failed_result = runner.invoke(annif.showProject, ['nonexistent'])
     assert result.exit_code == 0
 
 


### PR DESCRIPTION
A basic implementation for project administration commands. The `annif init` command also now checks for orphaned indexes and removes them if necessary.