### PR TITLE
Fail gracefully when trying to evaluate an empty corpus. 

### DIFF
--- a/annif/eval.py
+++ b/annif/eval.py
@@ -6,6 +6,7 @@ import warnings
 import numpy as np
 from sklearn.metrics import precision_score, recall_score, f1_score
 from sklearn.metrics import label_ranking_average_precision_score
+from annif.exception import NotSupportedException
 
 
 def true_positives(y_true, y_pred):
@@ -133,6 +134,9 @@ class EvaluationBatch:
         """evaluate a set of selected subjects against a gold standard using
         different metrics. The set of metrics can be either 'all' or
         'simple'."""
+
+        if not self._samples:
+            raise NotSupportedException("cannot evaluate empty corpus")
 
         y_true = np.array([gold_subjects.as_vector(self._subject_index)
                            for hits, gold_subjects in self._samples])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -441,6 +441,16 @@ def test_eval_docfile():
     assert result.exit_code == 0
 
 
+def test_eval_empty_file(tmpdir):
+    empty_file = tmpdir.ensure('empty.tsv')
+    failed_result = runner.invoke(
+        annif.cli.cli, [
+            'eval', 'dummy-fi', str(empty_file)])
+    assert failed_result.exception
+    assert failed_result.exit_code != 0
+    assert 'cannot evaluate empty corpus' in failed_result.output
+
+
 def test_eval_nonexistent_path():
     failed_result = runner.invoke(
         annif.cli.cli, [


### PR DESCRIPTION
Fixes #350

Show an error instead of crashing when trying to evaluate an empty corpus.