### PR TITLE
Add F1@5 evaluation metric

### DIFF
--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -6,6 +6,12 @@ import annif.eval
 import annif.suggestion
 
 
+def test_filter_pred_top_k():
+    pred = np.array([[0, 1, 3, 2], [1, 4, 3, 0]])
+    filtered = annif.eval.filter_pred_top_k(pred, 2)
+    assert filtered.tolist() == [[0, 0, 3, 2], [0, 4, 3, 0]]
+
+
 def test_precision_at_k():
     y_true = np.array([[1, 0, 1, 0, 1, 0]])
     y_pred = np.array([[6, 5, 4, 3, 2, 1]])


### PR DESCRIPTION
I find that I often want to see the F1 score at K=5, i.e. when the suggestions are limited to the top 5 subjects. Currently this requires using `annif eval --limit 5 ...` but this is inconvenient and I often forget the `--limit` parameter. 

This PR adds F1@5 to the list of evaluation results.

The `filter_pred_top_k` function is a bit awkward - my NumPy array mangling skills weren't enough to implement the logic without resorting to a `for` loop. It can be changed later if necessary, and the unit test verifies that it at least gives the correct result.