### PR TITLE
Avoid calling update with empty dicts

### DIFF
--- a/annif/backend/backend.py
+++ b/annif/backend/backend.py
@@ -39,7 +39,7 @@ class AnnifBackend(metaclass=abc.ABCMeta):
         """Suggest subjects for the input text and return a list of subjects
         represented as a list of SubjectSuggestion objects."""
         beparams = dict(self.params)
-        if params is not None:
+        if params:
             beparams.update(params)
         return self._suggest(text, project, params=beparams)
 


### PR DESCRIPTION
Was passing some functions with a debugger reading the code and noticed that here when the dict was not `None`, it could still be empty. And the `update` method was being called unnecessarily.

Won't cause any speed up, but still worth changing it I think?