### PR TITLE
Fix warning for joblib in scikit

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -18,6 +18,7 @@ connexion = {extras = ["swagger-ui"]}
 swagger-ui-bundle = "*"
 flask-cors = "*"
 click-log = "*"
+joblib = "*"
 nltk = "*"
 gensim = "*"
 sklearn = "*"

--- a/annif/backend/pav.py
+++ b/annif/backend/pav.py
@@ -4,7 +4,7 @@ PAV algorithm, a.k.a. isotonic regression, to turn raw scores returned by
 individual backends into probabilities."""
 
 import os.path
-from sklearn.externals import joblib
+import joblib
 from sklearn.isotonic import IsotonicRegression
 import numpy as np
 import annif.corpus

--- a/annif/project.py
+++ b/annif/project.py
@@ -4,7 +4,7 @@ import collections
 import configparser
 import enum
 import os.path
-from sklearn.externals import joblib
+import joblib
 from sklearn.feature_extraction.text import TfidfVectorizer
 from flask import current_app
 import annif

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
         'flask-cors',
         'click',
         'click-log',
+        'joblib',
         'nltk',
         'gensim',
         'sklearn',


### PR DESCRIPTION
Following the documentation and noticed the following warning:

```
/home/kinow/Development/python/workspace/Annif/venv/lib/python3.7/site-packages/sklearn/externals/joblib/__init__.py:15: DeprecationWarning: sklearn.externals.joblib is deprecated in 0.21 and will be removed in 0.23. Please import this functionality directly from joblib, which can be installed with: pip install joblib. If this warning is raised when loading pickled models, you may need to re-serialize those models with scikit-learn 0.21+.
  warnings.warn(msg, category=DeprecationWarning)
```

Not seen when running `pytest`.