### PR TITLE
Pin Python docker image version to 3.7 to fix build error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3-slim-buster AS builder
+FROM python:3.7-slim-buster AS builder
 
 LABEL maintainer="Juho Inkinen <juho.inkinen@helsinki.fi>"
 
@@ -34,7 +34,7 @@ RUN apt-get update \
 
 
 
-FROM python:3-slim-buster
+FROM python:3.7-slim-buster
 
 COPY --from=builder /usr/local/lib/python3.7 /usr/local/lib/python3.7
 


### PR DESCRIPTION
[Drone builds](https://drone.kansalliskirjasto.fi/NatLibFi/Annif/334/1/2) were failing. This was due to that the docker base image was pinned to tag `3-slim-buster`, whose [Python version was updated from 3.7 to 3.8](https://hub.docker.com/_/python?tab=description&page=1&name=3.7-slim-buster). 

Fix by pinning the tag to `3.7-slim-buster`.