### PR TITLE
Remove unused imports and declare dependencies used

### DIFF
--- a/annif/backend/__init__.py
+++ b/annif/backend/__init__.py
@@ -1,7 +1,5 @@
 """Registry of backend types for Annif"""
 
-import configparser
-from flask import current_app
 from . import dummy
 from . import ensemble
 from . import http

--- a/annif/corpus/__init__.py
+++ b/annif/corpus/__init__.py
@@ -7,3 +7,7 @@ from .subject import SubjectIndex, SubjectSet
 from .skos import SubjectFileSKOS
 from .types import Document
 from .combine import CombinedCorpus
+
+__all__ = [DocumentDirectory, DocumentFile, DocumentList, Subject,
+           SubjectDirectory, SubjectFileTSV, SubjectIndex, SubjectSet,
+           SubjectFileSKOS, Document, CombinedCorpus]

--- a/setup.py
+++ b/setup.py
@@ -21,16 +21,19 @@ setup(
     install_requires=[
         'connexion[swagger-ui]',
         'swagger_ui_bundle',
+        'flask',
         'flask-cors',
+        'click',
         'click-log',
         'nltk',
         'gensim',
         'sklearn',
         'rdflib'],
+    tests_require=['py', 'pytest', 'requests'],
     extras_require={
-        'fasttext': ['fasttextmirror'],
+        'fasttext': ['fasttext', 'fasttextmirror'],
         'voikko': ['voikko'],
-        'vw': ['vowpalwabbit'],
+        'vw': ['vowpalwabbit', 'numpy'],
     },
     entry_points={
         'console_scripts': ['annif=annif.cli:cli']},

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1,6 +1,5 @@
 """Unit tests for backends in Annif"""
 
-import os
 import pytest
 import annif
 import annif.backend

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,8 +4,6 @@ import contextlib
 import random
 import re
 import os.path
-import shutil
-import pytest
 from click.testing import CliRunner
 import annif.cli
 

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1,6 +1,5 @@
 """Unit tests for projects in Annif"""
 
-import os
 import pytest
 import annif.project
 import annif.backend.dummy

--- a/tests/test_rest.py
+++ b/tests/test_rest.py
@@ -1,6 +1,5 @@
 """Unit tests for REST API backend code in Annif"""
 
-import connexion
 import annif.rest
 
 


### PR DESCRIPTION
Today I worked on a different project and decided to use `click` for the first time from scratch. Knowing Annif used it, I came right here to look for the `setup.py` to see what was there.

Only found `click-log` (interesting!), but not `click`. Then decided to look what other transitive dependencies were being used in the project.

I think the second commit covers all the dependencies used in code and tests. Added them to the respective groups of dependencies.

Cheers
Bruno