### PR TITLE
use fasttextmirror package from official PyPI instead of fasttext from test PyPI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,5 @@ script:
   - pytest --cov=./
 after_success:
   - codecov
-  - coveralls
 notifications:
   slack: kansalliskirjasto:tyt7yhMrgqceJoKiSNt09nvV

--- a/Pipfile
+++ b/Pipfile
@@ -3,14 +3,8 @@ url = "https://pypi.python.org/simple"
 name = "pypi"
 verify_ssl = true
 
-[[source]]
-url = "https://testpypi.python.org/pypi"
-verify_ssl = true
-name = "test"
-
 [dev-packages]
 codecov = "*"
-python-coveralls = "*"
 pytest-cov = "*"
 pytest-watch = "*"
 pytest-flask = "*"
@@ -25,7 +19,7 @@ click-log = "*"
 nltk = "*"
 gensim = "*"
 sklearn = "*"
-fasttext = {version="*", index="test"}
+fasttextmirror = "*"
 rdflib = "*"
 
 [requires]

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
         'nltk',
         'gensim',
         'sklearn',
-        'fasttext',
+        'fasttextmirror',
         'rdflib'],
     entry_points={
         'console_scripts': ['annif=annif.cli:cli']})


### PR DESCRIPTION
This should make it easier to install the package also without Pipenv.
Also removes python-coveralls dependency because it caused install problems with Pipenv, probably because it explicitly depends on coverage==4.0.3 and there are other dependencies which will accept a newer version.