### PR TITLE
Issue318 handle missing or invalid path input for commands

### DIFF
--- a/annif/backend/fasttext.py
+++ b/annif/backend/fasttext.py
@@ -104,7 +104,7 @@ class FastTextBackend(mixins.ChunkingBackend, backend.AnnifBackend):
         self._model.save_model(modelpath)
 
     def train(self, corpus, project):
-        if corpus.are_documents_empty():
+        if corpus.is_empty():
             raise NotSupportedException('training backend {} with no documents'
                                         .format(self.backend_id))
         self._create_train_file(corpus, project)

--- a/annif/backend/fasttext.py
+++ b/annif/backend/fasttext.py
@@ -4,7 +4,7 @@ import collections
 import os.path
 import annif.util
 from annif.suggestion import SubjectSuggestion, ListSuggestionResult
-from annif.exception import NotInitializedException
+from annif.exception import NotInitializedException, NotSupportedException
 import fastText
 from . import backend
 from . import mixins
@@ -104,6 +104,9 @@ class FastTextBackend(mixins.ChunkingBackend, backend.AnnifBackend):
         self._model.save_model(modelpath)
 
     def train(self, corpus, project):
+        if corpus.are_documents_empty():
+            raise NotSupportedException('training backend {} with no documents'
+                                        .format(self.backend_id))
         self._create_train_file(corpus, project)
         self._create_model()
 

--- a/annif/backend/pav.py
+++ b/annif/backend/pav.py
@@ -11,7 +11,7 @@ import annif.corpus
 import annif.suggestion
 import annif.project
 import annif.util
-from annif.exception import NotInitializedException
+from annif.exception import NotInitializedException, NotSupportedException
 from . import ensemble
 
 
@@ -96,6 +96,9 @@ class PAVBackend(ensemble.EnsembleBackend):
             method=joblib.dump)
 
     def train(self, corpus, project):
+        if corpus.are_documents_empty():
+            raise NotSupportedException('training backend {} with no documents'
+                                        .format(self.backend_id))
         self.info("creating PAV models")
         sources = annif.util.parse_sources(self.params['sources'])
         min_docs = int(self.params['min-docs'])

--- a/annif/backend/pav.py
+++ b/annif/backend/pav.py
@@ -96,7 +96,7 @@ class PAVBackend(ensemble.EnsembleBackend):
             method=joblib.dump)
 
     def train(self, corpus, project):
-        if corpus.are_documents_empty():
+        if corpus.is_empty():
             raise NotSupportedException('training backend {} with no documents'
                                         .format(self.backend_id))
         self.info("creating PAV models")

--- a/annif/cli.py
+++ b/annif/cli.py
@@ -136,7 +136,7 @@ def run_clear_project(project_id):
 
 @cli.command('loadvoc')
 @click.argument('project_id')
-@click.argument('subjectfile', type=click.Path(dir_okay=False))
+@click.argument('subjectfile', type=click.Path(exists=True, dir_okay=False))
 @common_options
 def run_loadvoc(project_id, subjectfile):
     """
@@ -154,7 +154,7 @@ def run_loadvoc(project_id, subjectfile):
 
 @cli.command('train')
 @click.argument('project_id')
-@click.argument('paths', type=click.Path(), nargs=-1)
+@click.argument('paths', type=click.Path(exists=True), nargs=-1)
 @common_options
 def run_train(project_id, paths):
     """
@@ -167,7 +167,7 @@ def run_train(project_id, paths):
 
 @cli.command('learn')
 @click.argument('project_id')
