### PR TITLE
Issue273 default values for configuration settings

### DIFF
--- a/annif/backend/backend.py
+++ b/annif/backend/backend.py
@@ -28,7 +28,7 @@ class AnnifBackend(metaclass=abc.ABCMeta):
     def fill_params_with_defaults(self):
         """Set the parameters that are not provided in the projects config file
         with default values defined in the backend class and its bases."""
-        for source_cls in (self.__class__, *self.__class__.__bases__):
+        for source_cls in self.__class__.mro()[:-1]:  # omit the object class
             for default_param, default_value in \
                     source_cls.DEFAULT_PARAMS.items():
                 if default_param not in self.params:

--- a/annif/backend/backend.py
+++ b/annif/backend/backend.py
@@ -20,22 +20,11 @@ class AnnifBackend(metaclass=abc.ABCMeta):
         backend type."""
         self.backend_id = backend_id
         self.datadir = datadir
-        self._params = config_params
+        self.params = self.default_params().copy()
+        self.params.update(config_params)
 
     def default_params(self):
         return self.DEFAULT_PARAMS
-
-    @property
-    def params(self):
-        params_to_set = {param: str(val)
-                         for param, val in self.default_params().items()
-                         if param not in self._params}
-        if params_to_set:
-            self.debug(
-                'all parameters not set, using the following defaults: {}'
-                .format(params_to_set))
-            self._params.update(params_to_set)
-        return self._params.copy()
 
     def train(self, corpus, project):
         """train the model on the given document or subject corpus"""

--- a/annif/backend/backend.py
+++ b/annif/backend/backend.py
@@ -12,6 +12,10 @@ class AnnifBackend(metaclass=abc.ABCMeta):
     needs_subject_index = False
     needs_subject_vectorizer = False
 
+    DEFAULT_PARAMS = {
+        'limit': 100,
+    }
+
     def __init__(self, backend_id, params, datadir):
         """Initialize backend with specific parameters. The
         parameters are a dict. Keys and values depend on the specific
@@ -19,6 +23,21 @@ class AnnifBackend(metaclass=abc.ABCMeta):
         self.backend_id = backend_id
         self.params = params
         self.datadir = datadir
+        self.fill_params_with_defaults()
+
+    def fill_params_with_defaults(self):
+        """Set the parameters that are not provided in the projects config file
+        with default values defined in the backend class and its bases."""
+        for source_cls in (self.__class__, *self.__class__.__bases__):
+            for default_param, default_value in \
+                    source_cls.DEFAULT_PARAMS.items():
+                if default_param not in self.params:
+                    self.info(
+                        "no value set for parameter {}, "
+                        "using default value {} from {}"
+                        .format(default_param, default_value,
+                                source_cls.__name__))
+                    self.params[default_param] = str(default_value)
 
     def train(self, corpus, project):
         """train the model on the given document or subject corpus"""

--- a/annif/backend/backend.py
+++ b/annif/backend/backend.py
@@ -32,7 +32,7 @@ class AnnifBackend(metaclass=abc.ABCMeta):
             for default_param, default_value in \
                     source_cls.DEFAULT_PARAMS.items():
                 if default_param not in self.params:
