### PR TITLE
Refactor: extract data directory handling into a mixin class

### DIFF
--- a/annif/backend/backend.py
+++ b/annif/backend/backend.py
@@ -20,14 +20,7 @@ class AnnifBackend(metaclass=abc.ABCMeta):
         backend type."""
         self.backend_id = backend_id
         self.params = params
-        self._datadir = datadir
-
-    def _get_datadir(self):
-        """return the path of the directory where this backend can store its
-        data files"""
-        if not os.path.exists(self._datadir):
-            os.makedirs(self._datadir)
-        return self._datadir
+        self.datadir = datadir
 
     def train(self, corpus, project):
         """train the model on the given document or subject corpus"""

--- a/annif/backend/fasttext.py
+++ b/annif/backend/fasttext.py
@@ -41,7 +41,7 @@ class FastTextBackend(mixins.ChunkingBackend, backend.AnnifBackend):
 
     def initialize(self):
         if self._model is None:
-            path = os.path.join(self._get_datadir(), self.MODEL_FILE)
+            path = os.path.join(self.datadir, self.MODEL_FILE)
             self.debug('loading fastText model from {}'.format(path))
             if os.path.exists(path):
                 self._model = fastText.load_model(path)
@@ -89,14 +89,14 @@ class FastTextBackend(mixins.ChunkingBackend, backend.AnnifBackend):
                                   for uri in doc.uris]
 
         annif.util.atomic_save(doc_subjects,
-                               self._get_datadir(),
+                               self.datadir,
                                self.TRAIN_FILE,
                                method=self._write_train_file)
 
     def _create_model(self):
         self.info('creating fastText model')
-        trainpath = os.path.join(self._get_datadir(), self.TRAIN_FILE)
-        modelpath = os.path.join(self._get_datadir(), self.MODEL_FILE)
+        trainpath = os.path.join(self.datadir, self.TRAIN_FILE)
+        modelpath = os.path.join(self.datadir, self.MODEL_FILE)
         params = {param: self.FASTTEXT_PARAMS[param](val)
                   for param, val in self.params.items()
                   if param in self.FASTTEXT_PARAMS}

--- a/annif/backend/pav.py
+++ b/annif/backend/pav.py
@@ -31,7 +31,7 @@ class PAVBackend(ensemble.EnsembleBackend):
         sources = annif.util.parse_sources(self.params['sources'])
         for source_project_id, _ in sources:
             model_filename = self.MODEL_FILE_PREFIX + source_project_id
-            path = os.path.join(self._get_datadir(), model_filename)
+            path = os.path.join(self.datadir, model_filename)
             if os.path.exists(path):
                 self.debug('loading PAV model from {}'.format(path))
                 self._models[source_project_id] = joblib.load(path)
@@ -91,7 +91,7 @@ class PAVBackend(ensemble.EnsembleBackend):
         model_filename = self.MODEL_FILE_PREFIX + source_project_id
         annif.util.atomic_save(
             pav_regressions,
-            self._get_datadir(),
+            self.datadir,
             model_filename,
             method=joblib.dump)
 

--- a/annif/backend/tfidf.py
+++ b/annif/backend/tfidf.py
@@ -23,7 +23,7 @@ class TFIDFBackend(backend.AnnifBackend):
 
     def initialize(self):
         if self._index is None:
-            path = os.path.join(self._get_datadir(), self.INDEX_FILE)
+            path = os.path.join(self.datadir, self.INDEX_FILE)
             self.debug('loading similarity index from {}'.format(path))
             if os.path.exists(path):
                 self._index = gensim.similarities.SparseMatrixSimilarity.load(
@@ -42,7 +42,7 @@ class TFIDFBackend(backend.AnnifBackend):
             gscorpus, num_features=len(project.vectorizer.vocabulary_))
         annif.util.atomic_save(
             self._index,
-            self._get_datadir(),
+            self.datadir,
             self.INDEX_FILE)
 
     def _analyze(self, text, project, params):

--- a/annif/backend/vw_multi.py
+++ b/annif/backend/vw_multi.py
@@ -45,7 +45,7 @@ class VWMultiBackend(mixins.ChunkingBackend, backend.AnnifBackend):
 
     def initialize(self):
         if self._model is None:
-            path = os.path.join(self._get_datadir(), self.MODEL_FILE)
+            path = os.path.join(self.datadir, self.MODEL_FILE)
             if not os.path.exists(path):
                 raise NotInitializedException(
                     'model {} not found'.format(path),
@@ -139,7 +139,7 @@ class VWMultiBackend(mixins.ChunkingBackend, backend.AnnifBackend):
             examples.extend(self._format_examples(project, text, doc.uris))
         random.shuffle(examples)
         annif.util.atomic_save(examples,
-                               self._get_datadir(),
+                               self.datadir,
                                self.TRAIN_FILE,
                                method=self._write_train_file)
 
@@ -169,7 +169,7 @@ class VWMultiBackend(mixins.ChunkingBackend, backend.AnnifBackend):
 
     def _create_model(self, project):
         self.info('creating VW model (algorithm: {})'.format(self.algorithm))
-        trainpath = os.path.join(self._get_datadir(), self.TRAIN_FILE)
+        trainpath = os.path.join(self.datadir, self.TRAIN_FILE)
         params = self._create_params(
             {'data': trainpath, self.algorithm: len(project.subjects)})
         if params.get('passes', 1) > 1:
@@ -177,7 +177,7 @@ class VWMultiBackend(mixins.ChunkingBackend, backend.AnnifBackend):
             params.update({'cache': True, 'kill_cache': True})
         self.debug("model parameters: {}".format(params))
         self._model = pyvw.vw(**params)
-        modelpath = os.path.join(self._get_datadir(), self.MODEL_FILE)
+        modelpath = os.path.join(self.datadir, self.MODEL_FILE)
         self._model.save(modelpath)
 
     def train(self, corpus, project):

--- a/annif/datadir.py
+++ b/annif/datadir.py
@@ -1,0 +1,17 @@
+"""Mixin class for types that need a data directory"""
+
+import os
+import os.path
+
+
+class DatadirMixin:
+    """Mixin class for types that need a data directory for storing files"""
+
+    def __init__(self, datadir, typename, identifier):
+        self._datadir_path = os.path.join(datadir, typename, identifier)
+
+    @property
+    def datadir(self):
+        if not os.path.exists(self._datadir_path):
+            os.makedirs(self._datadir_path)
+        return self._datadir_path

--- a/annif/vocab.py
+++ b/annif/vocab.py
@@ -1,16 +1,16 @@
 """Vocabulary management functionality for Annif"""
 
-import os
 import os.path
 import annif
 import annif.corpus
 import annif.util
+from annif.datadir import DatadirMixin
 from annif.exception import NotInitializedException
 
 logger = annif.logger
 
 
-class AnnifVocabulary:
+class AnnifVocabulary(DatadirMixin):
     """Class representing a subject vocabulary which can be used by multiple
     Annif projects."""
 
@@ -18,24 +18,17 @@ class AnnifVocabulary:
     _subjects = None
 
     def __init__(self, vocab_id, datadir):
+        DatadirMixin.__init__(self, datadir, 'vocabs', vocab_id)
         self.vocab_id = vocab_id
-        self._datadir = os.path.join(datadir, 'vocabs', self.vocab_id)
-
-    def _get_datadir(self):
-        """return the path of the directory where this project can store its
-        data files"""
-        if not os.path.exists(self._datadir):
-            os.makedirs(self._datadir)
-        return self._datadir
 
     def _create_subject_index(self, subject_corpus):
         self._subjects = annif.corpus.SubjectIndex(subject_corpus)
-        annif.util.atomic_save(self._subjects, self._get_datadir(), 'subjects')
+        annif.util.atomic_save(self._subjects, self.datadir, 'subjects')
 
     @property
     def subjects(self):
         if self._subjects is None:
-            path = os.path.join(self._get_datadir(), 'subjects')
+            path = os.path.join(self.datadir, 'subjects')
             if os.path.exists(path):
                 logger.debug('loading subjects from %s', path)
                 self._subjects = annif.corpus.SubjectIndex.load(path)


### PR DESCRIPTION
This little refactoring introduces a DatadirMixin class that can be used by AnnifProject and AnnifVocabulary. Gets rid of the near-duplicate `_get_datadir` methods, hopefully silencing Code Climate complaints.