### PR TITLE
Fix UTF-8 BOM issues when reading files

### DIFF
--- a/annif/cli.py
+++ b/annif/cli.py
@@ -228,7 +228,7 @@ def run_index(project_id, directory, suffix, force,
 
     for docfilename, dummy_subjectfn in annif.corpus.DocumentDirectory(
             directory, require_subjects=False):
-        with open(docfilename, encoding='utf-8') as docfile:
+        with open(docfilename, encoding='utf-8-sig') as docfile:
             text = docfile.read()
         subjectfilename = re.sub(r'\.txt$', suffix, docfilename)
         if os.path.exists(subjectfilename) and not force:

--- a/annif/corpus/document.py
+++ b/annif/corpus/document.py
@@ -60,7 +60,7 @@ class DocumentFile(DocumentCorpus):
             opener = gzip.open
         else:
             opener = open
-        with opener(self.path, mode='rt', encoding='utf-8') as tsvfile:
+        with opener(self.path, mode='rt', encoding='utf-8-sig') as tsvfile:
             for line in tsvfile:
                 yield from self._parse_tsv_line(line)
 

--- a/annif/corpus/document.py
+++ b/annif/corpus/document.py
@@ -39,9 +39,9 @@ class DocumentDirectory(DocumentCorpus):
     def documents(self):
         for docfilename, keyfilename in self:
             with open(docfilename, errors='replace',
-                      encoding='utf-8') as docfile:
+                      encoding='utf-8-sig') as docfile:
                 text = docfile.read()