-                    self.info(
+                    self.debug(
                         "no value set for parameter {}, "
                         "using default value {} from {}"
                         .format(default_param, default_value,

--- a/annif/backend/backend.py
+++ b/annif/backend/backend.py
@@ -14,13 +14,13 @@ class AnnifBackend(metaclass=abc.ABCMeta):
 
     DEFAULT_PARAMS = {'limit': 100}
 
-    def __init__(self, backend_id, params, datadir):
+    def __init__(self, backend_id, config_params, datadir):
         """Initialize backend with specific parameters. The
         parameters are a dict. Keys and values depend on the specific
         backend type."""
         self.backend_id = backend_id
         self.datadir = datadir
-        self._params = params
+        self._params = config_params
 
     def default_params(self):
         return self.DEFAULT_PARAMS

--- a/annif/backend/backend.py
+++ b/annif/backend/backend.py
@@ -28,7 +28,7 @@ class AnnifBackend(metaclass=abc.ABCMeta):
     def fill_params_with_defaults(self):
         """Set the parameters that are not provided in the projects config file
         with default values defined in the backend class and its bases."""
-        for source_cls in self.__class__.mro()[:-1]:  # omit the object class
+        for source_cls in type(self).mro()[:-1]:  # omit the object class
             for default_param, default_value in \
                     source_cls.DEFAULT_PARAMS.items():
                 if default_param not in self.params:

--- a/annif/backend/backend.py
+++ b/annif/backend/backend.py
@@ -27,14 +27,13 @@ class AnnifBackend(metaclass=abc.ABCMeta):
 
     def fill_params_with_defaults(self):
         """Set the parameters that are not provided in the projects config file
-        with default values defined in the backend class and its bases."""
+        with default values defined in the backend class and its parents."""
         for source_cls in type(self).mro()[:-1]:  # omit the object class
             for default_param, default_value in \
                     source_cls.DEFAULT_PARAMS.items():
                 if default_param not in self.params:
                     self.debug(
-                        "no value set for parameter {}, "
-                        "using default value {} from {}"
+                        "parameter {} not set, using default value {} from {}"
                         .format(default_param, default_value,
                                 source_cls.__name__))
                     self.params[default_param] = str(default_value)

--- a/annif/backend/backend.py
+++ b/annif/backend/backend.py
@@ -28,12 +28,14 @@ class AnnifBackend(metaclass=abc.ABCMeta):
 
     def fill_params_with_defaults(self):
         """Set the parameters that are not provided in the projects config file
-        with default values defined in the backend class and its parents."""
-        for default_param, default_value in self.default_params().items():
-            if default_param not in self.params:
-                self.debug('parameter "{}" not set, using default value "{}"'
-                           .format(default_param, default_value))
-                self.params[default_param] = str(default_value)
+        with default values set in the backend class."""
+        params_to_set = {param: str(val)
+                         for param, val in self.default_params().items()
+                         if param not in self.params}
+        if params_to_set:
+            self.debug('all parameters not set, using following defaults: {}'
+                       .format(params_to_set))
+            self.params.update(params_to_set)
 
     def train(self, corpus, project):
         """train the model on the given document or subject corpus"""

--- a/annif/backend/backend.py
+++ b/annif/backend/backend.py
@@ -20,22 +20,22 @@ class AnnifBackend(metaclass=abc.ABCMeta):
         backend type."""
         self.backend_id = backend_id
         self.datadir = datadir
-        self.params = self.fill_params_with_defaults(params)
+        self._params = params
 
     def default_params(self):
         return self.DEFAULT_PARAMS
 
-    def fill_params_with_defaults(self, params):
-        """Set the parameters that are not provided in the projects config file
-        with default values set in the backend class."""
+    @property
+    def params(self):
         params_to_set = {param: str(val)
                          for param, val in self.default_params().items()
-                         if param not in params}
+                         if param not in self._params}
         if params_to_set:
-            self.debug('all parameters not set, using following defaults: {}'
-                       .format(params_to_set))
-            params.update(params_to_set)
-        return params
+            self.debug(
+                'all parameters not set, using the following defaults: {}'
+                .format(params_to_set))
+            self._params.update(params_to_set)
+        return self._params.copy()
 
     def train(self, corpus, project):
         """train the model on the given document or subject corpus"""

--- a/annif/backend/backend.py
+++ b/annif/backend/backend.py
@@ -19,23 +19,23 @@ class AnnifBackend(metaclass=abc.ABCMeta):
         parameters are a dict. Keys and values depend on the specific
         backend type."""
         self.backend_id = backend_id
-        self.params = params
         self.datadir = datadir
-        self.fill_params_with_defaults()
+        self.params = self.fill_params_with_defaults(params)
 
     def default_params(self):
         return self.DEFAULT_PARAMS
 
-    def fill_params_with_defaults(self):
+    def fill_params_with_defaults(self, params):
         """Set the parameters that are not provided in the projects config file
         with default values set in the backend class."""
         params_to_set = {param: str(val)
                          for param, val in self.default_params().items()
-                         if param not in self.params}
+                         if param not in params}
         if params_to_set:
             self.debug('all parameters not set, using following defaults: {}'
                        .format(params_to_set))
-            self.params.update(params_to_set)
+            params.update(params_to_set)
+        return params
 
     def train(self, corpus, project):
         """train the model on the given document or subject corpus"""

--- a/annif/backend/backend.py
+++ b/annif/backend/backend.py
@@ -12,9 +12,7 @@ class AnnifBackend(metaclass=abc.ABCMeta):
     needs_subject_index = False
     needs_subject_vectorizer = False
 
-    DEFAULT_PARAMS = {
-        'limit': 100,
-    }
+    DEFAULT_PARAMS = {'limit': 100}
 
     def __init__(self, backend_id, params, datadir):
         """Initialize backend with specific parameters. The
@@ -25,18 +23,17 @@ class AnnifBackend(metaclass=abc.ABCMeta):
         self.datadir = datadir
         self.fill_params_with_defaults()
 
+    def default_params(self):
+        return self.DEFAULT_PARAMS
+
     def fill_params_with_defaults(self):
         """Set the parameters that are not provided in the projects config file
         with default values defined in the backend class and its parents."""
-        for source_cls in type(self).mro()[:-1]:  # omit the object class
-            for default_param, default_value in \
-                    source_cls.DEFAULT_PARAMS.items():
-                if default_param not in self.params:
-                    self.debug(
-                        "parameter {} not set, using default value {} from {}"
-                        .format(default_param, default_value,
-                                source_cls.__name__))
-                    self.params[default_param] = str(default_value)
+        for default_param, default_value in self.default_params().items():
+            if default_param not in self.params:
+                self.debug('parameter "{}" not set, using default value "{}"'
+                           .format(default_param, default_value))
+                self.params[default_param] = str(default_value)
 
     def train(self, corpus, project):
         """train the model on the given document or subject corpus"""

--- a/annif/backend/backend.py
+++ b/annif/backend/backend.py
@@ -20,11 +20,17 @@ class AnnifBackend(metaclass=abc.ABCMeta):
         backend type."""
         self.backend_id = backend_id
         self.datadir = datadir
-        self.params = self.default_params().copy()
-        self.params.update(config_params)
+        self.config_params = config_params
 
     def default_params(self):
         return self.DEFAULT_PARAMS
+
+    @property
+    def params(self):
+        params = {}
+        params.update(self.default_params())
+        params.update(self.config_params)
+        return params
 
     def train(self, corpus, project):
         """train the model on the given document or subject corpus"""

--- a/annif/backend/dummy.py
+++ b/annif/backend/dummy.py
@@ -11,6 +11,10 @@ class DummyBackend(backend.AnnifLearningBackend):
     uri = 'http://example.org/dummy'
     label = 'dummy'
 
+    def default_params(self):
+        params = backend.AnnifBackend.DEFAULT_PARAMS.copy()
+        return params
+
     def initialize(self):
         self.initialized = True
 

--- a/annif/backend/dummy.py
+++ b/annif/backend/dummy.py
@@ -12,8 +12,7 @@ class DummyBackend(backend.AnnifLearningBackend):
     label = 'dummy'
 
     def default_params(self):
-        params = backend.AnnifBackend.DEFAULT_PARAMS.copy()
-        return params
+        return backend.AnnifBackend.DEFAULT_PARAMS
 
     def initialize(self):
         self.initialized = True

--- a/annif/backend/fasttext.py
+++ b/annif/backend/fasttext.py
@@ -33,7 +33,12 @@ class FastTextBackend(mixins.ChunkingBackend, backend.AnnifBackend):
         't': float
     }
 
-    DEFAULT_PARAMS = {'loss': 'hs'}  # TODO: and others
+    DEFAULT_PARAMS = {
+        'dim': 100,
+        'lr': 0.25,
+        'epoch': 5,
+        'loss': 'hs',
+    }
 
     MODEL_FILE = 'fasttext-model'
     TRAIN_FILE = 'fasttext-train.txt'

--- a/annif/backend/fasttext.py
+++ b/annif/backend/fasttext.py
@@ -33,6 +33,10 @@ class FastTextBackend(mixins.ChunkingBackend, backend.AnnifBackend):
         't': float
     }
 
+    DEFAULT_PARAMS = {
+        # 'chunksize': 2, # EXAMPLE Could override chunksize in ChunkingBackend
+    }
+
     MODEL_FILE = 'fasttext-model'
     TRAIN_FILE = 'fasttext-train.txt'
 

--- a/annif/backend/fasttext.py
+++ b/annif/backend/fasttext.py
@@ -33,15 +33,19 @@ class FastTextBackend(mixins.ChunkingBackend, backend.AnnifBackend):
         't': float
     }
 
-    DEFAULT_PARAMS = {
-        # 'chunksize': 2, # EXAMPLE Could override chunksize in ChunkingBackend
-    }
+    DEFAULT_PARAMS = {'loss': 'hs'}  # TODO: and others
 
     MODEL_FILE = 'fasttext-model'
     TRAIN_FILE = 'fasttext-train.txt'
 
     # defaults for uninitialized instances
     _model = None
+
+    def default_params(self):
+        params = backend.AnnifBackend.DEFAULT_PARAMS.copy()
+        params.update(mixins.ChunkingBackend.DEFAULT_PARAMS)
+        params.update(self.DEFAULT_PARAMS)
+        return params
 
     def initialize(self):
         if self._model is None:

--- a/annif/backend/mixins.py
+++ b/annif/backend/mixins.py
@@ -8,6 +8,10 @@ from annif.suggestion import ListSuggestionResult
 class ChunkingBackend(metaclass=abc.ABCMeta):
     """Annif backend mixin that implements chunking of input"""
 
