### PR TITLE
Add LGTM configuration excluding fasttext

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,0 +1,4 @@
+extraction:
+  python:
+    python_setup:
+      exclude_requirements: "fasttext"


### PR DESCRIPTION
Hi, as discussed over on the LGTM forum: https://discuss.lgtm.com/t/mostly-python-project-detected-as-javascript/1335