-@click.argument('paths', type=click.Path(), nargs=-1)
+@click.argument('paths', type=click.Path(exists=True), nargs=-1)
 @common_options
 def run_learn(project_id, paths):
     """
@@ -200,7 +200,7 @@ def run_suggest(project_id, limit, threshold, backend_param):
 
 @cli.command('index')
 @click.argument('project_id')
-@click.argument('directory', type=click.Path(file_okay=False))
+@click.argument('directory', type=click.Path(exists=True, file_okay=False))
 @click.option(
     '--suffix',
     default='.annif',
@@ -241,7 +241,7 @@ def run_index(project_id, directory, suffix, force,
 
 @cli.command('eval')
 @click.argument('project_id')
-@click.argument('paths', type=click.Path(), nargs=-1)
+@click.argument('paths', type=click.Path(exists=True), nargs=-1)
 @click.option('--limit', default=10, help='Maximum number of subjects')
 @click.option('--threshold', default=0.0, help='Minimum score threshold')
 @click.option('--backend-param', '-b', multiple=True,
@@ -275,7 +275,7 @@ def run_eval(project_id, paths, limit, threshold, backend_param):
 
 @cli.command('optimize')
 @click.argument('project_id')
-@click.argument('paths', type=click.Path(), nargs=-1)
+@click.argument('paths', type=click.Path(exists=True), nargs=-1)
 @click.option('--backend-param', '-b', multiple=True,
               help='Backend parameters to override')
 @common_options

--- a/annif/cli.py
+++ b/annif/cli.py
@@ -47,7 +47,7 @@ def open_documents(paths):
         return annif.corpus.DocumentFile(path)
 
     if len(paths) == 0:
-        logger.warning('Creating empty model')
+        logger.warning('Reading empty file')
         docs = open_doc_path(os.path.devnull)
     elif len(paths) == 1:
         docs = open_doc_path(paths[0])

--- a/annif/cli.py
+++ b/annif/cli.py
@@ -85,7 +85,7 @@ def set_project_config_file_path(ctx, param, value):
 def common_options(f):
     """Decorator to add common options for all CLI commands"""
     f = click.option(
-        '-p', '--projects', help='Set path to projects.cfg',
+        '-p', '--projects', help='Set path to projects.cfg', type=click.Path(),
         callback=set_project_config_file_path, expose_value=False,
         is_eager=True)(f)
     f = click_log.simple_verbosity_option(logger)(f)

--- a/annif/cli.py
+++ b/annif/cli.py
@@ -48,7 +48,7 @@ def open_documents(paths):
 
     if len(paths) == 0:
         logger.warning('Creating empty model')
-        docs = open_doc_path('/dev/null')
+        docs = open_doc_path(os.path.devnull)
     elif len(paths) == 1:
         docs = open_doc_path(paths[0])
     elif len(paths) > 1:

--- a/annif/cli.py
+++ b/annif/cli.py
@@ -51,7 +51,7 @@ def open_documents(paths):
         docs = open_doc_path(os.path.devnull)
     elif len(paths) == 1:
         docs = open_doc_path(paths[0])
-    elif len(paths) > 1:
+    else:
         corpora = [open_doc_path(path) for path in paths]
         docs = annif.corpus.CombinedCorpus(corpora)
     return docs

--- a/annif/cli.py
+++ b/annif/cli.py
@@ -88,7 +88,8 @@ def set_project_config_file_path(ctx, param, value):
 def common_options(f):
     """Decorator to add common options for all CLI commands"""
     f = click.option(
-        '-p', '--projects', help='Set path to projects.cfg', type=click.Path(),
+        '-p', '--projects', help='Set path to projects.cfg',
+        type=click.Path(dir_okay=False, exists=True),
         callback=set_project_config_file_path, expose_value=False,
         is_eager=True)(f)
     f = click_log.simple_verbosity_option(logger)(f)

--- a/annif/cli.py
+++ b/annif/cli.py
@@ -46,11 +46,14 @@ def open_documents(paths):
             return annif.corpus.DocumentDirectory(path, require_subjects=True)
         return annif.corpus.DocumentFile(path)
 
-    if len(paths) > 1:
+    if len(paths) == 0:
+        logger.warning('Creating empty model')
+        docs = open_doc_path('/dev/null')
+    elif len(paths) == 1:
+        docs = open_doc_path(paths[0])
+    elif len(paths) > 1:
         corpora = [open_doc_path(path) for path in paths]
         docs = annif.corpus.CombinedCorpus(corpora)
-    else:
-        docs = open_doc_path(paths[0])
     return docs
 
 

--- a/annif/corpus/types.py
+++ b/annif/corpus/types.py
@@ -37,6 +37,14 @@ class DocumentCorpus(metaclass=abc.ABCMeta):
 
         return Document(text=text, uris=uris, labels=labels)
 
+    def are_documents_empty(self):
+        """Check if there are no documents to iterate."""
+        try:
+            next(self.documents)
+            return False
+        except StopIteration:
+            return True
+
 
 Subject = collections.namedtuple('Subject', 'uri label text')
 

--- a/annif/corpus/types.py
+++ b/annif/corpus/types.py
@@ -37,7 +37,7 @@ class DocumentCorpus(metaclass=abc.ABCMeta):
 
         return Document(text=text, uris=uris, labels=labels)
 
-    def are_documents_empty(self):
+    def is_empty(self):
         """Check if there are no documents to iterate."""
         try:
             next(self.documents)

--- a/annif/project.py
+++ b/annif/project.py
@@ -193,7 +193,7 @@ class AnnifProject(DatadirMixin):
         if not self.backend.needs_subject_vectorizer:
             logger.debug('not creating vectorizer: not needed by backend')
             return
-        if subjectcorpus.are_documents_empty():
+        if subjectcorpus.is_empty():
             raise NotSupportedException(
                 'using TfidfVectorizer with no documents')
         logger.info('creating vectorizer')

--- a/annif/project.py
+++ b/annif/project.py
@@ -193,6 +193,9 @@ class AnnifProject(DatadirMixin):
         if not self.backend.needs_subject_vectorizer:
             logger.debug('not creating vectorizer: not needed by backend')
             return
+        if subjectcorpus.are_documents_empty():
+            raise NotSupportedException(
+                'using TfidfVectorizer with no documents')
         logger.info('creating vectorizer')
         self._vectorizer = TfidfVectorizer(
             tokenizer=self.analyzer.tokenize_words)

--- a/tests/projects.cfg
+++ b/tests/projects.cfg
@@ -98,3 +98,13 @@ loss=hs
 limit=100
 chunksize=24
 vocab=yso-fi
+
+[vw-multi-fi]
+name=vw_multi Finnish
+language=fi
+backend=vw_multi
+analyzer=snowball(finnish)
+bit_precision=1
+limit=100
+chunksize=2
+vocab=yso-fi

--- a/tests/projects.cfg
+++ b/tests/projects.cfg
@@ -98,13 +98,3 @@ loss=hs
 limit=100
 chunksize=24
 vocab=yso-fi
-
-[vw-multi-fi]
-name=vw_multi Finnish
-language=fi
-backend=vw_multi
-analyzer=snowball(finnish)
-bit_precision=1
-limit=100
-chunksize=2
-vocab=yso-fi

--- a/tests/test_backend_fasttext.py
+++ b/tests/test_backend_fasttext.py
@@ -3,6 +3,7 @@
 import pytest
 import annif.backend
 import annif.corpus
+from annif.exception import NotSupportedException
 
 fasttext = pytest.importorskip("annif.backend.fasttext")
 
@@ -46,6 +47,26 @@ def test_fasttext_train_unknown_subject(tmpdir, datadir, project):
     assert fasttext._model is not None
     assert datadir.join('fasttext-model').exists()
     assert datadir.join('fasttext-model').size() > 0
+
+
+def test_fasttext_train_nodocuments(tmpdir, datadir, project):
+    fasttext_type = annif.backend.get_backend("fasttext")
+    fasttext = fasttext_type(
+        backend_id='fasttext',
+        params={
+            'limit': 50,
+            'dim': 100,
+            'lr': 0.25,
+            'epoch': 20,
+            'loss': 'hs'},
+        datadir=str(datadir))
+
+    empty_file = tmpdir.ensure('empty.tsv')
+    empty_document_corpus = annif.corpus.DocumentFile(str(empty_file))
+
+    with pytest.raises(NotSupportedException) as excinfo:
+        fasttext.train(empty_document_corpus, project)
+    assert 'training backend fasttext with no documents' in str(excinfo.value)
 
 
 def test_fasttext_suggest(datadir, project):

--- a/tests/test_backend_pav.py
+++ b/tests/test_backend_pav.py
@@ -1,7 +1,9 @@
 """Unit tests for the PAV backend in Annif"""
 
+import pytest
 import annif.backend
 import annif.corpus
+from annif.exception import NotSupportedException
 
 
 def test_pav_train(app, datadir, tmpdir, project):
@@ -21,6 +23,21 @@ def test_pav_train(app, datadir, tmpdir, project):
         pav.train(document_corpus, project)
     assert datadir.join('pav-model-dummy-fi').exists()
     assert datadir.join('pav-model-dummy-fi').size() > 0
+
+
+def test_pav_train_nodocuments(tmpdir, datadir, project):
+    pav_type = annif.backend.get_backend("pav")
+    pav = pav_type(
+        backend_id='pav',
+        params={'limit': 50, 'min-docs': 2, 'sources': 'dummy-fi'},
+        datadir=str(datadir))
+
+    empty_file = tmpdir.ensure('empty.tsv')
+    empty_document_corpus = annif.corpus.DocumentFile(str(empty_file))
+
+    with pytest.raises(NotSupportedException) as excinfo:
+        pav.train(empty_document_corpus, project)
+    assert 'training backend pav with no documents' in str(excinfo.value)
 
 
 def test_pav_initialize(app, datadir):

--- a/tests/test_backend_vw_multi.py
+++ b/tests/test_backend_vw_multi.py
@@ -55,6 +55,34 @@ def test_vw_multi_train_and_learn(datadir, document_corpus, project):
     assert modelfile.size() != old_size or modelfile.mtime() != old_mtime
 
 
+def test_vw_multi_train_and_learn_nodocuments(datadir, tmpdir, project):
+    vw_type = annif.backend.get_backend('vw_multi')
+    vw = vw_type(
+        backend_id='vw_multi',
+        params={
+            'chunksize': 4,
+            'learning_rate': 0.5,
+            'loss_function': 'hinge'},
+        datadir=str(datadir))
+
+    empty_file = tmpdir.ensure('empty.tsv')
+    empty_document_corpus = annif.corpus.DocumentFile(str(empty_file))
+
+    vw.train(empty_document_corpus, project)
+    assert datadir.join('vw-train.txt').exists()
+    assert datadir.join('vw-train.txt').size() == 0
+
+    # test online learning
+    modelfile = datadir.join('vw-model')
+
+    old_size = modelfile.size()
+
+    vw.learn(empty_document_corpus, project)
+
+    assert modelfile.size() == old_size
+    assert datadir.join('vw-train.txt').size() == 0
+
+
 def test_vw_multi_train_from_project(app, datadir, document_corpus, project):
     vw_type = annif.backend.get_backend('vw_multi')
     vw = vw_type(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -199,18 +199,6 @@ def test_train_no_path(caplog):
     assert 'Reading empty file' == caplog.records[0].message
 
 
-def test_train_no_path_vw(caplog):
-    pytest.importorskip('annif.backend.vw_multi')
-    logger = annif.logger
-    logger.propagate = True
-    result = runner.invoke(
-        annif.cli.cli, [
-            'train', 'vw-multi-fi'])
-    assert not result.exception
-    assert result.exit_code == 0
-    assert 'Reading empty file' == caplog.records[0].message
-
-
 def test_learn(testdatadir):
     docfile = os.path.join(
         os.path.dirname(__file__),

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -197,7 +197,7 @@ def test_train_no_path_vw(caplog):
             'train', 'vw-multi-fi'])
     assert not result.exception
     assert result.exit_code == 0
-    assert 'Creating empty model' == caplog.records[0].message
+    assert 'Reading empty file' == caplog.records[0].message
 
 
 def test_train_no_path_tfidf(caplog):
@@ -208,7 +208,7 @@ def test_train_no_path_tfidf(caplog):
             'train', 'tfidf-fi'])
     assert failed_result.exception
     assert failed_result.exit_code != 0
-    assert 'Creating empty model' == caplog.records[0].message
+    assert 'Reading empty file' == caplog.records[0].message
     assert 'Not supported: using TfidfVectorizer with no documents' \
         in failed_result.output
 
@@ -222,7 +222,7 @@ def test_train_no_path_fasttext(caplog):
             'train', 'fasttext-fi'])
     assert failed_result.exception
     assert failed_result.exit_code != 0
-    assert 'Creating empty model' == caplog.records[0].message
+    assert 'Reading empty file' == caplog.records[0].message
     assert 'Not supported: training backend fasttext with no documents' \
         in failed_result.output
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -187,6 +187,43 @@ def test_train_nonexistent_path():
            'Path "nonexistent_path" does not exist.' in failed_result.output
 
 
+def test_train_no_path_vw(caplog):
+    logger = annif.logger
+    logger.propagate = True
+    result = runner.invoke(
+        annif.cli.cli, [
+            'train', 'vw-multi-fi'])
+    assert not result.exception
+    assert result.exit_code == 0
+    assert 'Creating empty model' == caplog.records[0].message
+
+
+def test_train_no_path_tfidf(caplog):
+    logger = annif.logger
+    logger.propagate = True
+    failed_result = runner.invoke(
+        annif.cli.cli, [
+            'train', 'tfidf-fi'])
+    assert failed_result.exception
+    assert failed_result.exit_code != 0
+    assert 'Creating empty model' == caplog.records[0].message
+    assert 'Not supported: using TfidfVectorizer with no documents' \
+        in failed_result.output
+
+
+def test_train_no_path_fasttext(caplog):
+    logger = annif.logger
+    logger.propagate = True
+    failed_result = runner.invoke(
+        annif.cli.cli, [
+            'train', 'fasttext-fi'])
+    assert failed_result.exception
+    assert failed_result.exit_code != 0
+    assert 'Creating empty model' == caplog.records[0].message
+    assert 'Not supported: training backend fasttext with no documents' \
+        in failed_result.output
+
+
 def test_learn(testdatadir):
     docfile = os.path.join(
         os.path.dirname(__file__),

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -50,13 +50,12 @@ def test_list_projects_config_path_option():
 
 
 def test_list_projects_config_path_option_nonexistent():
-    nonexistent_file = "nonexistent.cfg"
-    result = runner.invoke(
-        annif.cli.cli, ["list-projects", "--projects", nonexistent_file])
-    assert not result.exception
-    assert result.exit_code == 0
-    assert 'Project configuration file "{}" is missing.'.format(
-        nonexistent_file) in result.output
+    failed_result = runner.invoke(
+        annif.cli.cli, ["list-projects", "--projects", "nonexistent.cfg"])
+    assert failed_result.exception
+    assert failed_result.exit_code != 0
+    assert 'Error: Invalid value for "-p" / "--projects": ' \
+           'File "nonexistent.cfg" does not exist.' in failed_result.output
 
 
 def test_show_project():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -137,6 +137,16 @@ def test_loadvoc_rdf(testdatadir):
     assert testdatadir.join('vocabs/yso-fi/subjects').size() > 0
 
 
+def test_loadvoc_nonexistent_path():
+    failed_result = runner.invoke(
+        annif.cli.cli, [
+            'loadvoc', 'dummy-fi', 'nonexistent_path'])
+    assert failed_result.exception
+    assert failed_result.exit_code != 0
+    assert 'Invalid value for "SUBJECTFILE": ' \
+           'File "nonexistent_path" does not exist.' in failed_result.output
+
+
 def test_train(testdatadir):
     docfile = os.path.join(
         os.path.dirname(__file__),
@@ -168,6 +178,16 @@ def test_train_multiple(testdatadir):
     assert testdatadir.join('projects/tfidf-fi/tfidf-index').size() > 0
 
 
+def test_train_nonexistent_path():
+    failed_result = runner.invoke(
+        annif.cli.cli, [
+            'train', 'dummy-fi', 'nonexistent_path'])
+    assert failed_result.exception
+    assert failed_result.exit_code != 0
+    assert 'Invalid value for "[PATHS]...": ' \
+           'Path "nonexistent_path" does not exist.' in failed_result.output
+
+
 def test_learn(testdatadir):
     docfile = os.path.join(
         os.path.dirname(__file__),
@@ -188,6 +208,16 @@ def test_learn_notsupported(testdatadir):
     result = runner.invoke(annif.cli.cli, ['learn', 'tfidf-fi', docfile])
     assert result.exit_code != 0
     assert 'Learning not supported' in result.output
+
+
+def test_learn_nonexistent_path():
+    failed_result = runner.invoke(
+        annif.cli.cli, [
+            'learn', 'dummy-fi', 'nonexistent_path'])
+    assert failed_result.exception
+    assert failed_result.exit_code != 0
+    assert 'Invalid value for "[PATHS]...": ' \
+           'Path "nonexistent_path" does not exist.' in failed_result.output
 
 
 def test_suggest():
@@ -257,6 +287,17 @@ def test_index(tmpdir):
     assert "Not overwriting" not in result.output
     assert tmpdir.join('doc1.annif').read_text(
         'utf-8') == "<http://example.org/dummy>\tdummy\t1.0\n"
+
+
+def test_index_nonexistent_path():
+    failed_result = runner.invoke(
+        annif.cli.cli, [
+            'index', 'dummy-fi', 'nonexistent_path'])
+    assert failed_result.exception
+    assert failed_result.exit_code != 0
+    assert 'Invalid value for "DIRECTORY": ' \
+           'Directory "nonexistent_path" does not exist.' \
+           in failed_result.output
 
 
 def test_eval_label(tmpdir):
@@ -362,6 +403,16 @@ def test_eval_docfile():
     assert result.exit_code == 0
 
 
+def test_eval_nonexistent_path():
+    failed_result = runner.invoke(
+        annif.cli.cli, [
+            'eval', 'dummy-fi', 'nonexistent_path'])
+    assert failed_result.exception
+    assert failed_result.exit_code != 0
+    assert 'Invalid value for "[PATHS]...": ' \
+           'Path "nonexistent_path" does not exist.' in failed_result.output
+
+
 def test_optimize_dir(tmpdir):
     tmpdir.join('doc1.txt').write('doc1')
     tmpdir.join('doc1.key').write('dummy')
@@ -398,3 +449,13 @@ def test_optimize_docfile(tmpdir):
             'optimize', 'dummy-fi', str(docfile)])
     assert not result.exception
     assert result.exit_code == 0
+
+
+def test_optimize_nonexistent_path():
+    failed_result = runner.invoke(
+        annif.cli.cli, [
+            'optimize', 'dummy-fi', 'nonexistent_path'])
+    assert failed_result.exception
+    assert failed_result.exit_code != 0
+    assert 'Invalid value for "[PATHS]...": ' \
+           'Path "nonexistent_path" does not exist.' in failed_result.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,6 +4,7 @@ import contextlib
 import random
 import re
 import os.path
+import pytest
 from click.testing import CliRunner
 import annif.cli
 
@@ -188,6 +189,7 @@ def test_train_nonexistent_path():
 
 
 def test_train_no_path_vw(caplog):
+    pytest.importorskip('annif.backend.vw_multi')
     logger = annif.logger
     logger.propagate = True
     result = runner.invoke(
@@ -212,6 +214,7 @@ def test_train_no_path_tfidf(caplog):
 
 
 def test_train_no_path_fasttext(caplog):
+    pytest.importorskip('annif.backend.fasttext')
     logger = annif.logger
     logger.propagate = True
     failed_result = runner.invoke(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -188,6 +188,17 @@ def test_train_nonexistent_path():
            'Path "nonexistent_path" does not exist.' in failed_result.output
 
 
+def test_train_no_path(caplog):
+    logger = annif.logger
+    logger.propagate = True
+    result = runner.invoke(
+        annif.cli.cli, [
+            'train', 'dummy-fi'])
+    assert not result.exception
+    assert result.exit_code == 0
+    assert 'Reading empty file' == caplog.records[0].message
+
+
 def test_train_no_path_vw(caplog):
     pytest.importorskip('annif.backend.vw_multi')
     logger = annif.logger
@@ -198,33 +209,6 @@ def test_train_no_path_vw(caplog):
     assert not result.exception
     assert result.exit_code == 0
     assert 'Reading empty file' == caplog.records[0].message
-
-
-def test_train_no_path_tfidf(caplog):
-    logger = annif.logger
-    logger.propagate = True
-    failed_result = runner.invoke(
-        annif.cli.cli, [
-            'train', 'tfidf-fi'])
-    assert failed_result.exception
-    assert failed_result.exit_code != 0
-    assert 'Reading empty file' == caplog.records[0].message
-    assert 'Not supported: using TfidfVectorizer with no documents' \
-        in failed_result.output
-
-
-def test_train_no_path_fasttext(caplog):
-    pytest.importorskip('annif.backend.fasttext')
-    logger = annif.logger
-    logger.propagate = True
-    failed_result = runner.invoke(
-        annif.cli.cli, [
-            'train', 'fasttext-fi'])
-    assert failed_result.exception
-    assert failed_result.exit_code != 0
-    assert 'Reading empty file' == caplog.records[0].message
-    assert 'Not supported: training backend fasttext with no documents' \
-        in failed_result.output
 
 
 def test_learn(testdatadir):

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -246,7 +246,7 @@ def test_docfile_gzipped(tmpdir):
     assert len(list(docs.documents)) == 3
 
 
-def test_docfile_are_documents_empty(tmpdir):
+def test_docfile_is_empty(tmpdir):
     empty_file = tmpdir.ensure('empty.tsv')
     docs = annif.corpus.DocumentFile(str(empty_file))
-    assert docs.are_documents_empty()
+    assert docs.is_empty()

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -244,3 +244,11 @@ def test_docfile_gzipped(tmpdir):
 
     docs = annif.corpus.DocumentFile(str(docfile))
     assert len(list(docs.documents)) == 3
+
+
+def test_docfile_are_documents_empty():
+    import os.path
+    docfile = os.path.devnull
+
+    docs = annif.corpus.DocumentFile(str(docfile))
+    assert docs.are_documents_empty()

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -246,9 +246,7 @@ def test_docfile_gzipped(tmpdir):
     assert len(list(docs.documents)) == 3
 
 
-def test_docfile_are_documents_empty():
-    import os.path
-    docfile = os.path.devnull
-
-    docs = annif.corpus.DocumentFile(str(docfile))
+def test_docfile_are_documents_empty(tmpdir):
+    empty_file = tmpdir.ensure('empty.tsv')
+    docs = annif.corpus.DocumentFile(str(empty_file))
     assert docs.are_documents_empty()

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -113,6 +113,16 @@ def test_project_train_tfidf(app, document_corpus, testdatadir):
     assert testdatadir.join('projects/tfidf-fi/tfidf-index').size() > 0
 
 
+def test_project_train_tfidf_nodocuments(app, tmpdir):
+    with app.app_context():
+        project = annif.project.get_project('tfidf-fi')
+    empty_file = tmpdir.ensure('empty.tsv')
+    empty_document_corpus = annif.corpus.DocumentFile(str(empty_file))
+    with pytest.raises(NotSupportedException) as excinfo:
+        project.train(empty_document_corpus)
+    assert 'using TfidfVectorizer with no documents' in str(excinfo.value)
+
+
 def test_project_learn(app, tmpdir):
     tmpdir.join('doc1.txt').write('doc1')
     tmpdir.join('doc1.tsv').write('<http://example.org/key1>\tkey1')


### PR DESCRIPTION
Closes #318.

Adding `exists=True` argument to `type=click.Path()` enables Click to check the existence of paths, for example:

```
$ annif train tfidf-en nonexistent.tsv
Usage: annif train [OPTIONS] PROJECT_ID [PATHS]...
Try "annif train --help" for help.

Error: Invalid value for "[PATHS]...": Path "nonexistent.tsv" does not exist.
```

There are now [tests](https://github.com/NatLibFi/Annif/commit/67840a944dcae55dc0ba23949c300e7b10dd0947) for raising these errors for every command, but to me they actually seem a bit too much. After all, there is no actual Annif code that these tests check. To not bloat the test code base, should the test be removed or reduced in number?

The case of missing training file now maps to `/dev/null`, but as noted, it doesn't work in Windows. This behaviour would still need 

- [x] use cross-platform null device file ~~checks on the running OS (easy actually)~~, 

- [x] and implementing different behaviour for `vw-multi` compared to other backends (seems a bit complicated)

Could this behaviour on missing training file be dropped for now, as the use case seems quite rare, and "a workaround" (if one doesn't want or can't use `/dev/null`) for this is to create an actual, existing empty training file and train on that?

