### PR TITLE
Batch evaluation metrics

### DIFF
--- a/annif/cli.py
+++ b/annif/cli.py
@@ -217,9 +217,10 @@ def run_eval(project_id, subject_file, limit, threshold, backend_param):
         gold_subjects = annif.corpus.SubjectSet(subjfile.read())
 
     template = "{0:<20}\t{1}"
-    for metric, result, merge_function in annif.eval.evaluate_hits(
-            hits, gold_subjects):
-        click.echo(template.format(metric + ":", result))
+    eval_batch = annif.eval.EvaluationBatch()
+    eval_batch.evaluate(hits, gold_subjects)
+    for metric, score in eval_batch.results().items():
+        click.echo(template.format(metric + ":", score))
 
 
 @cli.command('evaldir')

--- a/annif/eval.py
+++ b/annif/eval.py
@@ -97,18 +97,24 @@ def evaluate(selected, gold):
     ]
 
 
+def transform_sample(sample):
+    hits, gold_subjects = sample
+    if gold_subjects.has_uris():
+        selected = [hit.uri for hit in hits]
+        gold_set = gold_subjects.subject_uris
+    else:
+        selected = [hit.label for hit in hits]
+        gold_set = gold_subjects.subject_labels
+    return (selected, gold_set)
+
+
 def evaluate_hits(samples):
     """evaluate a list of samples with hits and gold standard subjects,
        returning evaluation metrics"""
 
     results = []
-    for hits, gold_subjects in samples:
-        if gold_subjects.has_uris():
-            selected = [hit.uri for hit in hits]
-            gold_set = gold_subjects.subject_uris
-        else:
-            selected = [hit.label for hit in hits]
-            gold_set = gold_subjects.subject_labels
+    transformed_samples = [transform_sample(sample) for sample in samples]
+    for selected, gold_set in transformed_samples:
         results.append(evaluate(selected, gold_set))
     measures = collections.OrderedDict()
     merge_functions = {}

--- a/annif/eval.py
+++ b/annif/eval.py
@@ -5,7 +5,7 @@ import statistics
 import numpy
 import warnings
 from sklearn.preprocessing import MultiLabelBinarizer
-from sklearn.metrics import precision_score, recall_score
+from sklearn.metrics import precision_score, recall_score, f1_score
 
 
 def precision(selected, relevant):
@@ -44,17 +44,15 @@ def recall(selected, relevant):
         return recall_score(y_true, y_pred, average='samples')
 
 
-def f_measure(A, B):
+def f_measure(selected, relevant):
     """return the F-measure similarity of two sets"""
-    scores = []
-    for asubj, bsubj in zip(A, B):
-        setA = set(asubj)
-        setB = set(bsubj)
-        if len(setA) == 0 or len(setB) == 0:
-            scores.append(0.0)  # shortcut, avoid division by zero
-        else:
-            scores.append(2.0 * len(setA & setB) / (len(setA) + len(setB)))
-    return statistics.mean(scores)
+    mlb = MultiLabelBinarizer()
+    mlb.fit(list(relevant) + list(selected))
+    y_true = mlb.transform(relevant)
+    y_pred = mlb.transform(selected)
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore')
+        return f1_score(y_true, y_pred, average='samples')
 
 
 def true_positives(selected, relevant):

--- a/annif/eval.py
+++ b/annif/eval.py
@@ -15,6 +15,18 @@ def precision(selected, relevant):
     return len(sel & rel) / len(sel)
 
 
+def precision_1(selected, relevant):
+    return precision(selected[:1], relevant)
+
+
+def precision_3(selected, relevant):
+    return precision(selected[:3], relevant)
+
+
+def precision_5(selected, relevant):
+    return precision(selected[:5], relevant)
+
+
 def recall(selected, relevant):
     """return the recall, i.e. the fraction of relevant instances that were
     selected"""
@@ -79,6 +91,14 @@ def normalized_dcg(selected, relevant, at_k):
     return dcg_val / dcg_max
 
 
+def normalized_dcg_5(selected, relevant):
+    return normalized_dcg(selected, relevant, 5)
+
+
+def normalized_dcg_10(selected, relevant):
+    return normalized_dcg(selected, relevant, 10)
+
+
 def evaluate(selected, gold):
     """evaluate a set of selected subject against a gold standard using
     different metrics"""
