### PR TITLE
Switch to Xenial build system in Travis; test on Python 3.7 too

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
-sudo: false
+dist: xenial
 language: python
 python:
 - '3.5'
 - '3.6'
+- '3.7'
 cache: pip
 before_install:
 - export BOTO_CONFIG=/dev/null


### PR DESCRIPTION
The container-based Precise image we were using is no longer available, so it makes sense to switch to the most modern build environment available. We also get test on Python 3.7 which was previously difficult.