### PR TITLE
Always use UTF-8 encoding when parsing TSV file document corpora

### DIFF
--- a/annif/corpus/document.py
+++ b/annif/corpus/document.py
@@ -58,12 +58,10 @@ class DocumentFile(DocumentCorpus, DocumentToSubjectCorpusMixin):
     @property
     def documents(self):
         if self.path.endswith('.gz'):
-            def opener(path):
-                """open a gzip compressed file in text mode"""
-                return gzip.open(path, mode='rt')
+            opener = gzip.open
         else:
             opener = open
-        with opener(self.path) as tsvfile:
+        with opener(self.path, mode='rt', encoding='utf-8') as tsvfile:
             for line in tsvfile:
                 yield from self._parse_tsv_line(line)
 


### PR DESCRIPTION
This is a follow-up for PR #263 which added explicit `encoding="utf-8"` parameters to many `open` calls but missed one case: when reading document corpora from TSV files (optionally gzip compressed). This PR fixes the one remaining case while also simplifying the code slightly.

The problem was reported by Pekka K. / Yle Arkisto. It manifests mostly on Windows, where non-UTF-8 locales (e.g. cp1252) are commonly used.