+    DEFAULT_PARAMS = {
+        'chunksize': 1,
+    }
+
     @abc.abstractmethod
     def _suggest_chunks(self, chunktexts, project):
         """Suggest subjects for the chunked text; should be implemented by

--- a/annif/backend/mixins.py
+++ b/annif/backend/mixins.py
@@ -8,9 +8,10 @@ from annif.suggestion import ListSuggestionResult
 class ChunkingBackend(metaclass=abc.ABCMeta):
     """Annif backend mixin that implements chunking of input"""
 
-    DEFAULT_PARAMS = {
-        'chunksize': 1,
-    }
+    DEFAULT_PARAMS = {'chunksize': 1}
+
+    def default_params(self):
+        return self.DEFAULT_PARAMS
 
     @abc.abstractmethod
     def _suggest_chunks(self, chunktexts, project):

--- a/annif/backend/pav.py
+++ b/annif/backend/pav.py
@@ -24,6 +24,8 @@ class PAVBackend(ensemble.EnsembleBackend):
     # defaults for uninitialized instances
     _models = None
 
+    DEFAULT_PARAMS = {'min-docs': 10}
+
     def initialize(self):
         if self._models is not None:
             return  # already initialized

--- a/annif/backend/vw_multi.py
+++ b/annif/backend/vw_multi.py
@@ -7,6 +7,7 @@ import annif.project
 from annif.suggestion import ListSuggestionResult, VectorSuggestionResult
 from annif.exception import ConfigurationException
 from . import vw_base
+from . import backend
 from . import mixins
 
 
@@ -27,14 +28,24 @@ class VWMultiBackend(mixins.ChunkingBackend, vw_base.VWBaseBackend):
         'probabilities': (bool, None)
     }
 
-    DEFAULT_ALGORITHM = 'oaa'
     SUPPORTED_ALGORITHMS = ('oaa', 'ect', 'log_multi', 'multilabel_oaa')
 
     DEFAULT_INPUTS = '_text_'
 
+    DEFAULT_PARAMS = {'algorithm': 'oaa'}
+
+    def default_params(self):
+        params = backend.AnnifBackend.DEFAULT_PARAMS.copy()
+        params.update(mixins.ChunkingBackend.DEFAULT_PARAMS)
+        params.update(self.DEFAULT_PARAMS)
+        params.update({param: default_val
+                       for param, (_, default_val) in self.VW_PARAMS.items()
+                       if default_val is not None})
+        return params
+
     @property
     def algorithm(self):
-        algorithm = self.params.get('algorithm', self.DEFAULT_ALGORITHM)
+        algorithm = self.params['algorithm']
         if algorithm not in self.SUPPORTED_ALGORITHMS:
             raise ConfigurationException(
                 "{} is not a valid algorithm (allowed: {})".format(

--- a/annif/project.py
+++ b/annif/project.py
@@ -45,7 +45,7 @@ class AnnifProject(DatadirMixin):
     def __init__(self, project_id, config, datadir):
         DatadirMixin.__init__(self, datadir, 'projects', project_id)
         self.project_id = project_id
-        self.name = config['name']
+        self.name = config.get('name', project_id)
         self.language = config['language']
         self.analyzer_spec = config.get('analyzer', None)
         self.vocab_id = config.get('vocab', None)

--- a/annif/project.py
+++ b/annif/project.py
@@ -144,7 +144,7 @@ class AnnifProject(DatadirMixin):
             try:
                 backend_class = annif.backend.get_backend(backend_id)
                 self._backend = backend_class(
-                    backend_id, config_params=dict(self.config),
+                    backend_id, config_params=self.config,
                     datadir=self.datadir)
             except ValueError:
                 logger.warning(

--- a/annif/project.py
+++ b/annif/project.py
@@ -144,7 +144,8 @@ class AnnifProject(DatadirMixin):
             try:
                 backend_class = annif.backend.get_backend(backend_id)
                 self._backend = backend_class(
-                    backend_id, params=dict(self.config), datadir=self.datadir)
+                    backend_id, config_params=dict(self.config),
+                    datadir=self.datadir)
             except ValueError:
                 logger.warning(
                     "Could not create backend %s, "

--- a/annif/project.py
+++ b/annif/project.py
@@ -144,7 +144,7 @@ class AnnifProject(DatadirMixin):
             try:
                 backend_class = annif.backend.get_backend(backend_id)
                 self._backend = backend_class(
-                    backend_id, params=self.config, datadir=self.datadir)
+                    backend_id, params=dict(self.config), datadir=self.datadir)
             except ValueError:
                 logger.warning(
                     "Could not create backend %s, "

--- a/tests/projects.cfg
+++ b/tests/projects.cfg
@@ -56,6 +56,20 @@ backend=tfidf
 vocab=dummy
 analyzer=snowball(english)
 
+[noparams-tfidf-fi]
+name=TF-IDF Finnish using default params
+language=fi
+backend=tfidf
+analyzer=snowball(finnish)
+vocab=yso-fi
+
+[noparams-fasttext-fi]
+name=fastText Finnish using default params
+language=fi
+backend=fasttext
+analyzer=snowball(finnish)
+vocab=yso-fi
+
 [pav]
 name=PAV Ensemble Finnish
 language=fi

--- a/tests/projects.cfg
+++ b/tests/projects.cfg
@@ -50,6 +50,12 @@ language=en
 vocab=dummy
 analyzer=snowball(english)
 
+[noname]
+language=en
+backend=tfidf
+vocab=dummy
+analyzer=snowball(english)
+
 [pav]
 name=PAV Ensemble Finnish
 language=fi

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1,6 +1,7 @@
 """Unit tests for backends in Annif"""
 
 import pytest
+import logging
 import annif
 import annif.backend
 import annif.corpus
@@ -40,3 +41,16 @@ def test_learn_dummy(app, project, tmpdir):
     assert result[0].uri == 'http://example.org/key1'
     assert result[0].label == 'key1'
     assert result[0].score == 1.0
+
+
+def test_fill_params_with_defaults(app, caplog):
+    logger = annif.logger
+    logger.propagate = True
+    dummy_type = annif.backend.get_backend('dummy')
+    dummy = dummy_type(backend_id='dummy', params={},
+                       datadir=app.config['DATADIR'])
+    expected_default_params = {'limit': '100'}  # From AnnifBackend class
+    expected_msg = 'all parameters not set, using following defaults:'
+    caplog.set_level(logging.DEBUG)
+    assert expected_default_params == dummy.fill_params_with_defaults({})
+    assert expected_msg in caplog.records[0].message

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -43,14 +43,9 @@ def test_learn_dummy(app, project, tmpdir):
     assert result[0].score == 1.0
 
 
-def test_fill_params_with_defaults(app, caplog):
-    logger = annif.logger
-    logger.propagate = True
+def test_fill_params_with_defaults(app):
     dummy_type = annif.backend.get_backend('dummy')
     dummy = dummy_type(backend_id='dummy', config_params={},
                        datadir=app.config['DATADIR'])
-    expected_default_params = {'limit': '100'}  # From AnnifBackend class
-    expected_msg = 'all parameters not set, using the following defaults:'
-    caplog.set_level(logging.DEBUG)
+    expected_default_params = {'limit': 100}  # From AnnifBackend class
     assert expected_default_params == dummy.params
-    assert expected_msg in caplog.records[0].message

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -50,7 +50,7 @@ def test_fill_params_with_defaults(app, caplog):
     dummy = dummy_type(backend_id='dummy', params={},
                        datadir=app.config['DATADIR'])
     expected_default_params = {'limit': '100'}  # From AnnifBackend class
-    expected_msg = 'all parameters not set, using following defaults:'
+    expected_msg = 'all parameters not set, using the following defaults:'
     caplog.set_level(logging.DEBUG)
-    assert expected_default_params == dummy.fill_params_with_defaults({})
+    assert expected_default_params == dummy.params
     assert expected_msg in caplog.records[0].message

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -14,7 +14,7 @@ def test_get_backend_nonexistent():
 
 def test_get_backend_dummy(app, project):
     dummy_type = annif.backend.get_backend("dummy")
-    dummy = dummy_type(backend_id='dummy', params={},
+    dummy = dummy_type(backend_id='dummy', config_params={},
                        datadir=app.config['DATADIR'])
     result = dummy.suggest(text='this is some text', project=project)
     assert len(result) == 1
@@ -25,7 +25,7 @@ def test_get_backend_dummy(app, project):
 
 def test_learn_dummy(app, project, tmpdir):
     dummy_type = annif.backend.get_backend("dummy")
-    dummy = dummy_type(backend_id='dummy', params={},
+    dummy = dummy_type(backend_id='dummy', config_params={},
                        datadir=app.config['DATADIR'])
 
     tmpdir.join('doc1.txt').write('doc1')
@@ -47,7 +47,7 @@ def test_fill_params_with_defaults(app, caplog):
     logger = annif.logger
     logger.propagate = True
     dummy_type = annif.backend.get_backend('dummy')
-    dummy = dummy_type(backend_id='dummy', params={},
+    dummy = dummy_type(backend_id='dummy', config_params={},
                        datadir=app.config['DATADIR'])
     expected_default_params = {'limit': '100'}  # From AnnifBackend class
     expected_msg = 'all parameters not set, using the following defaults:'

--- a/tests/test_backend_fasttext.py
+++ b/tests/test_backend_fasttext.py
@@ -73,7 +73,7 @@ def test_fasttext_train_nodocuments(tmpdir, datadir, project):
     fasttext_type = annif.backend.get_backend("fasttext")
     fasttext = fasttext_type(
         backend_id='fasttext',
-        params={
+        config_params={
             'limit': 50,
             'dim': 100,
             'lr': 0.25,

--- a/tests/test_backend_fasttext.py
+++ b/tests/test_backend_fasttext.py
@@ -1,10 +1,37 @@
 """Unit tests for the fastText backend in Annif"""
 
+import logging
 import pytest
 import annif.backend
 import annif.corpus
 
 fasttext = pytest.importorskip("annif.backend.fasttext")
+
+
+def test_fasttext_default_params(datadir, project, caplog):
+    logger = annif.logger
+    logger.propagate = True
+    caplog.set_level(logging.DEBUG)
+
+    fasttext_type = annif.backend.get_backend("fasttext")
+    fasttext = fasttext_type(
+        backend_id='fasttext',
+        params={},
+        datadir=str(datadir))
+
+    expected_default_params = {
+        'limit': 100,
+        'chunksize': 1,
+        'dim': 100,
+        'lr': 0.25,
+        'epoch': 5,
+        'loss': 'hs',
+    }
+    expected_msg = "all parameters not set, using following defaults:"
+    assert expected_msg in caplog.records[0].message
+    actual_params = fasttext.params
+    for param, val in expected_default_params.items():
+        assert param in actual_params and actual_params[param] == str(val)
 
 
 def test_fasttext_train(datadir, document_corpus, project):

--- a/tests/test_backend_fasttext.py
+++ b/tests/test_backend_fasttext.py
@@ -1,6 +1,5 @@
 """Unit tests for the fastText backend in Annif"""
 
-import logging
 import pytest
 import annif.backend
 import annif.corpus
@@ -8,11 +7,7 @@ import annif.corpus
 fasttext = pytest.importorskip("annif.backend.fasttext")
 
 
-def test_fasttext_default_params(datadir, project, caplog):
-    logger = annif.logger
-    logger.propagate = True
-    caplog.set_level(logging.DEBUG)
-
+def test_fasttext_default_params(datadir, project):
     fasttext_type = annif.backend.get_backend("fasttext")
     fasttext = fasttext_type(
         backend_id='fasttext',
@@ -27,11 +22,9 @@ def test_fasttext_default_params(datadir, project, caplog):
         'epoch': 5,
         'loss': 'hs',
     }
-    expected_msg = "all parameters not set, using the following defaults:"
     actual_params = fasttext.params
-    assert expected_msg in caplog.records[0].message
     for param, val in expected_default_params.items():
-        assert param in actual_params and actual_params[param] == str(val)
+        assert param in actual_params and actual_params[param] == val
 
 
 def test_fasttext_train(datadir, document_corpus, project):

--- a/tests/test_backend_fasttext.py
+++ b/tests/test_backend_fasttext.py
@@ -16,7 +16,7 @@ def test_fasttext_default_params(datadir, project, caplog):
     fasttext_type = annif.backend.get_backend("fasttext")
     fasttext = fasttext_type(
         backend_id='fasttext',
-        params={},
+        config_params={},
         datadir=str(datadir))
 
     expected_default_params = {
@@ -38,7 +38,7 @@ def test_fasttext_train(datadir, document_corpus, project):
     fasttext_type = annif.backend.get_backend("fasttext")
     fasttext = fasttext_type(
         backend_id='fasttext',
-        params={
+        config_params={
             'limit': 50,
             'dim': 100,
             'lr': 0.25,
@@ -56,7 +56,7 @@ def test_fasttext_train_unknown_subject(tmpdir, datadir, project):
     fasttext_type = annif.backend.get_backend("fasttext")
     fasttext = fasttext_type(
         backend_id='fasttext',
-        params={
+        config_params={
             'limit': 50,
             'dim': 100,
             'lr': 0.25,
@@ -79,7 +79,7 @@ def test_fasttext_suggest(datadir, project):
     fasttext_type = annif.backend.get_backend("fasttext")
     fasttext = fasttext_type(
         backend_id='fasttext',
-        params={
+        config_params={
             'limit': 50,
             'chunksize': 1,
             'dim': 100,

--- a/tests/test_backend_fasttext.py
+++ b/tests/test_backend_fasttext.py
@@ -27,9 +27,9 @@ def test_fasttext_default_params(datadir, project, caplog):
         'epoch': 5,
         'loss': 'hs',
     }
-    expected_msg = "all parameters not set, using following defaults:"
-    assert expected_msg in caplog.records[0].message
+    expected_msg = "all parameters not set, using the following defaults:"
     actual_params = fasttext.params
+    assert expected_msg in caplog.records[0].message
     for param, val in expected_default_params.items():
         assert param in actual_params and actual_params[param] == str(val)
 

--- a/tests/test_backend_http.py
+++ b/tests/test_backend_http.py
@@ -17,7 +17,7 @@ def test_http_suggest(app, project):
         http_type = annif.backend.get_backend("http")
         http = http_type(
             backend_id='http',
-            params={
+            config_params={
                 'endpoint': 'http://api.example.org/analyze',
                 'project': 'dummy'},
             datadir=app.config['DATADIR'])
@@ -40,7 +40,7 @@ def test_http_suggest_with_results(app, project):
         http_type = annif.backend.get_backend("http")
         http = http_type(
             backend_id='http',
-            params={
+            config_params={
                 'endpoint': 'http://api.example.org/dummy/analyze',
             },
             datadir=app.config['DATADIR'])
@@ -63,7 +63,7 @@ def test_http_suggest_zero_score(app, project):
         http_type = annif.backend.get_backend("http")
         http = http_type(
             backend_id='http',
-            params={
+            config_params={
                 'endpoint': 'http://api.example.org/analyze',
                 'project': 'dummy'},
             datadir=app.config['DATADIR'])
@@ -79,7 +79,7 @@ def test_http_suggest_error(app, project):
         http_type = annif.backend.get_backend("http")
         http = http_type(
             backend_id='http',
-            params={
+            config_params={
                 'endpoint': 'http://api.example.org/analyze',
                 'project': 'dummy'},
             datadir=app.config['DATADIR'])
@@ -98,7 +98,7 @@ def test_http_suggest_json_fails(app, project):
         http_type = annif.backend.get_backend("http")
         http = http_type(
             backend_id='http',
-            params={
+            config_params={
                 'endpoint': 'http://api.example.org/analyze',
                 'project': 'dummy'},
             datadir=app.config['DATADIR'])
@@ -117,7 +117,7 @@ def test_http_suggest_unexpected_json(app, project):
         http_type = annif.backend.get_backend("http")
         http = http_type(
             backend_id='http',
-            params={
+            config_params={
                 'endpoint': 'http://api.example.org/analyze',
                 'project': 'dummy'},
             datadir=app.config['DATADIR'])

--- a/tests/test_backend_pav.py
+++ b/tests/test_backend_pav.py
@@ -44,7 +44,7 @@ def test_pav_train_nodocuments(tmpdir, datadir, project):
     pav_type = annif.backend.get_backend("pav")
     pav = pav_type(
         backend_id='pav',
-        params={'limit': 50, 'min-docs': 2, 'sources': 'dummy-fi'},
+        config_params={'limit': 50, 'min-docs': 2, 'sources': 'dummy-fi'},
         datadir=str(datadir))
 
     empty_file = tmpdir.ensure('empty.tsv')

--- a/tests/test_backend_pav.py
+++ b/tests/test_backend_pav.py
@@ -1,15 +1,10 @@
 """Unit tests for the PAV backend in Annif"""
 
-import logging
 import annif.backend
 import annif.corpus
 
 
-def test_pav_default_params(datadir, document_corpus, project, caplog):
-    logger = annif.logger
-    logger.propagate = True
-    caplog.set_level(logging.DEBUG)
-
+def test_pav_default_params(datadir, document_corpus, project):
     pav_type = annif.backend.get_backend("pav")
     pav = pav_type(
         backend_id='pav',
@@ -19,11 +14,9 @@ def test_pav_default_params(datadir, document_corpus, project, caplog):
     expected_default_params = {
         'min-docs': 10,
     }
-    expected_msg = "all parameters not set, using the following defaults:"
     actual_params = pav.params
-    assert expected_msg in caplog.records[0].message
     for param, val in expected_default_params.items():
-        assert param in actual_params and actual_params[param] == str(val)
+        assert param in actual_params and actual_params[param] == val
 
 
 def test_pav_train(app, datadir, tmpdir, project):

--- a/tests/test_backend_pav.py
+++ b/tests/test_backend_pav.py
@@ -13,7 +13,7 @@ def test_pav_default_params(datadir, document_corpus, project, caplog):
     pav_type = annif.backend.get_backend("pav")
     pav = pav_type(
         backend_id='pav',
-        params={},
+        config_params={},
         datadir=str(datadir))
 
     expected_default_params = {
@@ -30,7 +30,7 @@ def test_pav_train(app, datadir, tmpdir, project):
     pav_type = annif.backend.get_backend("pav")
     pav = pav_type(
         backend_id='pav',
-        params={'limit': 50, 'min-docs': 2, 'sources': 'dummy-fi'},
+        config_params={'limit': 50, 'min-docs': 2, 'sources': 'dummy-fi'},
         datadir=str(datadir))
 
     tmpfile = tmpdir.join('document.tsv')
@@ -49,7 +49,7 @@ def test_pav_initialize(app, datadir):
     pav_type = annif.backend.get_backend("pav")
     pav = pav_type(
         backend_id='pav',
-        params={'limit': 50, 'min-docs': 2, 'sources': 'dummy-fi'},
+        config_params={'limit': 50, 'min-docs': 2, 'sources': 'dummy-fi'},
         datadir=str(datadir))
 
     assert pav._models is None
@@ -65,7 +65,7 @@ def test_pav_suggest(app, datadir, project):
     pav_type = annif.backend.get_backend("pav")
     pav = pav_type(
         backend_id='pav',
-        params={'limit': 50, 'min-docs': 2, 'sources': 'dummy-fi'},
+        config_params={'limit': 50, 'min-docs': 2, 'sources': 'dummy-fi'},
         datadir=str(datadir))
 
     results = pav.suggest("""Arkeologiaa sanotaan joskus myös

