### PR TITLE
Do not push docker image with dev tag to quay.io

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -36,23 +36,6 @@ steps:
       event:
       - push
 
-  - name: build_and_publish-dev
-    image: plugins/docker
-    settings:
-      dockerfile: Dockerfile-dev
-      username:
-        from_secret: docker_username
-      password:
-        from_secret: docker_password
-      registry: quay.io
-      repo: quay.io/natlibfi/annif
-      tags: [dev]
-    when:
-      branch:
-      - master
-      event:
-      - push
-
   - name: build_publish_and_tag_with_release_version
     image: plugins/docker
     settings:

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -12,7 +12,6 @@ RUN pip install pipenv --no-cache-dir \
 	&& pipenv install --system --skip-lock --dev
 
 COPY . .
-RUN chmod -R 777 /Annif
 
 USER annif_user
 


### PR DESCRIPTION
The image intended for [development](https://github.com/NatLibFi/Annif/blob/master/Dockerfile-dev) (i.e. one including the installed [dev packages of Pipfile](https://github.com/NatLibFi/Annif/blob/master/Pipfile#L6) and pytest) was automatically build by drone and pushed to quay.io with the `dev` tag. However, that tag name could cause confusion (especially when tags with release versions will come to use).

This PR removes the drone step for building and publishing dev image, and the instructions in [Wiki for using docker for development](https://github.com/NatLibFi/Annif/wiki/Usage-with-Docker#using-docker-in-annif-development) is updated with instructions to manually build the image for development.

Also removes unnecessary full-access to everyone for source code in image.