### PR TITLE
Issue309 key files with labels only

### DIFF
--- a/annif/corpus/convert.py
+++ b/annif/corpus/convert.py
@@ -9,7 +9,6 @@ from .types import Document, DocumentCorpus, SubjectCorpus
 class DocumentToSubjectCorpusMixin(SubjectCorpus):
     """Mixin class for enabling a DocumentCorpus to act as a SubjectCorpus"""
 
-    _subject_index = None
     _subject_corpus = None
     _temp_directory = None
 
@@ -18,12 +17,6 @@ class DocumentToSubjectCorpusMixin(SubjectCorpus):
         if self._subject_corpus is None:
             self._generate_corpus_from_documents()
         return self._subject_corpus.subjects
-
-    def set_subject_index(self, subject_index):
-        """Set a subject index for looking up labels that are necessary for
-        conversion"""
-
-        self._subject_index = subject_index
 
     def _subject_filename(self, subject_id):
         filename = '{:08d}.txt'.format(subject_id)

--- a/annif/corpus/document.py
+++ b/annif/corpus/document.py
@@ -42,8 +42,9 @@ class DocumentDirectory(DocumentCorpus, DocumentToSubjectCorpusMixin):
                 text = docfile.read()
             with open(keyfilename, encoding='utf-8') as keyfile:
                 subjects = SubjectSet.from_string(keyfile.read())
-            yield Document(text=text, uris=subjects.subject_uris,
-                           labels=subjects.subject_labels)
+            yield self._create_document(text=text,
+                                        uris=subjects.subject_uris,
+                                        labels=subjects.subject_labels)
 
 
 class DocumentFile(DocumentCorpus, DocumentToSubjectCorpusMixin):
@@ -66,7 +67,9 @@ class DocumentFile(DocumentCorpus, DocumentToSubjectCorpusMixin):
                 text, uris = line.split('\t', maxsplit=1)
                 subjects = [annif.util.cleanup_uri(uri)
                             for uri in uris.split()]
-                yield Document(text=text, uris=subjects, labels=[])
+                yield self._create_document(text=text,
+                                            uris=subjects,
+                                            labels=[])
 
 
 class DocumentList(DocumentCorpus, DocumentToSubjectCorpusMixin):

--- a/annif/corpus/subject.py
+++ b/annif/corpus/subject.py
@@ -78,6 +78,22 @@ class SubjectIndex:
             logger.warning('Unknown subject label "%s"', label)
             return None
 
+    def uris_to_labels(self, uris):
+        """return a list of labels corresponding to the given URIs; unknown
+        URIs are ignored"""
+
+        return [self[subject_id][1]
+                for subject_id in (self.by_uri(uri) for uri in uris)
+                if subject_id is not None]
+
+    def labels_to_uris(self, labels):
+        """return a list of URIs corresponding to the given labels; unknown
+        labels are ignored"""
+
+        return [self[subject_id][0]
+                for subject_id in (self.by_label(label) for label in labels)
+                if subject_id is not None]
+
     def save(self, path):
         """Save this subject index into a file."""
 

--- a/annif/corpus/types.py
+++ b/annif/corpus/types.py
@@ -29,18 +29,10 @@ class DocumentCorpus(metaclass=abc.ABCMeta):
         information. URIs for labels and vice versa are looked up from the
         subject index, if available."""
 
-        sidx = self._subject_index
-
-        if not uris and labels and sidx:
-            uris = set((sidx[subject_id][0]
-                        for subject_id in (sidx.by_label(label)
-                                           for label in labels)
-                        if subject_id is not None))
-        if not labels and uris and sidx:
-            labels = set((sidx[subject_id][1]
-                          for subject_id in (sidx.by_uri(uri)
-                                             for uri in uris)
-                          if subject_id is not None))
+        if not uris and labels and self._subject_index:
+            uris = set((self._subject_index.labels_to_uris(labels)))
+        if not labels and uris and self._subject_index:
+            labels = set((self._subject_index.uris_to_labels(uris)))
 
         return Document(text=text, uris=uris, labels=labels)
 

--- a/annif/corpus/types.py
+++ b/annif/corpus/types.py
@@ -10,11 +10,19 @@ Document = collections.namedtuple('Document', 'text uris labels')
 class DocumentCorpus(metaclass=abc.ABCMeta):
     """Abstract base class for document corpora"""
 
+    _subject_index = None
+
     @property
     @abc.abstractmethod
     def documents(self):
         """Iterate through the document corpus, yielding Document objects."""
         pass  # pragma: no cover
+
+    def set_subject_index(self, subject_index):
+        """Set a subject index for looking up labels that are necessary for
+        conversion"""
+
+        self._subject_index = subject_index
 
 
 Subject = collections.namedtuple('Subject', 'uri label text')

--- a/annif/corpus/types.py
+++ b/annif/corpus/types.py
@@ -32,13 +32,15 @@ class DocumentCorpus(metaclass=abc.ABCMeta):
         sidx = self._subject_index
 
         if not uris and labels and sidx:
-            uris = set((sidx[sidx.by_label(label)][0]
-                        for label in labels
-                        if sidx.by_label(label)))
+            uris = set((sidx[subject_id][0]
+                        for subject_id in (sidx.by_label(label)
+                                           for label in labels)
+                        if subject_id is not None))
         if not labels and uris and sidx:
-            labels = set((sidx[sidx.by_uri(uri)][1]
-                          for uri in uris
-                          if sidx.by_uri(uri)))
+            labels = set((sidx[subject_id][1]
+                          for subject_id in (sidx.by_uri(uri)
+                                             for uri in uris)
+                          if subject_id is not None))
 
         return Document(text=text, uris=uris, labels=labels)
 

--- a/annif/corpus/types.py
+++ b/annif/corpus/types.py
@@ -24,6 +24,24 @@ class DocumentCorpus(metaclass=abc.ABCMeta):
 
         self._subject_index = subject_index
 
+    def _create_document(self, text, uris, labels):
+        """Create a new Document instance from possibly incomplete
+        information. URIs for labels and vice versa are looked up from the
+        subject index, if available."""
+
+        sidx = self._subject_index
+
+        if not uris and labels and sidx:
+            uris = set((sidx[sidx.by_label(label)][0]
+                        for label in labels
+                        if sidx.by_label(label)))
+        if not labels and uris and sidx:
+            labels = set((sidx[sidx.by_uri(uri)][1]
+                          for uri in uris
+                          if sidx.by_uri(uri)))
+
+        return Document(text=text, uris=uris, labels=labels)
+
 
 Subject = collections.namedtuple('Subject', 'uri label text')
 

--- a/annif/corpus/types.py
+++ b/annif/corpus/types.py
@@ -29,10 +29,11 @@ class DocumentCorpus(metaclass=abc.ABCMeta):
         information. URIs for labels and vice versa are looked up from the
         subject index, if available."""
 