--- a/tests/test_backend_pav.py
+++ b/tests/test_backend_pav.py
@@ -1,7 +1,29 @@
 """Unit tests for the PAV backend in Annif"""
 
+import logging
 import annif.backend
 import annif.corpus
+
+
+def test_pav_default_params(datadir, document_corpus, project, caplog):
+    logger = annif.logger
+    logger.propagate = True
+    caplog.set_level(logging.DEBUG)
+
+    pav_type = annif.backend.get_backend("pav")
+    pav = pav_type(
+        backend_id='pav',
+        params={},
+        datadir=str(datadir))
+
+    expected_default_params = {
+        'min-docs': 10,
+    }
+    expected_msg = "all parameters not set, using following defaults:"
+    assert expected_msg in caplog.records[0].message
+    actual_params = pav.params
+    for param, val in expected_default_params.items():
+        assert param in actual_params and actual_params[param] == str(val)
 
 
 def test_pav_train(app, datadir, tmpdir, project):

--- a/tests/test_backend_pav.py
+++ b/tests/test_backend_pav.py
@@ -19,9 +19,9 @@ def test_pav_default_params(datadir, document_corpus, project, caplog):
     expected_default_params = {
         'min-docs': 10,
     }
-    expected_msg = "all parameters not set, using following defaults:"
-    assert expected_msg in caplog.records[0].message
+    expected_msg = "all parameters not set, using the following defaults:"
     actual_params = pav.params
