### PR TITLE
Fix build to be triggered on push to master only

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -26,8 +26,8 @@ steps:
       repo: quay.io/natlibfi/annif
       tags: [dev]
 
-  trigger:
-    branch:
-    - master
-    event:
-    - push
+trigger:
+  branch:
+  - master
+  event:
+  - push

--- a/.drone.yml
+++ b/.drone.yml
@@ -26,6 +26,8 @@ steps:
       repo: quay.io/natlibfi/annif
       tags: [dev]
 
-    when:
-      event: push
-      branch: [master]
+  trigger:
+    branch:
+    - master
+    event:
+    - push


### PR DESCRIPTION
The previously used when clause applies only to individual steps of a pipeline