### PR TITLE
Pin base image to Debian Buster; update libboost version accordingly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-slim AS builder
+FROM python:3-slim-buster AS builder
 
 LABEL maintainer="Juho Inkinen <juho.inkinen@helsinki.fi>"
 
@@ -34,7 +34,7 @@ RUN apt-get update \
 
 
 
-FROM python:3.7-slim
+FROM python:3-slim-buster
 
 COPY --from=builder /usr/local/lib/python3.7 /usr/local/lib/python3.7
 
@@ -48,9 +48,9 @@ RUN apt-get update \
 		annif[voikko] \
 	## Vowpal Wabbit
 	&& apt-get install -y --no-install-recommends \
-		libboost-program-options1.62.0 \
-		libboost-python1.62.0 \
-		libboost-system1.62.0 \
+		libboost-program-options1.67.0 \
+		libboost-python1.67.0 \
+		libboost-system1.67.0 \
 	&& pip install --no-cache-dir \
 		vowpalwabbit \
 	## Clean up:


### PR DESCRIPTION
Drone builds (e.g. https://drone.kansalliskirjasto.fi/NatLibFi/Annif/118/1/2) were failing with error:
```
Package libboost-python1.62.0 is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source
E: Unable to locate package libboost-program-options1.62.0
E: Couldn't find any package by glob 'libboost-program-options1.62.0'
E: Couldn't find any package by regex 'libboost-program-options1.62.0'
E: Package 'libboost-python1.62.0' has no installation candidate
E: Unable to locate package libboost-system1.62.0
E: Couldn't find any package by glob 'libboost-system1.62.0'
E: Couldn't find any package by regex 'libboost-system1.62.0'
```

This (apparently) was due to that the base image `python:3.7-slim` was updated ten days ago in [Docker Hub](https://hub.docker.com/_/python?tab=tags&page=4) from Debian Stretch to Debian Buster, and the above 1.62.0 versions of libboost were not available to install. (Also, builds in my local machine were all the time successful for some reason.)

This fixes the drone builds by updating the libboost packages to 1.67 that are available in Buster, to which the base image is also pinned (also the python version pinning is relaxed from 3.7 to 3, to allow possibly more frequent security updates).