### PR TITLE
fix-RTD-build-error

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,3 @@
 sphinxcontrib-apidoc==0.3.0
+flask
+PyYAML>=5.1


### PR DESCRIPTION
Although the RTD build errors seemed already to be fixed by adding `.readthedocs.yml` (in #285), the errors still appeared (first in the stable version [build](https://readthedocs.org/projects/annif/builds/9330384/), then also in [latest](https://readthedocs.org/projects/annif/builds/9344263/). 

The errors seem to be related to capitalization of package names, the actual error is:

`error: The 'click' distribution was not found and is required by click-log, annif`

The same error raised also for `flask` (after trying to get pass the `click` error). 

See also the discussion in https://github.com/readthedocs/readthedocs.org/issues/4051


On my local machine a workaround for these is to add `flask` and `PyYAML` packages to the `requirements.txt`