### PR TITLE
Drone caching

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -36,7 +36,7 @@ steps:
       target: builder
     when:
       branch:
-      - drone-caching
+      - master
       event:
       - push
 
@@ -50,7 +50,7 @@ steps:
         - quay.io/natlibfi/annif:latest
     when:
       branch:
-      - drone-caching
+      - master
       event:
       - push
 


### PR DESCRIPTION
This enables docker-image layer caching in drone (in the sense that image is pulled from quay.io repo and only the layers that are changed are rebuild). The dry-run build times are supposed to decrease from 6-8 min to 1-2 min.