-        if not uris and labels and self._subject_index:
-            uris = set((self._subject_index.labels_to_uris(labels)))
-        if not labels and uris and self._subject_index:
-            labels = set((self._subject_index.uris_to_labels(uris)))
+        if self._subject_index:
+            if not uris and labels:
+                uris = set((self._subject_index.labels_to_uris(labels)))
+            if not labels and uris:
+                labels = set((self._subject_index.uris_to_labels(uris)))
 
         return Document(text=text, uris=uris, labels=labels)
 

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -1,6 +1,7 @@
 """Unit tests for corpus functionality in Annif"""
 
 import gzip
+import pytest
 import annif.corpus
 
 
@@ -115,11 +116,28 @@ def test_docdir_tsv_require_subjects(tmpdir):
     assert files[1][1] == str(tmpdir.join('doc2.tsv'))
 
 
-def test_docdir_as_doccorpus(tmpdir):
+def test_docdir_tsv_as_doccorpus(tmpdir):
     tmpdir.join('doc1.txt').write('doc1')
     tmpdir.join('doc1.tsv').write('<http://example.org/subj1>\tsubj1')
     tmpdir.join('doc2.txt').write('doc2')
-    tmpdir.join('doc2.tsv').write('<http://example.org/subj2>\tsubj1')
+    tmpdir.join('doc2.tsv').write('<http://example.org/subj2>\tsubj2')
+    tmpdir.join('doc3.txt').write('doc3')
+
+    docdir = annif.corpus.DocumentDirectory(str(tmpdir), require_subjects=True)
+    docs = list(docdir.documents)
+    assert len(docs) == 2
+    assert docs[0].text == 'doc1'
+    assert docs[0].uris == {'http://example.org/subj1'}
+    assert docs[1].text == 'doc2'
+    assert docs[1].uris == {'http://example.org/subj2'}
+
+
+@pytest.mark.xfail
+def test_docdir_key_as_doccorpus(tmpdir):
+    tmpdir.join('doc1.txt').write('doc1')
+    tmpdir.join('doc1.key').write('subj1')
+    tmpdir.join('doc2.txt').write('doc2')
+    tmpdir.join('doc2.key').write('subj2')
     tmpdir.join('doc3.txt').write('doc3')
 
     docdir = annif.corpus.DocumentDirectory(str(tmpdir), require_subjects=True)

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -1,7 +1,6 @@
 """Unit tests for corpus functionality in Annif"""
 
 import gzip
-import pytest
 import annif.corpus
 
 
@@ -132,21 +131,21 @@ def test_docdir_tsv_as_doccorpus(tmpdir):
     assert docs[1].uris == {'http://example.org/subj2'}
 
 
-@pytest.mark.xfail
-def test_docdir_key_as_doccorpus(tmpdir):
+def test_docdir_key_as_doccorpus(tmpdir, subject_index):
     tmpdir.join('doc1.txt').write('doc1')
-    tmpdir.join('doc1.key').write('subj1')
+    tmpdir.join('doc1.key').write('arkeologit')
     tmpdir.join('doc2.txt').write('doc2')
-    tmpdir.join('doc2.key').write('subj2')
+    tmpdir.join('doc2.key').write('kalliotaide')
     tmpdir.join('doc3.txt').write('doc3')
 
     docdir = annif.corpus.DocumentDirectory(str(tmpdir), require_subjects=True)
+    docdir.set_subject_index(subject_index)
     docs = list(docdir.documents)
     assert len(docs) == 2
     assert docs[0].text == 'doc1'
-    assert docs[0].uris == {'http://example.org/subj1'}
+    assert docs[0].uris == {'http://www.yso.fi/onto/yso/p10849'}
     assert docs[1].text == 'doc2'
-    assert docs[1].uris == {'http://example.org/subj2'}
+    assert docs[1].uris == {'http://www.yso.fi/onto/yso/p13027'}
 
 
 def test_subjdir(tmpdir):


### PR DESCRIPTION
Fixes #309

This PR modifies the document corpus processing code so that URIs are looked up based on labels and vice versa (with the help of a subject index). This should make it possible to use simple `.key` files with only subject labels, as [specified in the wiki](https://github.com/NatLibFi/Annif/wiki/Document-corpus-formats#simple-subject-file-format).

Marking as draft PR since some refactoring may be necessary before merging.