### PR TITLE
Issue251 cli init command

### DIFF
--- a/annif/cli.py
+++ b/annif/cli.py
@@ -128,7 +128,7 @@ def run_show_project(project_id):
 @common_options
 def run_init_project(project_id):
     """
-    Remove the data files of a project.
+    Initialize the project to its original, untrained state.
     """
 
     proj = get_project(project_id)

--- a/annif/cli.py
+++ b/annif/cli.py
@@ -132,7 +132,6 @@ def run_clear_project(project_id):
     """
     proj = get_project(project_id)
     proj.remove_model_data()
-    click.echo('Removed model data for project {}.'.format(project_id))
 
 
 @cli.command('loadvoc')

--- a/annif/cli.py
+++ b/annif/cli.py
@@ -10,6 +10,7 @@ import click
 import click_log
 from flask import current_app
 from flask.cli import FlaskGroup, ScriptInfo
+from shutil import rmtree
 import annif
 import annif.corpus
 import annif.eval
@@ -130,19 +131,15 @@ def run_init_project(project_id):
     """
     Initialize the project to its original, untrained state.
     """
-
     proj = get_project(project_id)
-    datadir_path = proj.datadir
-    data_files = os.listdir(datadir_path)
-    if data_files:
-        for data_file in data_files:
-            os.remove(os.path.join(datadir_path, data_file))
-        click.echo('Removed data files for project {}.'.format(project_id))
-    else:
+    datadir_path = proj._datadir_path
+    if not os.path.isdir(datadir_path):
         click.echo(
-            'No data files to remove for project {}.'.format(project_id),
+            'No model data to remove for project {}.'.format(project_id),
             err=True)
         sys.exit(1)
+    rmtree(datadir_path)
+    click.echo('Removed model data for project {}.'.format(project_id))
 
 
 @cli.command('loadvoc')

--- a/annif/cli.py
+++ b/annif/cli.py
@@ -10,7 +10,6 @@ import click
 import click_log
 from flask import current_app
 from flask.cli import FlaskGroup, ScriptInfo
-from shutil import rmtree
 import annif
 import annif.corpus
 import annif.eval
@@ -132,13 +131,7 @@ def run_init_project(project_id):
     Initialize the project to its original, untrained state.
     """
     proj = get_project(project_id)
-    datadir_path = proj._datadir_path
-    if not os.path.isdir(datadir_path):
-        click.echo(
-            'No model data to remove for project {}.'.format(project_id),
-            err=True)
-        sys.exit(1)
-    rmtree(datadir_path)
+    proj.remove_model_data()
     click.echo('Removed model data for project {}.'.format(project_id))
 
 

--- a/annif/cli.py
+++ b/annif/cli.py
@@ -123,6 +123,28 @@ def run_show_project(project_id):
     click.echo(template.format('Access:', proj.access.name))
 
 
+@cli.command('init')
+@click.argument('project_id')
+@common_options
+def run_init_project(project_id):
+    """
+    Remove the data files of a project.
+    """
+
+    proj = get_project(project_id)
+    datadir_path = proj.datadir
+    data_files = os.listdir(datadir_path)
+    if data_files:
+        for data_file in data_files:
+            os.remove(os.path.join(datadir_path, data_file))
+        click.echo('Removed data files for project {}.'.format(project_id))
+    else:
+        click.echo(
+            'No data files to remove for project {}.'.format(project_id),
+            err=True)
+        sys.exit(1)
+
+
 @cli.command('loadvoc')
 @click.argument('project_id')
 @click.argument('subjectfile', type=click.Path(dir_okay=False))

--- a/annif/cli.py
+++ b/annif/cli.py
@@ -123,10 +123,10 @@ def run_show_project(project_id):
     click.echo(template.format('Access:', proj.access.name))
 
 
-@cli.command('init')
+@cli.command('clear')
 @click.argument('project_id')
 @common_options
-def run_init_project(project_id):
+def run_clear_project(project_id):
     """
     Initialize the project to its original, untrained state.
     """

--- a/annif/project.py
+++ b/annif/project.py
@@ -221,10 +221,13 @@ class AnnifProject(DatadirMixin):
     def remove_model_data(self):
         """remove the data of this project"""
         datadir_path = self._datadir_path
-        if not os.path.isdir(datadir_path):
-            raise AnnifException('No model data to remove for project {}.'
-                                 .format(self.project_id))
-        rmtree(datadir_path)
+        if os.path.isdir(datadir_path):
+            rmtree(datadir_path)
+            logger.info('Removed model data for project {}.'
+                        .format(self.project_id))
+        else:
+            logger.warning('No model data to remove for project {}.'
+                           .format(self.project_id))
 
 
 def _create_projects(projects_file, datadir, init_projects):

--- a/annif/project.py
+++ b/annif/project.py
@@ -7,6 +7,7 @@ import os.path
 import joblib
 from sklearn.feature_extraction.text import TfidfVectorizer
 from flask import current_app
+from shutil import rmtree
 import annif
 import annif.analyzer
 import annif.corpus
