### PR TITLE
Add more features to the model in vw_ensemble

### DIFF
--- a/annif/backend/vw_ensemble.py
+++ b/annif/backend/vw_ensemble.py
@@ -44,6 +44,10 @@ class VWEnsembleBackend(
     # will make it more careful so that it will require more training data.
     DEFAULT_DISCOUNT_RATE = 0.01
 
+    # score threshold for "zero features": scores lower than this will be
+    # considered zero and marked with a zero feature given to VW
+    ZERO_THRESHOLD = 0.001
+
     def _load_subject_freq(self):
         path = os.path.join(self.datadir, self.FREQ_FILE)
         if not os.path.exists(path):
@@ -101,9 +105,16 @@ class VWEnsembleBackend(
             val = 1
         else:
             val = -1
-        ex = "{} |{}".format(val, subject_id)
-        for proj_idx, proj in enumerate(self._source_project_ids):
-            ex += " {}:{:.6f}".format(proj, scores[proj_idx])
+
+        features = " ".join(["{}:{:.6f}".format(proj, scores[proj_idx])
+                             for proj_idx, proj
+                             in enumerate(self._source_project_ids)])
+        zero_features = " ".join(["zero^{}".format(proj)
+                                  for proj_idx, proj
+                                  in enumerate(self._source_project_ids)
+                                  if scores[proj_idx] < self.ZERO_THRESHOLD])
+        ex = "{} |raw {} {} |{} {} {}".format(
+            val, features, zero_features, subject_id, features, zero_features)
         return ex
 
     def _doc_score_vector(self, doc, source_projects):
@@ -119,7 +130,8 @@ class VWEnsembleBackend(
         true = subjects.as_vector(project.subjects)
         score_vector = self._doc_score_vector(doc, source_projects)
         for subj_id in range(len(true)):
-            if true[subj_id] or score_vector[:, subj_id].sum() > 0.0:
+            if true[subj_id] \
+               or score_vector[:, subj_id].sum() >= self.ZERO_THRESHOLD:
                 ex = (subj_id, self._format_example(
                     subj_id,
                     score_vector[:, subj_id],

--- a/annif/backend/vw_ensemble.py
+++ b/annif/backend/vw_ensemble.py
@@ -113,9 +113,8 @@ class VWEnsembleBackend(
                                   for proj_idx, proj
                                   in enumerate(self._source_project_ids)
                                   if scores[proj_idx] < self.ZERO_THRESHOLD])
-        ex = "{} |raw {} {} |{} {} {}".format(
+        return "{} |raw {} {} |{} {} {}".format(
             val, features, zero_features, subject_id, features, zero_features)
-        return ex
 
     def _doc_score_vector(self, doc, source_projects):
         score_vectors = []

--- a/annif/backend/vw_ensemble.py
+++ b/annif/backend/vw_ensemble.py
@@ -98,14 +98,16 @@ class VWEnsembleBackend(
         sources = annif.util.parse_sources(self.params['sources'])
         return [project_id for project_id, _ in sources]
 
-    def _format_example(self, subject_id, scores, true=None):
+    @staticmethod
+    def _format_value(true):
         if true is None:
-            val = ''
+            return ''
         elif true:
-            val = 1
+            return 1
         else:
-            val = -1
+            return -1
 
+    def _format_example(self, subject_id, scores, true=None):
         features = " ".join(["{}:{:.6f}".format(proj, scores[proj_idx])
                              for proj_idx, proj
                              in enumerate(self._source_project_ids)])
@@ -114,7 +116,12 @@ class VWEnsembleBackend(
                                   in enumerate(self._source_project_ids)
                                   if scores[proj_idx] < self.ZERO_THRESHOLD])
         return "{} |raw {} {} |{} {} {}".format(
-            val, features, zero_features, subject_id, features, zero_features)
+            self._format_value(true),
+            features,
+            zero_features,
+            subject_id,
+            features,
+            zero_features)
 
     def _doc_score_vector(self, doc, source_projects):
         score_vectors = []

--- a/annif/backend/vw_ensemble.py
+++ b/annif/backend/vw_ensemble.py
@@ -148,6 +148,11 @@ class VWEnsembleBackend(
         random.shuffle(examples)
         return examples
 
+    def _create_model(self, project):
+        # add interactions between raw (descriptor-invariant) features to
+        # the mix
+        super()._create_model(project, {'q': 'rr'})
+
     @staticmethod
     def _write_freq_file(subject_freq, filename):
         with open(filename, 'w') as freqfile:

--- a/tests/test_backend_vw_ensemble.py
+++ b/tests/test_backend_vw_ensemble.py
@@ -126,7 +126,7 @@ def test_vw_ensemble_format_example(datadir):
         datadir=str(datadir))
 
     ex = vw_ensemble._format_example(0, [0.5])
-    assert ex == ' |0 dummy-en:0.500000'
+    assert ex == ' |raw dummy-en:0.500000  |0 dummy-en:0.500000 '
 
 
 def test_vw_ensemble_format_example_avoid_sci_notation(datadir):
@@ -137,4 +137,5 @@ def test_vw_ensemble_format_example_avoid_sci_notation(datadir):
         datadir=str(datadir))
 
     ex = vw_ensemble._format_example(0, [7.24e-05])
-    assert ex == ' |0 dummy-en:0.000072'
+    assert ex == ' |raw dummy-en:0.000072 zero^dummy-en' + \
+                 ' |0 dummy-en:0.000072 zero^dummy-en'


### PR DESCRIPTION
Related to #235 

This PR adds more features to the ML models built in the vw_ensemble backend:

* raw, descriptor invariant scores returned by the source project
* "zero features" whenever a source project returns a zero or near-zero score for a concept
* combinations (interactions) between raw scores

In my experiments, these additional features seem to give a small improvement in results.