### PR TITLE
Turn AnnifException into an abstract base class and fix message prefix behavior

### DIFF
--- a/annif/exception.py
+++ b/annif/exception.py
@@ -1,10 +1,11 @@
 """Custom exceptions used by Annif"""
 
 
+import abc
 from click import ClickException
 
 
-class AnnifException(ClickException):
+class AnnifException(ClickException, metaclass=abc.ABCMeta):
     """Base Annif exception. We define this as a subclass of ClickException so
     that the CLI can automatically handle exceptions."""
 
@@ -13,22 +14,10 @@ class AnnifException(ClickException):
         self.project_id = project_id
         self.backend_id = backend_id
 
-    def format_message(self):
-        if self.project_id is not None:
-            return "Project '{}': {}".format(self.project_id,
-                                             self.message)
-        if self.backend_id is not None:
-            return "Backend '{}': {}".format(self.backend_id,
-                                             self.message)
-        return "Error: {}".format(self.message)
-
-
-class NotInitializedException(AnnifException):
-    """Exception raised for attempting to use a project or backend that
-    cannot be initialized, most likely since it is not yet functional
-    because of lack of vocabulary or training."""
-
-    prefix = "Couldn't initialize"
+    @property
+    @abc.abstractmethod
+    def prefix(self):
+        pass
 
     def format_message(self):
         if self.project_id is not None:
@@ -42,14 +31,28 @@ class NotInitializedException(AnnifException):
         return "{}: {}".format(self.prefix, self.message)
 
 
+class NotInitializedException(AnnifException):
+    """Exception raised for attempting to use a project or backend that
+    cannot be initialized, most likely since it is not yet functional
+    because of lack of vocabulary or training."""
+
+    @property
+    def prefix(self):
+        return "Couldn't initialize"
+
+
 class ConfigurationException(AnnifException):
     """Exception raised when a project or backend is misconfigured."""
 
-    prefix = "Misconfigured"
+    @property
+    def prefix(self):
+        return "Misconfigured"
 
 
 class NotSupportedException(AnnifException):
     """Exception raised when an operation is not supported by a project or
     backend."""
 
-    prefix = "Not supported"
+    @property
+    def prefix(self):
+        return "Not supported"

--- a/annif/exception.py
+++ b/annif/exception.py
@@ -1,23 +1,24 @@
 """Custom exceptions used by Annif"""
 
 
-import abc
 from click import ClickException
 
 
-class AnnifException(ClickException, metaclass=abc.ABCMeta):
+class AnnifException(ClickException):
     """Base Annif exception. We define this as a subclass of ClickException so
-    that the CLI can automatically handle exceptions."""
+    that the CLI can automatically handle exceptions. This exception cannot be
+    instantiated directly - subclasses should be used instead."""
 
     def __init__(self, message, project_id=None, backend_id=None):
         super().__init__(message)
         self.project_id = project_id
         self.backend_id = backend_id
 
-    @property
-    @abc.abstractmethod
-    def prefix(self):
-        pass
+        if self.prefix is None:
+            raise TypeError("Cannot instantiate exception without a prefix.")
+
+    # subclasses should set this to a descriptive prefix
+    prefix = None
 
     def format_message(self):
         if self.project_id is not None:
@@ -36,23 +37,17 @@ class NotInitializedException(AnnifException):
     cannot be initialized, most likely since it is not yet functional
     because of lack of vocabulary or training."""
 
-    @property
-    def prefix(self):
-        return "Couldn't initialize"
+    prefix = "Couldn't initialize"
 
 
 class ConfigurationException(AnnifException):
     """Exception raised when a project or backend is misconfigured."""
 
-    @property
-    def prefix(self):
-        return "Misconfigured"
+    prefix = "Misconfigured"
 
 
 class NotSupportedException(AnnifException):
     """Exception raised when an operation is not supported by a project or
     backend."""
 
-    @property
-    def prefix(self):
-        return "Not supported"
+    prefix = "Not supported"

--- a/tests/test_exception.py
+++ b/tests/test_exception.py
@@ -1,0 +1,22 @@
+"""Unit tests for Annif exception classes"""
+
+import pytest
+from annif.exception import AnnifException
+from click import ClickException
+
+
+def test_annifexception_not_instantiable():
+    with pytest.raises(TypeError):
+        exc = AnnifException("test message")
+
+
+def test_annifexception_is_clickexception():
+
+    # we need to define a custom class to make an instantiable exception
+    class CustomException(AnnifException):
+        @property
+        def prefix(self):
+            return "my prefix"
+
+    exc = CustomException("test message")
+    assert isinstance(exc, ClickException)


### PR DESCRIPTION
I realized that `AnnifException` isn't intended to be instantiated directly but doing so was still possible. This PR changes into an abstract base class, which cannot be instantiated.

While performing the change, I noticed that the prefix mechanism used to generate error messages was broken. This PR fixes it as well.

Example error before the changes:

    Error: Project 'noanalyzer': vocab setting is missing

Example error after the changes:

    Error: Misconfigured project 'noanalyzer': vocab setting is missing