@@ -86,11 +106,11 @@ def evaluate(selected, gold):
         ('Precision', precision(selected, gold), statistics.mean),
         ('Recall', recall(selected, gold), statistics.mean),
         ('F-measure', f_measure(selected, gold), statistics.mean),
-        ('NDCG@5', normalized_dcg(selected, gold, 5), statistics.mean),
-        ('NDCG@10', normalized_dcg(selected, gold, 10), statistics.mean),
-        ('Precision@1', precision(selected[:1], gold), statistics.mean),
-        ('Precision@3', precision(selected[:3], gold), statistics.mean),
-        ('Precision@5', precision(selected[:5], gold), statistics.mean),
+        ('NDCG@5', normalized_dcg_5(selected, gold), statistics.mean),
+        ('NDCG@10', normalized_dcg_10(selected, gold), statistics.mean),
+        ('Precision@1', precision_1(selected, gold), statistics.mean),
+        ('Precision@3', precision_3(selected, gold), statistics.mean),
+        ('Precision@5', precision_5(selected, gold), statistics.mean),
         ('True positives', true_positives(selected, gold), sum),
         ('False positives', false_positives(selected, gold), sum),
         ('False negatives', false_negatives(selected, gold), sum)

--- a/annif/eval.py
+++ b/annif/eval.py
@@ -3,20 +3,21 @@
 import collections
 import statistics
 import numpy
+import warnings
+from sklearn.preprocessing import MultiLabelBinarizer
+from sklearn.metrics import precision_score
 
 
 def precision(selected, relevant):
     """return the precision, i.e. the fraction of selected instances that
     are relevant"""
-    scores = []
-    for ssubj, rsubj in zip(selected, relevant):
-        sel = set(ssubj)
-        rel = set(rsubj)
-        if len(sel) == 0:
-            scores.append(0.0)  # avoid division by zero
-        else:
-            scores.append(len(sel & rel) / len(sel))
-    return statistics.mean(scores)
+    mlb = MultiLabelBinarizer()
+    mlb.fit(list(relevant) + list(selected))
+    y_true = mlb.transform(relevant)
+    y_pred = mlb.transform(selected)
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore')
+        return precision_score(y_true, y_pred, average='samples')
 
 
 def precision_1(selected, relevant):

--- a/annif/eval.py
+++ b/annif/eval.py
@@ -136,14 +136,6 @@ def transform_sample(sample):
     return (selected, gold_set)
 
 
-def evaluate_hits(samples):
-    """evaluate a list of samples with hits and gold standard subjects,
-       returning evaluation metrics"""
-
-    transformed_samples = [transform_sample(sample) for sample in samples]
-    return evaluate(transformed_samples)
-
-
 class EvaluationBatch:
     """A class for evaluating batches of results using all available metrics.
     The evaluate() method is called once per document in the batch.
@@ -156,4 +148,6 @@ class EvaluationBatch:
         self._samples.append((hits, gold_subjects))
 
     def results(self):
-        return evaluate_hits(self._samples)
+        transformed_samples = [transform_sample(sample)
+                               for sample in self._samples]
+        return evaluate(transformed_samples)

--- a/annif/eval.py
+++ b/annif/eval.py
@@ -8,16 +8,20 @@ from sklearn.preprocessing import MultiLabelBinarizer
 from sklearn.metrics import precision_score, recall_score, f1_score
 
 
-def precision(selected, relevant):
-    """return the precision, i.e. the fraction of selected instances that
-    are relevant"""
+def sklearn_metric_score(selected, relevant, metric_fn):
     mlb = MultiLabelBinarizer()
     mlb.fit(list(relevant) + list(selected))
     y_true = mlb.transform(relevant)
     y_pred = mlb.transform(selected)
     with warnings.catch_warnings():
         warnings.simplefilter('ignore')
-        return precision_score(y_true, y_pred, average='samples')
+        return metric_fn(y_true, y_pred, average='samples')
+
+
+def precision(selected, relevant):
+    """return the precision, i.e. the fraction of selected instances that
+    are relevant"""
+    return sklearn_metric_score(selected, relevant, precision_score)
 
 
 def precision_1(selected, relevant):
@@ -35,24 +39,12 @@ def precision_5(selected, relevant):
 def recall(selected, relevant):
     """return the recall, i.e. the fraction of relevant instances that were
     selected"""
-    mlb = MultiLabelBinarizer()
-    mlb.fit(list(relevant) + list(selected))
-    y_true = mlb.transform(relevant)
-    y_pred = mlb.transform(selected)
-    with warnings.catch_warnings():
-        warnings.simplefilter('ignore')
-        return recall_score(y_true, y_pred, average='samples')
+    return sklearn_metric_score(selected, relevant, recall_score)
 
 
 def f_measure(selected, relevant):
     """return the F-measure similarity of two sets"""
-    mlb = MultiLabelBinarizer()
-    mlb.fit(list(relevant) + list(selected))
-    y_true = mlb.transform(relevant)
-    y_pred = mlb.transform(selected)
-    with warnings.catch_warnings():
-        warnings.simplefilter('ignore')
-        return f1_score(y_true, y_pred, average='samples')
+    return sklearn_metric_score(selected, relevant, f1_score)
 
 
 def true_positives(selected, relevant):

--- a/annif/eval.py
+++ b/annif/eval.py
@@ -116,15 +116,17 @@ class EvaluationBatch:
     Final results can be queried using the results() method."""
 
     def __init__(self):
