### PR TITLE
Issue297 set docker image tag from git tag

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -13,7 +13,6 @@ steps:
       registry: quay.io
       repo: quay.io/natlibfi/annif
       auto_tag: true
-      dry_run: true
 
 trigger:
   branch:

--- a/.drone.yml
+++ b/.drone.yml
@@ -12,8 +12,7 @@ steps:
         from_secret: docker_password
       registry: quay.io
       repo: quay.io/natlibfi/annif
-      tag: [test-tag]
-      dry_run: true
+      auto_tag: true
 
 trigger:
   branch:

--- a/.drone.yml
+++ b/.drone.yml
@@ -26,6 +26,20 @@ steps:
       repo: quay.io/natlibfi/annif
       tags: [dev]
 
+ - name: docker-tag-image-with-git-tag
+    image: plugins/docker
+    settings:
+      dockerfile: Dockerfile
+      username:
+        from_secret: docker_username
+      password:
+        from_secret: docker_password
+      registry: quay.io
+      repo: quay.io/natlibfi/annif
+      auto_tag: true
+      when:
+        event: tag
+
 trigger:
   branch:
   - master

--- a/.drone.yml
+++ b/.drone.yml
@@ -26,7 +26,7 @@ steps:
       repo: quay.io/natlibfi/annif
       tags: [dev]
 
- - name: docker-tag-image-with-git-tag
+  - name: docker-tag-image-with-git-tag
     image: plugins/docker
     settings:
       dockerfile: Dockerfile

--- a/.drone.yml
+++ b/.drone.yml
@@ -13,6 +13,7 @@ steps:
       registry: quay.io
       repo: quay.io/natlibfi/annif
       auto_tag: true
+      dry_run: true
 
 trigger:
   branch:

--- a/.drone.yml
+++ b/.drone.yml
@@ -2,7 +2,7 @@ kind: pipeline
 name: default
 steps:
 
-  - name: docker-tagged-release
+  - name: docker
     image: plugins/docker
     settings:
       dockerfile: Dockerfile
@@ -12,12 +12,22 @@ steps:
         from_secret: docker_password
       registry: quay.io
       repo: quay.io/natlibfi/annif
-      auto_tag: true
-      dry_run: true
+      tags: [latest]
+
+  - name: docker-dev
+    image: plugins/docker
+    settings:
+      dockerfile: Dockerfile-dev
+      username:
+        from_secret: docker_username
+      password:
+        from_secret: docker_password
+      registry: quay.io
+      repo: quay.io/natlibfi/annif
+      tags: [dev]
 
 trigger:
   branch:
   - master
-  - issue297-set-docker-image-tag-from-git-tag
   event:
   - push

--- a/.drone.yml
+++ b/.drone.yml
@@ -12,7 +12,8 @@ steps:
         from_secret: docker_password
       registry: quay.io
       repo: quay.io/natlibfi/annif
-      auto_tag: true
+      tag: [test-tag]
+      dry_run: true
 
 trigger:
   branch:

--- a/.drone.yml
+++ b/.drone.yml
@@ -2,7 +2,7 @@ kind: pipeline
 name: default
 steps:
 
-  - name: docker
+  - name: docker-tagged-release
     image: plugins/docker
     settings:
       dockerfile: Dockerfile
@@ -12,22 +12,12 @@ steps:
         from_secret: docker_password
       registry: quay.io
       repo: quay.io/natlibfi/annif
-      tags: [latest]
-
-  - name: docker-dev
-    image: plugins/docker
-    settings:
-      dockerfile: Dockerfile-dev
-      username:
-        from_secret: docker_username
-      password:
-        from_secret: docker_password
-      registry: quay.io
-      repo: quay.io/natlibfi/annif
-      tags: [dev]
+      auto_tag: true
+      dry_run: true
 
 trigger:
   branch:
   - master
+  - issue297-set-docker-image-tag-from-git-tag
   event:
   - push


### PR DESCRIPTION
When doing a release, a specific Docker image should now be build and tagged with the value from git tag (release version).

This closes #297.