+    assert expected_msg in caplog.records[0].message
     for param, val in expected_default_params.items():
         assert param in actual_params and actual_params[param] == str(val)
 

--- a/tests/test_backend_tfidf.py
+++ b/tests/test_backend_tfidf.py
@@ -33,9 +33,9 @@ def test_tfidf_default_params(datadir, project, caplog):
     expected_default_params = {
         'limit': 100  # From AnnifBackend class
     }
-    expected_msg = "all parameters not set, using following defaults:"
-    assert expected_msg in caplog.records[0].message
+    expected_msg = "all parameters not set, using the following defaults:"
     actual_params = tfidf.params
+    assert expected_msg in caplog.records[0].message
     for param, val in expected_default_params.items():
         assert param in actual_params and actual_params[param] == str(val)
 

--- a/tests/test_backend_tfidf.py
+++ b/tests/test_backend_tfidf.py
@@ -4,7 +4,6 @@ import annif
 import annif.backend
 import annif.corpus
 from sklearn.feature_extraction.text import TfidfVectorizer
-import logging
 import pytest
 import unittest.mock
 
@@ -19,11 +18,7 @@ def project(document_corpus):
     return proj
 
 
-def test_tfidf_default_params(datadir, project, caplog):
-    logger = annif.logger
-    logger.propagate = True
-    caplog.set_level(logging.DEBUG)
-
+def test_tfidf_default_params(datadir, project):
     tfidf_type = annif.backend.get_backend("tfidf")
     tfidf = tfidf_type(
         backend_id='tfidf',
@@ -33,11 +28,9 @@ def test_tfidf_default_params(datadir, project, caplog):
     expected_default_params = {
         'limit': 100  # From AnnifBackend class
     }
-    expected_msg = "all parameters not set, using the following defaults:"
     actual_params = tfidf.params
-    assert expected_msg in caplog.records[0].message
     for param, val in expected_default_params.items():
-        assert param in actual_params and actual_params[param] == str(val)
+        assert param in actual_params and actual_params[param] == val
 
 
 def test_tfidf_train(datadir, document_corpus, project):

--- a/tests/test_backend_tfidf.py
+++ b/tests/test_backend_tfidf.py
@@ -4,6 +4,7 @@ import annif
 import annif.backend
 import annif.corpus
 from sklearn.feature_extraction.text import TfidfVectorizer
+import logging
 import pytest
 import unittest.mock
 
@@ -16,6 +17,27 @@ def project(document_corpus):
     proj.vectorizer = TfidfVectorizer(tokenizer=proj.analyzer.tokenize_words)
     proj.vectorizer.fit([subj.text for subj in document_corpus.subjects])
     return proj
+
+
+def test_tfidf_default_params(datadir, project, caplog):
+    logger = annif.logger
+    logger.propagate = True
+    caplog.set_level(logging.DEBUG)
+
+    tfidf_type = annif.backend.get_backend("tfidf")
+    tfidf = tfidf_type(
+        backend_id='tfidf',
+        params={},
+        datadir=str(datadir))
+
+    expected_default_params = {
+        'limit': 100  # From AnnifBackend class
+    }
+    expected_msg = "all parameters not set, using following defaults:"
+    assert expected_msg in caplog.records[0].message
+    actual_params = tfidf.params
+    for param, val in expected_default_params.items():
+        assert param in actual_params and actual_params[param] == str(val)
 
 
 def test_tfidf_train(datadir, document_corpus, project):

--- a/tests/test_backend_tfidf.py
+++ b/tests/test_backend_tfidf.py
@@ -27,7 +27,7 @@ def test_tfidf_default_params(datadir, project, caplog):
     tfidf_type = annif.backend.get_backend("tfidf")
     tfidf = tfidf_type(
         backend_id='tfidf',
-        params={},
+        config_params={},
         datadir=str(datadir))
 
     expected_default_params = {
@@ -44,7 +44,7 @@ def test_tfidf_train(datadir, document_corpus, project):
     tfidf_type = annif.backend.get_backend("tfidf")
     tfidf = tfidf_type(
         backend_id='tfidf',
-        params={'limit': 10},
+        config_params={'limit': 10},
         datadir=str(datadir))
 
     tfidf.train(document_corpus, project)
@@ -57,7 +57,7 @@ def test_tfidf_suggest(datadir, project):
     tfidf_type = annif.backend.get_backend("tfidf")
     tfidf = tfidf_type(
         backend_id='tfidf',
-        params={'limit': 10},
+        config_params={'limit': 10},
         datadir=str(datadir))
 
     results = tfidf.suggest("""Arkeologiaa sanotaan joskus myös
@@ -77,7 +77,7 @@ def test_tfidf_suggest_unknown(datadir, project):
     tfidf_type = annif.backend.get_backend("tfidf")
     tfidf = tfidf_type(
         backend_id='tfidf',
-        params={'limit': 10},
+        config_params={'limit': 10},
         datadir=str(datadir))
 
     results = tfidf.suggest("abcdefghijk", project)  # unknown word

--- a/tests/test_backend_vw_ensemble.py
+++ b/tests/test_backend_vw_ensemble.py
@@ -28,9 +28,9 @@ def test_vw_ensemble_default_params(datadir, project, caplog):
         'discount_rate': 0.01,
         'loss_function': 'squared',
     }
-    expected_msg = "all parameters not set, using following defaults:"
-    assert expected_msg in caplog.records[0].message
+    expected_msg = "all parameters not set, using the following defaults:"
     actual_params = vw.params
+    assert expected_msg in caplog.records[0].message
     for param, val in expected_default_params.items():
         assert param in actual_params and actual_params[param] == str(val)
 

--- a/tests/test_backend_vw_ensemble.py
+++ b/tests/test_backend_vw_ensemble.py
@@ -1,5 +1,6 @@
 """Unit tests for the vw_ensemble backend in Annif"""
 
+import logging
 import json
 import time
 import pytest
@@ -9,6 +10,29 @@ import annif.project
 from annif.exception import NotInitializedException
 
 pytest.importorskip("annif.backend.vw_ensemble")
+
+
+def test_vw_ensemble_default_params(datadir, project, caplog):
+    logger = annif.logger
+    logger.propagate = True
+    caplog.set_level(logging.DEBUG)
+
+    vw_type = annif.backend.get_backend("vw_ensemble")
+    vw = vw_type(
+        backend_id='vw_ensemble',
+        params={},
+        datadir=str(datadir))
+
+    expected_default_params = {
+        'limit': 100,
+        'discount_rate': 0.01,
+        'loss_function': 'squared',
+    }
+    expected_msg = "all parameters not set, using following defaults:"
+    assert expected_msg in caplog.records[0].message
+    actual_params = vw.params
+    for param, val in expected_default_params.items():
+        assert param in actual_params and actual_params[param] == str(val)
 
 
 def test_vw_ensemble_suggest_no_model(datadir, project):

--- a/tests/test_backend_vw_ensemble.py
+++ b/tests/test_backend_vw_ensemble.py
@@ -1,6 +1,5 @@
 """Unit tests for the vw_ensemble backend in Annif"""
 
-import logging
 import json
 import time
 import pytest
@@ -12,11 +11,7 @@ from annif.exception import NotInitializedException
 pytest.importorskip("annif.backend.vw_ensemble")
 
 
-def test_vw_ensemble_default_params(datadir, project, caplog):
-    logger = annif.logger
-    logger.propagate = True
-    caplog.set_level(logging.DEBUG)
-
+def test_vw_ensemble_default_params(datadir, project):
     vw_type = annif.backend.get_backend("vw_ensemble")
     vw = vw_type(
         backend_id='vw_ensemble',
@@ -28,11 +23,9 @@ def test_vw_ensemble_default_params(datadir, project, caplog):
         'discount_rate': 0.01,
         'loss_function': 'squared',
     }
-    expected_msg = "all parameters not set, using the following defaults:"
     actual_params = vw.params
-    assert expected_msg in caplog.records[0].message
     for param, val in expected_default_params.items():
-        assert param in actual_params and actual_params[param] == str(val)
+        assert param in actual_params and actual_params[param] == val
 
 
 def test_vw_ensemble_suggest_no_model(datadir, project):

--- a/tests/test_backend_vw_ensemble.py
+++ b/tests/test_backend_vw_ensemble.py
@@ -20,7 +20,7 @@ def test_vw_ensemble_default_params(datadir, project, caplog):
     vw_type = annif.backend.get_backend("vw_ensemble")
     vw = vw_type(
         backend_id='vw_ensemble',
-        params={},
+        config_params={},
         datadir=str(datadir))
 
     expected_default_params = {
@@ -39,7 +39,7 @@ def test_vw_ensemble_suggest_no_model(datadir, project):
     vw_ensemble_type = annif.backend.get_backend('vw_ensemble')
     vw_ensemble = vw_ensemble_type(
         backend_id='vw_ensemble',
-        params={'sources': 'dummy-en'},
+        config_params={'sources': 'dummy-en'},
         datadir=str(datadir))
 
     with pytest.raises(NotInitializedException):
@@ -50,7 +50,7 @@ def test_vw_ensemble_train_and_learn(app, datadir, tmpdir):
     vw_ensemble_type = annif.backend.get_backend("vw_ensemble")
     vw_ensemble = vw_ensemble_type(
         backend_id='vw_ensemble',
-        params={'sources': 'dummy-en'},
+        config_params={'sources': 'dummy-en'},
         datadir=str(datadir))
 
     tmpfile = tmpdir.join('document.tsv')
@@ -91,7 +91,7 @@ def test_vw_ensemble_initialize(app, datadir):
     vw_ensemble_type = annif.backend.get_backend("vw_ensemble")
     vw_ensemble = vw_ensemble_type(
         backend_id='vw_ensemble',
-        params={'sources': 'dummy-en'},
+        config_params={'sources': 'dummy-en'},
         datadir=str(datadir))
 
     assert vw_ensemble._model is None
@@ -107,7 +107,7 @@ def test_vw_ensemble_suggest(app, datadir):
     vw_ensemble_type = annif.backend.get_backend("vw_ensemble")
     vw_ensemble = vw_ensemble_type(
         backend_id='vw_ensemble',
-        params={'sources': 'dummy-en'},
+        config_params={'sources': 'dummy-en'},
         datadir=str(datadir))
 
     project = annif.project.get_project('dummy-en')
@@ -127,7 +127,7 @@ def test_vw_ensemble_suggest_set_discount_rate(app, datadir):
     vw_ensemble_type = annif.backend.get_backend("vw_ensemble")
     vw_ensemble = vw_ensemble_type(
         backend_id='vw_ensemble',
-        params={'sources': 'dummy-en', 'discount_rate': '0.02'},
+        config_params={'sources': 'dummy-en', 'discount_rate': '0.02'},
         datadir=str(datadir))
 
     project = annif.project.get_project('dummy-en')
@@ -146,7 +146,7 @@ def test_vw_ensemble_format_example(datadir):
     vw_ensemble_type = annif.backend.get_backend("vw_ensemble")
     vw_ensemble = vw_ensemble_type(
         backend_id='vw_ensemble',
-        params={'sources': 'dummy-en'},
+        config_params={'sources': 'dummy-en'},
         datadir=str(datadir))
 
     ex = vw_ensemble._format_example(0, [0.5])
@@ -157,7 +157,7 @@ def test_vw_ensemble_format_example_avoid_sci_notation(datadir):
     vw_ensemble_type = annif.backend.get_backend("vw_ensemble")
     vw_ensemble = vw_ensemble_type(
         backend_id='vw_ensemble',
-        params={'sources': 'dummy-en'},
+        config_params={'sources': 'dummy-en'},
         datadir=str(datadir))
 
     ex = vw_ensemble._format_example(0, [7.24e-05])

--- a/tests/test_backend_vw_multi.py
+++ b/tests/test_backend_vw_multi.py
@@ -1,6 +1,5 @@
 """Unit tests for the fastText backend in Annif"""
 
-import logging
 import pytest
 import annif.backend
 import annif.corpus
@@ -19,11 +18,7 @@ def vw_corpus(tmpdir):
     return annif.corpus.DocumentFile(str(tmpfile))
 
 
-def test_vw_multi_default_params(datadir, project, caplog):
-    logger = annif.logger
-    logger.propagate = True
-    caplog.set_level(logging.DEBUG)
-
+def test_vw_multi_default_params(datadir, project):
     vw_type = annif.backend.get_backend("vw_multi")
     vw = vw_type(
         backend_id='vw_multi',
@@ -36,11 +31,9 @@ def test_vw_multi_default_params(datadir, project, caplog):
         'algorithm': 'oaa',
         'loss_function': 'logistic',
     }
-    expected_msg = "all parameters not set, using the following defaults:"
     actual_params = vw.params
-    assert expected_msg in caplog.records[0].message
     for param, val in expected_default_params.items():
-        assert param in actual_params and actual_params[param] == str(val)
+        assert param in actual_params and actual_params[param] == val
 
 
 def test_vw_multi_suggest_no_model(datadir, project):

--- a/tests/test_backend_vw_multi.py
+++ b/tests/test_backend_vw_multi.py
@@ -1,5 +1,6 @@
 """Unit tests for the fastText backend in Annif"""
 
+import logging
 import pytest
 import annif.backend
 import annif.corpus
@@ -16,6 +17,30 @@ def vw_corpus(tmpdir):
                   "arkeologia\thttp://www.yso.fi/onto/yso/p1265\n" +
                   "...\thttp://example.com/none")
     return annif.corpus.DocumentFile(str(tmpfile))
+
+
+def test_vw_multi_default_params(datadir, project, caplog):
+    logger = annif.logger
+    logger.propagate = True
+    caplog.set_level(logging.DEBUG)
+
+    vw_type = annif.backend.get_backend("vw_multi")
+    vw = vw_type(
+        backend_id='vw_multi',
+        params={},
+        datadir=str(datadir))
+
+    expected_default_params = {
+        'limit': 100,
+        'chunksize': 1,
+        'algorithm': 'oaa',
+        'loss_function': 'logistic',
+    }
+    expected_msg = "all parameters not set, using following defaults:"
+    assert expected_msg in caplog.records[0].message
+    actual_params = vw.params
+    for param, val in expected_default_params.items():
+        assert param in actual_params and actual_params[param] == str(val)
 
 
 def test_vw_multi_suggest_no_model(datadir, project):

--- a/tests/test_backend_vw_multi.py
+++ b/tests/test_backend_vw_multi.py
@@ -36,9 +36,9 @@ def test_vw_multi_default_params(datadir, project, caplog):
         'algorithm': 'oaa',
         'loss_function': 'logistic',
     }
-    expected_msg = "all parameters not set, using following defaults:"
-    assert expected_msg in caplog.records[0].message
+    expected_msg = "all parameters not set, using the following defaults:"
     actual_params = vw.params
+    assert expected_msg in caplog.records[0].message
     for param, val in expected_default_params.items():
         assert param in actual_params and actual_params[param] == str(val)
 

--- a/tests/test_backend_vw_multi.py
+++ b/tests/test_backend_vw_multi.py
@@ -77,7 +77,7 @@ def test_vw_multi_train_and_learn_nodocuments(datadir, tmpdir, project):
     vw_type = annif.backend.get_backend('vw_multi')
     vw = vw_type(
         backend_id='vw_multi',
-        params={
+        config_params={
             'chunksize': 4,
             'learning_rate': 0.5,
             'loss_function': 'hinge'},

--- a/tests/test_backend_vw_multi.py
+++ b/tests/test_backend_vw_multi.py
@@ -27,7 +27,7 @@ def test_vw_multi_default_params(datadir, project, caplog):
     vw_type = annif.backend.get_backend("vw_multi")
     vw = vw_type(
         backend_id='vw_multi',
-        params={},
+        config_params={},
         datadir=str(datadir))
 
     expected_default_params = {
@@ -47,7 +47,7 @@ def test_vw_multi_suggest_no_model(datadir, project):
     vw_type = annif.backend.get_backend('vw_multi')
     vw = vw_type(
         backend_id='vw_multi',
-        params={'chunksize': 4},
+        config_params={'chunksize': 4},
         datadir=str(datadir))
 
     with pytest.raises(NotInitializedException):
@@ -58,7 +58,7 @@ def test_vw_multi_train_and_learn(datadir, document_corpus, project):
     vw_type = annif.backend.get_backend('vw_multi')
     vw = vw_type(
         backend_id='vw_multi',
-        params={
+        config_params={
             'chunksize': 4,
             'learning_rate': 0.5,
             'loss_function': 'hinge'},
@@ -84,7 +84,7 @@ def test_vw_multi_train_from_project(app, datadir, document_corpus, project):
     vw_type = annif.backend.get_backend('vw_multi')
     vw = vw_type(
         backend_id='vw_multi',
-        params={
+        config_params={
             'chunksize': 4,
             'inputs': '_text_,dummy-en'},
         datadir=str(datadir))
@@ -100,7 +100,7 @@ def test_vw_multi_train_multiple_passes(datadir, document_corpus, project):
     vw_type = annif.backend.get_backend('vw_multi')
     vw = vw_type(
         backend_id='vw_multi',
-        params={
+        config_params={
             'chunksize': 4,
             'learning_rate': 0.5,
             'passes': 2},
@@ -116,7 +116,7 @@ def test_vw_multi_train_invalid_algorithm(datadir, document_corpus, project):
     vw_type = annif.backend.get_backend('vw_multi')
     vw = vw_type(
         backend_id='vw_multi',
-        params={
+        config_params={
             'chunksize': 4,
             'learning_rate': 0.5,
             'algorithm': 'invalid'},
@@ -130,7 +130,7 @@ def test_vw_multi_train_invalid_loss_function(datadir, project, vw_corpus):
     vw_type = annif.backend.get_backend('vw_multi')
     vw = vw_type(
         backend_id='vw_multi',
-        params={'chunksize': 4, 'loss_function': 'invalid'},
+        config_params={'chunksize': 4, 'loss_function': 'invalid'},
         datadir=str(datadir))
 
     with pytest.raises(ConfigurationException):
@@ -141,7 +141,7 @@ def test_vw_multi_train_invalid_learning_rate(datadir, project, vw_corpus):
     vw_type = annif.backend.get_backend('vw_multi')
     vw = vw_type(
         backend_id='vw_multi',
-        params={'chunksize': 4, 'learning_rate': 'high'},
+        config_params={'chunksize': 4, 'learning_rate': 'high'},
         datadir=str(datadir))
 
     with pytest.raises(ConfigurationException):
@@ -152,7 +152,7 @@ def test_vw_multi_suggest(datadir, project):
     vw_type = annif.backend.get_backend('vw_multi')
     vw = vw_type(
         backend_id='vw_multi',
-        params={'chunksize': 4, 'probabilities': 1},
+        config_params={'chunksize': 4, 'probabilities': 1},
         datadir=str(datadir))
 
     results = vw.suggest("""Arkeologiaa sanotaan joskus myös
@@ -172,7 +172,7 @@ def test_vw_multi_suggest_empty(datadir, project):
     vw_type = annif.backend.get_backend('vw_multi')
     vw = vw_type(
         backend_id='vw_multi',
-        params={'chunksize': 4},
+        config_params={'chunksize': 4},
         datadir=str(datadir))
 
     results = vw.suggest("...", project)
@@ -184,7 +184,7 @@ def test_vw_multi_suggest_multiple_passes(datadir, project):
     vw_type = annif.backend.get_backend('vw_multi')
     vw = vw_type(
         backend_id='vw_multi',
-        params={'chunksize': 4, 'passes': 2},
+        config_params={'chunksize': 4, 'passes': 2},
         datadir=str(datadir))
 
     results = vw.suggest("...", project)
@@ -196,7 +196,7 @@ def test_vw_multi_train_ect(datadir, document_corpus, project):
     vw_type = annif.backend.get_backend('vw_multi')
     vw = vw_type(
         backend_id='vw_multi',
-        params={
+        config_params={
             'chunksize': 4,
             'learning_rate': 0.5,
             'algorithm': 'ect'},
@@ -212,8 +212,8 @@ def test_vw_multi_suggest_ect(datadir, project):
     vw_type = annif.backend.get_backend('vw_multi')
     vw = vw_type(
         backend_id='vw_multi',
-        params={'chunksize': 1,
-                'algorithm': 'ect'},
+        config_params={'chunksize': 1,
+                       'algorithm': 'ect'},
         datadir=str(datadir))
 
     results = vw.suggest("""Arkeologiaa sanotaan joskus myös
@@ -230,7 +230,7 @@ def test_vw_multi_train_log_multi(datadir, document_corpus, project):
     vw_type = annif.backend.get_backend('vw_multi')
     vw = vw_type(
         backend_id='vw_multi',
-        params={
+        config_params={
             'chunksize': 4,
             'learning_rate': 0.5,
             'algorithm': 'log_multi'},
@@ -246,8 +246,8 @@ def test_vw_multi_suggest_log_multi(datadir, project):
     vw_type = annif.backend.get_backend('vw_multi')
     vw = vw_type(
         backend_id='vw_multi',
-        params={'chunksize': 1,
-                'algorithm': 'log_multi'},
+        config_params={'chunksize': 1,
+                       'algorithm': 'log_multi'},
         datadir=str(datadir))
 
     results = vw.suggest("""Arkeologiaa sanotaan joskus myös
@@ -264,7 +264,7 @@ def test_vw_multi_train_multilabel_oaa(datadir, document_corpus, project):
     vw_type = annif.backend.get_backend('vw_multi')
     vw = vw_type(
         backend_id='vw_multi',
-        params={
+        config_params={
             'chunksize': 4,
             'learning_rate': 0.5,
             'algorithm': 'multilabel_oaa'},
@@ -280,8 +280,8 @@ def test_vw_multi_suggest_multilabel_oaa(datadir, project):
     vw_type = annif.backend.get_backend('vw_multi')
     vw = vw_type(
         backend_id='vw_multi',
-        params={'chunksize': 1,
-                'algorithm': 'multilabel_oaa'},
+        config_params={'chunksize': 1,
+                       'algorithm': 'multilabel_oaa'},
         datadir=str(datadir))
 
     results = vw.suggest("""Arkeologiaa sanotaan joskus myös

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -89,6 +89,12 @@ def test_get_project_nobackend(app):
             backend = project.backend
 
 
+def test_get_project_noname(app):
+    with app.app_context():
+        project = annif.project.get_project('noname')
+        assert project.name == project.project_id
+
+
 def test_get_project_invalid_config_file(app):
     app = annif.create_app(
         config_name='annif.default_config.TestingInvalidProjectsConfig')

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -107,6 +107,7 @@ def test_get_project_default_params_tfidf(app):
 
 
 def test_get_project_default_params_fasttext(app):
+    pytest.importorskip("annif.backend.fasttext")
     with app.app_context():
         project = annif.project.get_project('noparams-fasttext-fi')
     expected_default_params = {

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -95,6 +95,31 @@ def test_get_project_noname(app):
         assert project.name == project.project_id
 
 
+def test_get_project_default_params_tfidf(app):
+    with app.app_context():
+        project = annif.project.get_project('noparams-tfidf-fi')
+    expected_default_params = {
+        'limit': 100  # From AnnifBackend class
+    }
+    actual_params = project.backend.params
+    for param, val in expected_default_params.items():
+        assert param in actual_params and actual_params[param] == str(val)
+
+
+def test_get_project_default_params_fasttext(app):
+    with app.app_context():
+        project = annif.project.get_project('noparams-fasttext-fi')
+    expected_default_params = {
+        'limit': 100,  # From AnnifBackend class
+        'dim': 100,    # Rest from FastTextBackend class
+        'lr': 0.25,
+        'epoch': 5,
+        'loss': 'hs'}
+    actual_params = project.backend.params
+    for param, val in expected_default_params.items():
+        assert param in actual_params and actual_params[param] == str(val)
+
+
 def test_get_project_invalid_config_file(app):
     app = annif.create_app(
         config_name='annif.default_config.TestingInvalidProjectsConfig')

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -103,7 +103,7 @@ def test_get_project_default_params_tfidf(app):
     }
     actual_params = project.backend.params
     for param, val in expected_default_params.items():
-        assert param in actual_params and actual_params[param] == str(val)
+        assert param in actual_params and actual_params[param] == val
 
 
 def test_get_project_default_params_fasttext(app):
@@ -118,7 +118,7 @@ def test_get_project_default_params_fasttext(app):
         'loss': 'hs'}
     actual_params = project.backend.params
     for param, val in expected_default_params.items():
-        assert param in actual_params and actual_params[param] == str(val)
+        assert param in actual_params and actual_params[param] == val
 
 
 def test_get_project_invalid_config_file(app):


### PR DESCRIPTION
Implemented one initial approach for discussion.

In this good is that default parameters can be included only in the relevant base classes for a backend (e.g. `chunksize` in `ChunkingBackend`). The Fasttext and VW params could be included to `DEFAULT_PARAMS` too (with a bit of work for passing only the backend specific params to the backends). 

Not-so-good is maybe the location of this, should it be in `project.py` instead? 

Another completely different approach could be to use to use [ConfigParser's defaults implementation](https://pymotw.com/3/configparser/#using-defaults).