### PR TITLE
Issue282 handling syntax errors in projects config

### DIFF
--- a/annif/default_config.py
+++ b/annif/default_config.py
@@ -36,3 +36,7 @@ class TestingInitializeConfig(TestingConfig):
 
 class TestingNoProjectsConfig(TestingConfig):
     PROJECTS_FILE = 'tests/notfound.cfg'
+
+
+class TestingInvalidProjectsConfig(TestingConfig):
+    PROJECTS_FILE = 'tests/projects_invalid.cfg'

--- a/annif/project.py
+++ b/annif/project.py
@@ -127,7 +127,7 @@ class AnnifProject(DatadirMixin):
             if self.analyzer_spec:
                 self._analyzer = annif.analyzer.get_analyzer(
                     self.analyzer_spec)
-            elif self.backend.needs_subject_vectorizer:
+            else:
                 raise ConfigurationException(
                     "analyzer setting is missing (and needed by the backend)",
                     project_id=self.project_id)

--- a/annif/project.py
+++ b/annif/project.py
@@ -87,10 +87,10 @@ class AnnifProject(DatadirMixin):
 
     def _initialize_backend(self):
         logger.debug("Project '%s': initializing backend", self.project_id)
-        if not self.backend:
-            logger.debug("Cannot initialize backend: does not exist")
-            return
         try:
+            if not self.backend:
+                logger.debug("Cannot initialize backend: does not exist")
+                return
             self.backend.initialize()
         except AnnifException as err:
             logger.warning(err.format_message())
@@ -127,6 +127,9 @@ class AnnifProject(DatadirMixin):
     @property
     def backend(self):
         if self._backend is None:
+            if 'backend' not in self.config:
+                raise ConfigurationException(
+                    "backend setting is missing", project_id=self.project_id)
             backend_id = self.config['backend']
             try:
                 backend_class = annif.backend.get_backend(backend_id)
@@ -214,7 +217,7 @@ class AnnifProject(DatadirMixin):
         return {'project_id': self.project_id,
                 'name': self.name,
                 'language': self.language,
-                'backend': {'backend_id': self.config['backend']}
+                'backend': {'backend_id': self.config.get('backend')}
                 }
 
 

--- a/annif/project.py
+++ b/annif/project.py
@@ -233,7 +233,11 @@ def _create_projects(projects_file, datadir, init_projects):
     config = configparser.ConfigParser()
     config.optionxform = lambda option: option
     with open(projects_file, encoding='utf-8') as projf:
-        config.read_file(projf)
+        try:
+            config.read_file(projf)
+        except (configparser.DuplicateOptionError,
+                configparser.DuplicateSectionError) as err:
+            raise ConfigurationException(err)
 
     # create AnnifProject objects from the configuration file
     projects = collections.OrderedDict()

--- a/tests/projects.cfg
+++ b/tests/projects.cfg
@@ -33,9 +33,9 @@ sources=dummy-en,dummydummy
 vocab=dummy
 
 [noanalyzer]
-name=TFIDF with no analyzer
+name=Dummy with no analyzer
 language=en
-backend=tfidf
+backend=dummy
 vocab=dummy
 
 [novocab]

--- a/tests/projects.cfg
+++ b/tests/projects.cfg
@@ -33,9 +33,9 @@ sources=dummy-en,dummydummy
 vocab=dummy
 
 [noanalyzer]
-name=Dummy with no analyzer
+name=TFIDF with no analyzer
 language=en
-backend=dummy
+backend=tfidf
 vocab=dummy
 
 [novocab]

--- a/tests/projects.cfg
+++ b/tests/projects.cfg
@@ -44,6 +44,12 @@ language=en
 backend=tfidf
 analyzer=snowball(english)
 
+[nobackend]
+name=Dummy with no backend
+language=en
+vocab=dummy
+analyzer=snowball(english)
+
 [pav]
 name=PAV Ensemble Finnish
 language=fi

--- a/tests/projects_invalid.cfg
+++ b/tests/projects_invalid.cfg
@@ -1,0 +1,23 @@
+# Project configuration for Annif unit tests
+
+[duplicatedproject]
+name=Dummy with no backend
+language=en
+backend=dummy
+vocab=dummy
+analyzer=snowball(english)
+
+[duplicatedproject]
+name=Dummy with no backend
+language=en
+backend=dummy
+vocab=dummy
+analyzer=snowball(english)
+
+[duplicatedvocab]
+name=Dummy with no backend
+language=en
+backend=dummy
+vocab=dummy
+vocab=dummy
+analyzer=snowball(english)

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -82,6 +82,14 @@ def test_get_project_nobackend(app):
             backend = project.backend
 
 
+def test_get_project_invalid_config_file(app):
+    app = annif.create_app(
+        config_name='annif.default_config.TestingInvalidProjectsConfig')
+    with app.app_context():
+        with pytest.raises(ConfigurationException):
+            project = annif.project.get_project('duplicatedvocab')
+
+
 def test_project_load_vocabulary_tfidf(app, vocabulary, testdatadir):
     with app.app_context():
         project = annif.project.get_project('tfidf-fi')

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -68,6 +68,13 @@ def test_get_project_nonexistent(app):
             annif.project.get_project('nonexistent')
 
 
+def test_get_project_noanalyzer(app):
+    with app.app_context():
+        project = annif.project.get_project('noanalyzer')
+        with pytest.raises(ConfigurationException):
+            analyzer = project.analyzer
+
+
 def test_get_project_novocab(app):
     with app.app_context():
         project = annif.project.get_project('novocab')

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -75,6 +75,13 @@ def test_get_project_novocab(app):
             vocab = project.vocab
 
 
+def test_get_project_nobackend(app):
+    with app.app_context():
+        project = annif.project.get_project('nobackend')
+        with pytest.raises(ConfigurationException):
+            backend = project.backend
+
+
 def test_project_load_vocabulary_tfidf(app, vocabulary, testdatadir):
     with app.app_context():
         project = annif.project.get_project('tfidf-fi')


### PR DESCRIPTION
 Raise `ConfigurationException` instead of full traceback in following situations:

1. when trying to use (train/suggest) a project without a backend set in `projects.cfg`:
    ```
    $ annif train nobackend -p tests/projects.cfg any_trainingdata.tsv 
    Error: Project 'nobackend': backend setting is missing
    ```
    This is in line with missing vocab error: ` "Error: Project 'maui-fi': vocab setting is missing"`.

2. when trying to use `projects.cfg` that has duplicated sections or entries:
    ```
    $ annif train any_backend -p tests/projects_invalid.cfg any_trainingdata.tsv 
    Error: Error: While reading from 'tests/projects_invalid.cfg' [line 10]: section 'duplicatedproject' already exists
    ```
This closes #282.
