### PR TITLE
Explicitly set charset=utf-8 for POST requests to Maui Server. 

### DIFF
--- a/annif/backend/maui.py
+++ b/annif/backend/maui.py
@@ -114,9 +114,13 @@ class MauiBackend(backend.AnnifBackend):
 
     def _suggest_request(self, text):
         data = {'text': text}
+        headers = {"Content-Type":
+                   "application/x-www-form-urlencoded; charset=UTF-8"}
 
         try:
-            resp = requests.post(self.tagger_url + '/suggest', data=data)
+            resp = requests.post(self.tagger_url + '/suggest',
+                                 data=data,
+                                 headers=headers)
             resp.raise_for_status()
         except requests.exceptions.RequestException as err:
             self.warning("HTTP request failed: {}".format(err))


### PR DESCRIPTION
This avoids encoding problems when Maui Server is run under Tomcat. Tomcat assumes that POST request content is ISO-8859-1 encoded (following the relevant specs) unless you tell it otherwise.