### PR TITLE
Dry run of drone builds for p rs

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -6,6 +6,13 @@ steps:
     image: plugins/docker
     settings:
       dockerfile: Dockerfile
+      username:
+        from_secret: docker_username
+      password:
+        from_secret: docker_password
+      registry: quay.io
+      repo: quay.io/natlibfi/annif
+      tags: [dry-run-builded]
     dry_run: true
     when:
       event:

--- a/.drone.yml
+++ b/.drone.yml
@@ -12,7 +12,7 @@ steps:
         from_secret: docker_password
       registry: quay.io
       repo: quay.io/natlibfi/annif
-      tags: [dry-run-builded]
+      tags: [dry-run-built]
     dry_run: true
     when:
       event:


### PR DESCRIPTION
Apparently even in dry-run build step there needs to be the same settings as in actual build-and-publish steps ([drone build errored](https://drone.kansalliskirjasto.fi/NatLibFi/Annif/120/1/2) with `Error parsing reference: ":latest" is not a valid repository/tag: invalid reference format`)