-        self._results = []
+        self._samples = []
 
     def evaluate(self, hits, gold_subjects):
-        self._results.append(evaluate_hits(hits, gold_subjects))
+        self._samples.append((hits, gold_subjects))
 
     def results(self):
+        results = [evaluate_hits(hits, gold_subjects)
+                   for hits, gold_subjects in self._samples]
         measures = collections.OrderedDict()
         merge_functions = {}
-        for result in self._results:
+        for result in results:
             for metric, score, merge_function in result:
                 measures.setdefault(metric, [])
                 measures[metric].append(score)

--- a/annif/eval.py
+++ b/annif/eval.py
@@ -5,7 +5,7 @@ import statistics
 import numpy
 import warnings
 from sklearn.preprocessing import MultiLabelBinarizer
-from sklearn.metrics import precision_score
+from sklearn.metrics import precision_score, recall_score
 
 
 def precision(selected, relevant):
@@ -35,15 +35,13 @@ def precision_5(selected, relevant):
 def recall(selected, relevant):
     """return the recall, i.e. the fraction of relevant instances that were
     selected"""
-    scores = []
-    for ssubj, rsubj in zip(selected, relevant):
-        sel = set(ssubj)
-        rel = set(rsubj)
-        if len(rel) == 0:
-            scores.append(0.0)  # avoid division by zero
-        else:
-            scores.append(len(sel & rel) / len(rel))
-    return statistics.mean(scores)
+    mlb = MultiLabelBinarizer()
+    mlb.fit(list(relevant) + list(selected))
+    y_true = mlb.transform(relevant)
+    y_pred = mlb.transform(selected)
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore')
+        return recall_score(y_true, y_pred, average='samples')
 
 
 def f_measure(A, B):

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -6,98 +6,98 @@ import annif.hit
 
 
 def test_precision():
-    selected = set(['A', 'C', 'E', 'F', 'H'])
-    gold = set(['A', 'B', 'C', 'D'])
+    selected = [set(['A', 'C', 'E', 'F', 'H'])]
+    gold = [set(['A', 'B', 'C', 'D'])]
     assert annif.eval.precision(selected, gold) == 0.4
 
 
 def test_precision_empty():
-    selected = set()
-    gold = set(['A', 'B', 'C', 'D'])
+    selected = [set()]
+    gold = [set(['A', 'B', 'C', 'D'])]
     assert annif.eval.precision(selected, gold) == 0.0
 
 
 def test_precision_empty2():
-    selected = set(['A', 'C', 'E', 'F', 'H'])
-    gold = set()
+    selected = [set(['A', 'C', 'E', 'F', 'H'])]
+    gold = [set()]
     assert annif.eval.precision(selected, gold) == 0.0
 
 
 def test_recall():
-    selected = set(['A', 'C', 'E', 'F'])
-    gold = set(['A', 'B', 'C', 'D', 'E'])
+    selected = [set(['A', 'C', 'E', 'F'])]
+    gold = [set(['A', 'B', 'C', 'D', 'E'])]
     assert annif.eval.recall(selected, gold) == 0.6
 
 
 def test_recall_empty():