-            with open(keyfilename, encoding='utf-8') as keyfile:
+            with open(keyfilename, encoding='utf-8-sig') as keyfile:
                 subjects = SubjectSet.from_string(keyfile.read())
             yield self._create_document(text=text,
                                         uris=subjects.subject_uris,

--- a/annif/corpus/subject.py
+++ b/annif/corpus/subject.py
@@ -15,7 +15,7 @@ class SubjectFileTSV:
 
     @property
     def subjects(self):
-        with open(self.path, encoding='utf-8') as subjfile:
+        with open(self.path, encoding='utf-8-sig') as subjfile:
             for line in subjfile:
                 uri, label = line.strip().split(None, 1)
                 clean_uri = annif.util.cleanup_uri(uri)

--- a/annif/project.py
+++ b/annif/project.py
@@ -213,7 +213,7 @@ def _create_projects(projects_file, datadir, init_projects):
 
     config = configparser.ConfigParser()
     config.optionxform = lambda option: option
-    with open(projects_file, encoding='utf-8') as projf:
+    with open(projects_file, encoding='utf-8-sig') as projf:
         try:
             config.read_file(projf)
         except (configparser.DuplicateOptionError,

--- a/tests/corpora/archaeology/subjects-bom.tsv
+++ b/tests/corpora/archaeology/subjects-bom.tsv
@@ -1,0 +1,10 @@
+﻿<http://www.yso.fi/onto/yso/p10073>	mykeneläinen kulttuuri
+<http://www.yso.fi/onto/yso/p10174>	fosfaattianalyysi
+<http://www.yso.fi/onto/yso/p10295>	kykladinen kulttuuri
+<http://www.yso.fi/onto/yso/p10415>	rahalöydöt
+<http://www.yso.fi/onto/yso/p10416>	aarrelöydöt
+<http://www.yso.fi/onto/yso/p10417>	muinaisesineet
+<http://www.yso.fi/onto/yso/p10826>	Askolan kulttuuri
+<http://www.yso.fi/onto/yso/p10849>	arkeologit
+<http://www.yso.fi/onto/yso/p10986>	piirtokirjoitukset
+<http://www.yso.fi/onto/yso/p11052>	rannansiirtyminen

--- a/tests/projects_for_config_path_option.cfg
+++ b/tests/projects_for_config_path_option.cfg
@@ -1,4 +1,4 @@
-# Project configuration for Annif unit tests
+﻿# Project configuration for Annif unit tests
 
 
 [dummy_for_projects_option]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -126,6 +126,25 @@ def test_loadvoc_tsv(testdatadir):
     assert testdatadir.join('vocabs/yso-fi/subjects.ttl').size() > 0
 
 
+def test_loadvoc_tsv_with_bom(testdatadir):
+    with contextlib.suppress(FileNotFoundError):
+        os.remove(str(testdatadir.join('projects/tfidf-fi/subjects')))
+    with contextlib.suppress(FileNotFoundError):
+        os.remove(str(testdatadir.join('projects/tfidf-fi/subjects.ttl')))
+    subjectfile = os.path.join(
+        os.path.dirname(__file__),
+        'corpora',
+        'archaeology',
+        'subjects-bom.tsv')
+    result = runner.invoke(annif.cli.cli, ['loadvoc', 'tfidf-fi', subjectfile])
+    assert not result.exception
+    assert result.exit_code == 0
+    assert testdatadir.join('vocabs/yso-fi/subjects').exists()
+    assert testdatadir.join('vocabs/yso-fi/subjects').size() > 0
+    assert testdatadir.join('vocabs/yso-fi/subjects.ttl').exists()
+    assert testdatadir.join('vocabs/yso-fi/subjects.ttl').size() > 0
+
+
 def test_loadvoc_rdf(testdatadir):
     with contextlib.suppress(FileNotFoundError):
         os.remove(str(testdatadir.join('projects/tfidf-fi/subjects')))

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -178,6 +178,18 @@ def test_docfile_plain(tmpdir):
     assert len(list(docs.documents)) == 3
 
 
+def test_docfile_bom(tmpdir):
+    docfile = tmpdir.join('documents_bom.tsv')
+    data = """Läntinen\t<http://www.yso.fi/onto/yso/p2557>
+        Oulunlinnan\t<http://www.yso.fi/onto/yso/p7346>
+        Harald Hirmuinen\t<http://www.yso.fi/onto/yso/p6479>"""
+    docfile.write(data.encode('utf-8-sig'))
+
+    docs = annif.corpus.DocumentFile(str(docfile))
+    firstdoc = next(docs.documents)
+    assert firstdoc.text.startswith("Läntinen")
+
+
 def test_docfile_plain_invalid_lines(tmpdir, caplog):
     logger = annif.logger
     logger.propagate = True

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -83,6 +83,24 @@ def test_docdir_tsv(tmpdir):
     assert files[2][1] is None
 
 
+def test_docdir_tsv_bom(tmpdir):
+    tmpdir.join('doc1.txt').write('doc1'.encode('utf-8-sig'))
+    tmpdir.join('doc1.tsv').write(
+        '<http://example.org/key1>\tkey1'.encode('utf-8-sig'))
+    tmpdir.join('doc2.txt').write('doc2'.encode('utf-8-sig'))
+    tmpdir.join('doc2.tsv').write(
+        '<http://example.org/key2>\tkey2'.encode('utf-8-sig'))
+
+    docdir = annif.corpus.DocumentDirectory(str(tmpdir))
+    docs = list(docdir.documents)
+    assert docs[0].text == 'doc1'
+    assert list(docs[0].uris)[0] == 'http://example.org/key1'
+    assert list(docs[0].labels)[0] == 'key1'
+    assert docs[1].text == 'doc2'
+    assert list(docs[1].uris)[0] == 'http://example.org/key2'
+    assert list(docs[1].labels)[0] == 'key2'
+
+
 def test_docdir_key_require_subjects(tmpdir):
     tmpdir.join('doc1.txt').write('doc1')
     tmpdir.join('doc1.key').write('<http://example.org/key1>\tkey1')


### PR DESCRIPTION
Fixes #307 

This PR changes the way text files (including `projects.cfg`, TSV and TXT files) are read in order to handle UTF-8 byte order marks (BOM) gracefully. In practice, we just switch from `utf-8` encoding to `utf-8-sig`, which ignores existing BOMs.