### PR TITLE
Avoid PytestUnknownMarkWarning by registering custom mark

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,3 @@
 [pytest]
 addopts = --pep8
+markers = pep8


### PR DESCRIPTION
I've been having a warning on every pytest run (with the following related package version: pytest=5.0.1; pytest-cache=1.0; pytest-cov=2.7.1; pytest-flask=0.15.0; pytest-pep8=1.0.6; pytest-watch=4.2.0):
```
============================================================================================= warnings summary =============================================================================================
/home/jmminkin/.local/share/virtualenvs/Annif-b5vsMxU8/lib/python3.6/site-packages/_pytest/mark/structures.py:332
  /home/jmminkin/.local/share/virtualenvs/Annif-b5vsMxU8/lib/python3.6/site-packages/_pytest/mark/structures.py:332: PytestUnknownMarkWarning: Unknown pytest.mark.pep8 - is this a typo?  You can register
custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
    PytestUnknownMarkWarning,

-- Docs: https://docs.pytest.org/en/latest/warnings.html
================================================================================= 218 passed, 1 warnings in 32.06 seconds ==================================================================================
```


This makes the warning go away by registering the `pep8` mark as instructed. 