-    selected = set()
-    gold = set(['A', 'B', 'C', 'D', 'E'])
+    selected = [set()]
+    gold = [set(['A', 'B', 'C', 'D', 'E'])]
     assert annif.eval.recall(selected, gold) == 0.0
 
 
 def test_recall_empty2():
-    selected = set(['A', 'C', 'E', 'F'])
-    gold = set()
+    selected = [set(['A', 'C', 'E', 'F'])]
+    gold = [set()]
     assert annif.eval.recall(selected, gold) == 0.0
 
 
 def test_f_measure():
-    selected = set(['complex systems', 'network', 'small world'])
-    gold = set(['theoretical', 'small world', 'network', 'dynamics'])
+    selected = [set(['complex systems', 'network', 'small world'])]
+    gold = [set(['theoretical', 'small world', 'network', 'dynamics'])]
     f_measure = annif.eval.f_measure(selected, gold)
     assert f_measure > 0.57
     assert f_measure < 0.58
 
 
 def test_ndcg_empty():
-    selected = []
-    gold = ['A', 'E', 'I', 'O', 'U']
+    selected = [[]]
+    gold = [['A', 'E', 'I', 'O', 'U']]
     ndcg = annif.eval.normalized_dcg(selected, gold, 5)
     assert ndcg == 0
 
 
 def test_ndcg_empty2():
-    selected = ['A', 'B', 'C', 'D', 'E']
-    gold = []
+    selected = [['A', 'B', 'C', 'D', 'E']]
+    gold = [[]]
     ndcg = annif.eval.normalized_dcg(selected, gold, 5)
     assert ndcg == 0
 
 
 def test_ndcg_5():
-    selected = ['A', 'B', 'C', 'D', 'E', 'F', 'G']  # len=7
-    gold = ['A', 'E', 'I', 'O', 'U', 'Z', 'X',
-            'C', 'V', 'B', 'N', 'M']  # len=12
+    selected = [['A', 'B', 'C', 'D', 'E', 'F', 'G']]  # len=7
+    gold = [['A', 'E', 'I', 'O', 'U', 'Z', 'X',
+             'C', 'V', 'B', 'N', 'M']]  # len=12
     ndcg = annif.eval.normalized_dcg(selected, gold, 5)
     assert ndcg > 0.85
     assert ndcg < 0.86
 
 
 def test_ndcg_10():
-    selected = ['A', 'B', 'C', 'D', 'E', 'F', 'G']  # len=7
-    gold = ['A', 'E', 'I', 'O', 'U', 'Z', 'X',
-            'C', 'V', 'B', 'N', 'M']  # len=12
+    selected = [['A', 'B', 'C', 'D', 'E', 'F', 'G']]  # len=7
+    gold = [['A', 'E', 'I', 'O', 'U', 'Z', 'X',
+             'C', 'V', 'B', 'N', 'M']]  # len=12
     ndcg = annif.eval.normalized_dcg(selected, gold, 10)
     assert ndcg > 0.55
     assert ndcg < 0.56
 
 
 def test_true_positives():
-    selected = ['A', 'B', 'C']
-    gold = ['A', 'C', 'E', 'F', 'G']
+    selected = [['A', 'B', 'C']]
+    gold = [['A', 'C', 'E', 'F', 'G']]
     true_positives = annif.eval.true_positives(selected, gold)
     assert true_positives == 2
 
 
 def test_false_positives():
-    selected = ['A', 'B', 'C']
-    gold = ['A', 'C', 'E', 'F', 'G']
+    selected = [['A', 'B', 'C']]
+    gold = [['A', 'C', 'E', 'F', 'G']]
     false_positives = annif.eval.false_positives(selected, gold)
     assert false_positives == 1
 
 
 def test_false_negatives():
-    selected = ['A', 'B', 'C']
-    gold = ['A', 'C', 'E', 'F', 'G']
+    selected = [['A', 'B', 'C']]
+    gold = [['A', 'C', 'E', 'F', 'G']]
     false_negatives = annif.eval.false_negatives(selected, gold)
     assert false_negatives == 3
 


### PR DESCRIPTION
This PR changes the way evaluation metrics are implemented. Previously they were run separately for each document and the results aggregated on the outer level. After this PR the evaluation measures instead take batches of documents and only return the final score.

The custom implementations of precision, recall and f-measure (f1 score) metrics are replaced by their sklearn equivalents.