### PR TITLE
Use vw version 8.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,10 @@ addons:
     - libboost-program-options-dev
     - libboost-python-dev
     - zlib1g-dev
+    - cmake
+    - libboost-system-dev
+    - libboost-thread-dev
+    - libboost-test-dev
 cache: pip
 before_install:
 - export BOTO_CONFIG=/dev/null

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,8 @@ install:
 # - voikko dependencies
 - if [[ $TRAVIS_PYTHON_VERSION == '3.5' ]]; then pip install voikko; fi
 # - vw dependencies
-- if [[ $TRAVIS_PYTHON_VERSION == '3.5' ]]; then sudo ln -sf /usr/lib/x86_64-linux-gnu/libboost_python-py35.a /usr/lib/x86_64-linux-gnu/libboost_python.a; fi
-- if [[ $TRAVIS_PYTHON_VERSION == '3.5' ]]; then sudo ln -sf /usr/lib/x86_64-linux-gnu/libboost_python-py35.so /usr/lib/x86_64-linux-gnu/libboost_python.so; fi
+- if [[ $TRAVIS_PYTHON_VERSION == '3.5' ]]; then sudo ln -sf /usr/lib/x86_64-linux-gnu/libboost_python-py35.a /usr/lib/x86_64-linux-gnu/libboost_python3.a; fi
+- if [[ $TRAVIS_PYTHON_VERSION == '3.5' ]]; then sudo ln -sf /usr/lib/x86_64-linux-gnu/libboost_python-py35.so /usr/lib/x86_64-linux-gnu/libboost_python3.so; fi
 - if [[ $TRAVIS_PYTHON_VERSION == '3.5' ]]; then pip install vowpalwabbit; fi
 script:
 - pytest --cov=./

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,13 +16,21 @@ RUN apt-get update \
 	&& pip install --no-cache-dir \
 		cython \
 		fasttextmirror \
-	## Vowpal Wabbit. Using old VW because 8.5 links to wrong Python version
+	## Vowpal Wabbit
 	&& apt-get install -y --no-install-recommends \
 		libboost-program-options-dev \
 		zlib1g-dev \
 		libboost-python-dev \
+		cmake \
+		libboost-system-dev \
+		libboost-thread-dev \
+		libboost-test-dev \
+	&& ln -sf /usr/lib/x86_64-linux-gnu/libboost_python-py35.a \
+		/usr/lib/x86_64-linux-gnu/libboost_python3.a \
+	&& ln -sf /usr/lib/x86_64-linux-gnu/libboost_python-py35.so \
+		/usr/lib/x86_64-linux-gnu/libboost_python3.so \
 	&& pip install --no-cache-dir \
-		vowpalwabbit==8.4
+		vowpalwabbit
 
 
 
@@ -38,12 +46,13 @@ RUN apt-get update \
 		voikko-fi \
 	&& pip install --no-cache-dir \
 		annif[voikko] \
-	## Vowpal Wabbit. Using old VW because 8.5 links to wrong Python version
+	## Vowpal Wabbit
 	&& apt-get install -y --no-install-recommends \
 		libboost-program-options1.62.0 \
 		libboost-python1.62.0 \
+		libboost-system1.62.0 \
 	&& pip install --no-cache-dir \
-		vowpalwabbit==8.4 \
+		vowpalwabbit \
 	## Clean up:
 	&& rm -rf /var/lib/apt/lists/* /usr/include/* \
 	&& rm -rf /root/.cache/pip*/*


### PR DESCRIPTION
Vowpalwabbit version [`8.7.0.post1`](https://github.com/VowpalWabbit/vowpal_wabbit/releases/tag/8.7.0) was released 12.7.2019 in Pypi. It requires a few new dependencies to be installed, and change on the linking fix of libboost. The [VW wikipage](https://github.com/NatLibFi/Annif/wiki/Optional-features-and-dependencies) has been updated according to these.

However, issue #291 states VW should be pinned to 8.5. Is that still valid now when newer version is released (note that 8.6 is not in Pypi)?