### PR TITLE
Fix unsuccessful setting of readonly bash variable by using different name than UID

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     image: quay.io/natlibfi/annif
     volumes:
       - ${ANNIF_PROJECTS}:/annif-projects
-    user: ${UID}:${GID}
+    user: ${MY_UID}:${MY_GID}
     stdin_open: true
     tty: true
     command: bash
@@ -25,7 +25,7 @@ services:
     image: quay.io/natlibfi/annif
     volumes:
       - ${ANNIF_PROJECTS}:/annif-projects
-    user: ${UID}:${GID}
+    user: ${MY_UID}:${MY_GID}
     command: ["gunicorn", "annif:create_app()", "--bind", "0.0.0.0:8000"]
 
   nginx:


### PR DESCRIPTION
In [the wiki section](https://github.com/NatLibFi/Annif/wiki/Usage-with-Docker#using-annif-with-gunicorn-nginx-and-maui-backend) for `docker-compose.yml` it was instructed to run command
```
ANNIF_PROJECTS=~/annif-projects UID=${UID} GID=${GID} docker-compose up
```
to start up the services, which set `UID` and `GID` variables which in turn were intended to be used for setting user in containers. However this was actually failing with the warning
```
bash: UID: readonly variable
WARNING: The UID variable is not set. Defaulting to a blank string.
```
and the user remained root in the containers. 

This is fixed by using different name than `UID` in the `docker-compose.yml` and the instruction in Wiki.