### PR TITLE
vw-multi backend: use input from other projects

### DIFF
--- a/annif/backend/fasttext.py
+++ b/annif/backend/fasttext.py
@@ -108,12 +108,9 @@ class FastTextBackend(mixins.ChunkingBackend, backend.AnnifBackend):
         self._create_model()
 
     def _predict_chunks(self, chunktexts, project, limit):
-        normalized_chunks = []
-        for chunktext in chunktexts:
-            normalized = self._normalize_text(project, chunktext)
-            if normalized != '':
-                normalized_chunks.append(normalized)
-        return self._model.predict(normalized_chunks, limit)
+        return self._model.predict(list(
+            filter(None, [self._normalize_text(project, chunktext)
+                          for chunktext in chunktexts])), limit)
 
     def _analyze_chunks(self, chunktexts, project):
         limit = int(self.params['limit'])

--- a/annif/backend/fasttext.py
+++ b/annif/backend/fasttext.py
@@ -107,9 +107,18 @@ class FastTextBackend(mixins.ChunkingBackend, backend.AnnifBackend):
         self._create_train_file(corpus, project)
         self._create_model()
 
+    def _predict_chunks(self, chunktexts, project, limit):
+        normalized_chunks = []
+        for chunktext in chunktexts:
+            normalized = self._normalize_text(project, chunktext)
+            if normalized != '':
+                normalized_chunks.append(normalized)
+        return self._model.predict(normalized_chunks, limit)
+
     def _analyze_chunks(self, chunktexts, project):
         limit = int(self.params['limit'])
-        chunklabels, chunkscores = self._model.predict(chunktexts, limit)
+        chunklabels, chunkscores = self._predict_chunks(
+            chunktexts, project, limit)
         label_scores = collections.defaultdict(float)
         for labels, scores in zip(chunklabels, chunkscores):
             for label, score in zip(labels, scores):

--- a/annif/backend/mixins.py
+++ b/annif/backend/mixins.py
@@ -24,10 +24,7 @@ class ChunkingBackend(metaclass=abc.ABCMeta):
         chunksize = int(params['chunksize'])
         chunktexts = []
         for i in range(0, len(sentences), chunksize):
-            chunktext = ' '.join(sentences[i:i + chunksize])
-            normalized = self._normalize_text(project, chunktext)
-            if normalized != '':
-                chunktexts.append(normalized)
+            chunktexts.append(' '.join(sentences[i:i + chunksize]))
         self.debug('Split sentences into {} chunks'.format(len(chunktexts)))
         if len(chunktexts) == 0:  # nothing to analyze, empty result
             return ListAnalysisResult(hits=[], subject_index=project.subjects)

--- a/annif/backend/vw_multi.py
+++ b/annif/backend/vw_multi.py
@@ -152,7 +152,10 @@ class VWMultiBackend(mixins.ChunkingBackend, backend.AnnifBackend):
     def _analyze_chunks(self, chunktexts, project):
         results = []
         for chunktext in chunktexts:
-            example = ' | {}'.format(chunktext)
+            normalized = self._normalize_text(project, chunktext)
+            if normalized == '':
+                continue
+            example = ' | {}'.format(normalized)
             result = self._model.predict(example)
             if self.algorithm == 'multilabel_oaa':
                 # result is a list of subject IDs - need to vectorize

--- a/annif/backend/vw_multi.py
+++ b/annif/backend/vw_multi.py
@@ -118,11 +118,10 @@ class VWMultiBackend(mixins.ChunkingBackend, backend.AnnifBackend):
                 proj = annif.project.get_project(input)
                 result = proj.analyze(text)
                 features = [
-                    '{}:{}'.format(
-                        self._cleanup_text(
-                            hit.uri),
-                        hit.score) for hit in result.hits]
-                namespaces[input] = ' '.join(features)
+                    '{}:{}'.format(self._cleanup_text(hit.uri), hit.score)
+                    for hit in result.hits]
+                if features:
+                    namespaces[input] = ' '.join(features)
         if not namespaces:
             return None
         return ' '.join(['|{} {}'.format(namespace, featurestr)
@@ -204,7 +203,7 @@ class VWMultiBackend(mixins.ChunkingBackend, backend.AnnifBackend):
             else:
                 result = np.array(result)
             results.append(result)
-        if len(results) == 0:  # empty result
+        if not results:  # empty result
             return ListAnalysisResult(hits=[], subject_index=project.subjects)
         return VectorAnalysisResult(
             np.array(results).mean(axis=0), project.subjects)

--- a/annif/backend/vw_multi.py
+++ b/annif/backend/vw_multi.py
@@ -109,18 +109,14 @@ class VWMultiBackend(mixins.ChunkingBackend, backend.AnnifBackend):
 
     def _get_input(self, input, project, text):
         if input == '_text_':
-            normalized = self._normalize_text(project, text)
-            if normalized != '':
-                return normalized
+            return self._normalize_text(project, text)
         else:
             proj = annif.project.get_project(input)
             result = proj.analyze(text)
             features = [
                 '{}:{}'.format(self._cleanup_text(hit.uri), hit.score)
                 for hit in result.hits]
-            if features:
-                return ' '.join(features)
-        return None
+            return ' '.join(features)
 
     def _inputs_to_exampletext(self, project, text):
         namespaces = {}

--- a/tests/test_backend_vw_multi.py
+++ b/tests/test_backend_vw_multi.py
@@ -13,7 +13,8 @@ def vw_corpus(tmpdir):
     """return a small document corpus for testing VW training"""
     tmpfile = tmpdir.join('document.tsv')
     tmpfile.write("nonexistent\thttp://example.com/nonexistent\n" +
-                  "arkeologia\thttp://www.yso.fi/onto/yso/p1265")
+                  "arkeologia\thttp://www.yso.fi/onto/yso/p1265\n" +
+                  "...\thttp://example.com/none")
     return annif.corpus.DocumentFile(str(tmpfile))
 
 

--- a/tests/test_backend_vw_multi.py
+++ b/tests/test_backend_vw_multi.py
@@ -44,6 +44,22 @@ def test_vw_multi_train(datadir, document_corpus, project):
     assert datadir.join('vw-model').size() > 0
 
 
+def test_vw_multi_train_from_project(app, datadir, document_corpus, project):
+    vw_type = annif.backend.get_backend('vw_multi')
+    vw = vw_type(
+        backend_id='vw_multi',
+        params={
+            'chunksize': 4,
+            'inputs': '_text_,dummy-en'},
+        datadir=str(datadir))
+
+    with app.app_context():
+        vw.train(document_corpus, project)
+    assert vw._model is not None
+    assert datadir.join('vw-model').exists()
+    assert datadir.join('vw-model').size() > 0
+
+
 def test_vw_multi_train_multiple_passes(datadir, document_corpus, project):
     vw_type = annif.backend.get_backend('vw_multi')
     vw = vw_type(


### PR DESCRIPTION
Makes it possible to specify what inputs are used to build the VW model. Thus it's possible to use e.g. a well trained subject indexing algorithm as input to the vw classifier.