@@ -216,6 +217,14 @@ class AnnifProject(DatadirMixin):
                 'language': self.language,
                 'backend': {'backend_id': self.config['backend']}
                 }
+
+    def remove_model_data(self):
+        """remove the data of this project"""
+        datadir_path = self._datadir_path
+        if not os.path.isdir(datadir_path):
+            raise AnnifException('No model data to remove for project {}.'
+                                 .format(self.project_id))
+        rmtree(datadir_path)
 
 
 def _create_projects(projects_file, datadir, init_projects):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -93,7 +93,7 @@ def test_init_project(testdatadir):
     assert runner.invoke(
         annif.cli.cli,
         ['init', 'dummy-fi']).exit_code == 0
-    assert not os.path.exists(fpath)
+    assert not os.path.isdir(dirpath)
 
 
 def test_init_project_nonexistent(testdatadir):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -84,22 +84,22 @@ def test_show_project_nonexistent():
     assert failed_result.exception
 
 
-def test_init_project(testdatadir):
+def test_clear_project(testdatadir):
     dirpath = os.path.join(str(testdatadir), 'projects', 'dummy-fi')
-    fpath = os.path.join(str(dirpath), 'test_init_project_datafile')
+    fpath = os.path.join(str(dirpath), 'test_clear_project_datafile')
     os.makedirs(dirpath)
     open(fpath, 'a').close()
 
     assert runner.invoke(
         annif.cli.cli,
-        ['init', 'dummy-fi']).exit_code == 0
+        ['clear', 'dummy-fi']).exit_code == 0
     assert not os.path.isdir(dirpath)
 
 
-def test_init_project_nonexistent(testdatadir):
+def test_clear_project_nonexistent(testdatadir):
     runner.invoke(
         annif.cli.cli,
-        ['init', TEMP_PROJECT]).exit_code != 0
+        ['clear', TEMP_PROJECT]).exit_code != 0
 
 
 def test_loadvoc_tsv(testdatadir):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -99,10 +99,6 @@ def test_init_project(testdatadir):
 def test_init_project_nonexistent(testdatadir):
     runner.invoke(
         annif.cli.cli,
-        ['init', 'dummy-fi']).exit_code != 0
-    # Nonexistent project:
-    runner.invoke(
-        annif.cli.cli,
         ['init', TEMP_PROJECT]).exit_code != 0
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -84,6 +84,28 @@ def test_show_project_nonexistent():
     assert failed_result.exception
 
 
+def test_init_project(testdatadir):
+    dirpath = os.path.join(testdatadir, 'projects', 'dummy-fi')
+    fpath = os.path.join(dirpath, 'test_init_project_datafile')
+    os.makedirs(dirpath)
+    open(fpath, 'a').close()
+
+    assert runner.invoke(
+        annif.cli.cli,
+        ['init', 'dummy-fi']).exit_code == 0
+    assert not os.path.exists(fpath)
+
+
+def test_init_project_nonexistent(testdatadir):
+    runner.invoke(
+        annif.cli.cli,
+        ['init', 'dummy-fi']).exit_code != 0
+    # Nonexistent project:
+    runner.invoke(
+        annif.cli.cli,
+        ['init', TEMP_PROJECT]).exit_code != 0
+
+
 def test_loadvoc_tsv(testdatadir):
     with contextlib.suppress(FileNotFoundError):
         os.remove(str(testdatadir.join('projects/tfidf-fi/subjects')))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -96,10 +96,15 @@ def test_clear_project(testdatadir):
     assert not os.path.isdir(dirpath)
 
 
-def test_clear_project_nonexistent(testdatadir):
+def test_clear_project_nonexistent_data(testdatadir, caplog):
+    logger = annif.logger
+    logger.propagate = True
     runner.invoke(
         annif.cli.cli,
-        ['clear', TEMP_PROJECT]).exit_code != 0
+        ['clear', 'dummy-fi']).exit_code != 0
+    assert len(caplog.records) == 1
+    expected_msg = 'No model data to remove for project dummy-fi.'
+    assert expected_msg == caplog.records[0].message
 
 
 def test_loadvoc_tsv(testdatadir):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -85,8 +85,8 @@ def test_show_project_nonexistent():
 
 
 def test_init_project(testdatadir):
-    dirpath = os.path.join(testdatadir, 'projects', 'dummy-fi')
-    fpath = os.path.join(dirpath, 'test_init_project_datafile')
+    dirpath = os.path.join(str(testdatadir), 'projects', 'dummy-fi')
+    fpath = os.path.join(str(dirpath), 'test_init_project_datafile')
     os.makedirs(dirpath)
     open(fpath, 'a').close()
 


### PR DESCRIPTION
The `init` command simply deletes all files under `data/projects/project-to-remove/` (that directory will remain):
```
$ annif init tfidf-fi-copy 
Removed data files for project tfidf-fi-copy.

$ annif init nonexistent-project
No projects found with id 'nonexistent-project'.
```

Stated in the issue comment: "It could wipe all state and reset any configuration settings." 
Is this PR enough for this? 

The issue #269 for creating backend for using Maui server plans using `init` command for "creating tagger on the Maui server end", which is left for future.

This closes #251.