### PR TITLE
Refactor backend project

### DIFF
--- a/annif/backend/backend.py
+++ b/annif/backend/backend.py
@@ -32,7 +32,7 @@ class AnnifBackend(metaclass=abc.ABCMeta):
         params.update(self.config_params)
         return params
 
-    def train(self, corpus, project):
+    def train(self, corpus):
         """train the model on the given document or subject corpus"""
         pass  # default is to do nothing, subclasses may override
 

--- a/annif/backend/backend.py
+++ b/annif/backend/backend.py
@@ -73,6 +73,6 @@ class AnnifLearningBackend(AnnifBackend):
     """Base class for Annif backends that can perform online learning"""
 
     @abc.abstractmethod
-    def learn(self, corpus, project):
+    def learn(self, corpus):
         """further train the model on the given document or subject corpus"""
         pass  # pragma: no cover

--- a/annif/backend/backend.py
+++ b/annif/backend/backend.py
@@ -42,19 +42,19 @@ class AnnifBackend(metaclass=abc.ABCMeta):
         pass
 
     @abc.abstractmethod
-    def _suggest(self, text, project, params):
+    def _suggest(self, text, params):
         """This method should implemented by backends. It implements
         the suggest functionality, with pre-processed parameters."""
         pass  # pragma: no cover
 
-    def suggest(self, text, project, params=None):
+    def suggest(self, text, params=None):
         """Suggest subjects for the input text and return a list of subjects
         represented as a list of SubjectSuggestion objects."""
         self.initialize()
         beparams = dict(self.params)
         if params:
             beparams.update(params)
-        return self._suggest(text, project, params=beparams)
+        return self._suggest(text, params=beparams)
 
     def debug(self, message):
         """Log a debug message from this backend"""

--- a/annif/backend/backend.py
+++ b/annif/backend/backend.py
@@ -13,13 +13,14 @@ class AnnifBackend(metaclass=abc.ABCMeta):
 
     DEFAULT_PARAMS = {'limit': 100}
 
-    def __init__(self, backend_id, config_params, datadir):
+    def __init__(self, backend_id, config_params, project):
         """Initialize backend with specific parameters. The
         parameters are a dict. Keys and values depend on the specific
         backend type."""
         self.backend_id = backend_id
-        self.datadir = datadir
         self.config_params = config_params
+        self.project = project
+        self.datadir = project.datadir
 
     def default_params(self):
         return self.DEFAULT_PARAMS

--- a/annif/backend/dummy.py
+++ b/annif/backend/dummy.py
@@ -17,12 +17,12 @@ class DummyBackend(backend.AnnifLearningBackend):
     def initialize(self):
         self.initialized = True
 
-    def _suggest(self, text, project, params):
+    def _suggest(self, text, params):
         score = float(params.get('score', 1.0))
         return ListSuggestionResult([SubjectSuggestion(uri=self.uri,
                                                        label=self.label,
                                                        score=score)],
-                                    project.subjects)
+                                    self.project.subjects)
 
     def learn(self, corpus):
         # in this dummy backend we "learn" by picking up the URI and label

--- a/annif/backend/dummy.py
+++ b/annif/backend/dummy.py
@@ -24,7 +24,7 @@ class DummyBackend(backend.AnnifLearningBackend):
                                                        score=score)],
                                     project.subjects)
 
-    def learn(self, corpus, project):
+    def learn(self, corpus):
         # in this dummy backend we "learn" by picking up the URI and label
         # of the first subject of the first document in the learning set
         # and using that in subsequent analysis results

--- a/annif/backend/ensemble.py
+++ b/annif/backend/ensemble.py
@@ -30,16 +30,14 @@ class EnsembleBackend(backend.AnnifBackend):
                     hits=norm_hits, weight=weight))
         return hits_from_sources
 
-    def _merge_hits_from_sources(self, hits_from_sources, project, params):
+    def _merge_hits_from_sources(self, hits_from_sources, params):
         """Hook for merging hits from sources. Can be overridden by
         subclasses."""
-        return annif.util.merge_hits(hits_from_sources, project.subjects)
+        return annif.util.merge_hits(hits_from_sources, self.project.subjects)
 
-    def _suggest(self, text, project, params):
+    def _suggest(self, text, params):
         sources = annif.util.parse_sources(params['sources'])
         hits_from_sources = self._suggest_with_sources(text, sources)
-        merged_hits = self._merge_hits_from_sources(hits_from_sources,
-                                                    project,
-                                                    params)
+        merged_hits = self._merge_hits_from_sources(hits_from_sources, params)
         self.debug('{} hits after merging'.format(len(merged_hits)))
         return merged_hits

--- a/annif/backend/http.py
+++ b/annif/backend/http.py
@@ -11,7 +11,7 @@ from . import backend
 class HTTPBackend(backend.AnnifBackend):
     name = "http"
 
-    def _suggest(self, text, project, params):
+    def _suggest(self, text, params):
         data = {'text': text}
         if 'project' in params:
             data['project'] = params['project']
@@ -21,13 +21,13 @@ class HTTPBackend(backend.AnnifBackend):
             req.raise_for_status()
         except requests.exceptions.RequestException as err:
             self.warning("HTTP request failed: {}".format(err))
-            return ListSuggestionResult([], project.subjects)
+            return ListSuggestionResult([], self.project.subjects)
 
         try:
             response = req.json()
         except ValueError as err:
             self.warning("JSON decode failed: {}".format(err))
-            return ListSuggestionResult([], project.subjects)
+            return ListSuggestionResult([], self.project.subjects)
 
         if 'results' in response:
             results = response['results']
@@ -40,7 +40,7 @@ class HTTPBackend(backend.AnnifBackend):
                                                            score=h['score'])
                                          for h in results
                                          if h['score'] > 0.0],
-                                        project.subjects)
+                                        self.project.subjects)
         except (TypeError, ValueError) as err:
             self.warning("Problem interpreting JSON data: {}".format(err))
-            return ListSuggestionResult([], project.subjects)
+            return ListSuggestionResult([], self.project.subjects)

--- a/annif/backend/maui.py
+++ b/annif/backend/maui.py
@@ -132,21 +132,21 @@ class MauiBackend(backend.AnnifBackend):
             self.warning("JSON decode failed: {}".format(err))
             return None
 
-    def _response_to_result(self, response, project):
+    def _response_to_result(self, response):
         try:
             return ListSuggestionResult(
                 [SubjectSuggestion(uri=h['id'],
                                    label=h['label'],
                                    score=h['probability'])
                  for h in response['topics']
-                 if h['probability'] > 0.0], project.subjects)
+                 if h['probability'] > 0.0], self.project.subjects)
         except (TypeError, ValueError) as err:
             self.warning("Problem interpreting JSON data: {}".format(err))
-            return ListSuggestionResult([], project.subjects)
+            return ListSuggestionResult([], self.project.subjects)
 
-    def _suggest(self, text, project, params):
+    def _suggest(self, text, params):
         response = self._suggest_request(text)
         if response:
-            return self._response_to_result(response, project)
+            return self._response_to_result(response)
         else:
-            return ListSuggestionResult([], project.subjects)
+            return ListSuggestionResult([], self.project.subjects)

--- a/annif/backend/maui.py
+++ b/annif/backend/maui.py
@@ -58,11 +58,11 @@ class MauiBackend(backend.AnnifBackend):
         except requests.exceptions.RequestException as err:
             raise OperationFailedException(err)
 
-    def _upload_vocabulary(self, project):
+    def _upload_vocabulary(self):
         self.info("Uploading vocabulary")
         try:
             resp = requests.put(self.tagger_url + '/vocab',
-                                data=project.vocab.as_skos())
+                                data=self.project.vocab.as_skos())
             resp.raise_for_status()
         except requests.exceptions.RequestException as err:
             raise OperationFailedException(err)
@@ -102,12 +102,12 @@ class MauiBackend(backend.AnnifBackend):
                 return
             time.sleep(1)
 
-    def train(self, corpus, project):
+    def train(self, corpus):
         if corpus.is_empty():
             raise NotSupportedException('training backend {} with no documents'
                                         .format(self.backend_id))
         self._initialize_tagger()
-        self._upload_vocabulary(project)
+        self._upload_vocabulary()
         self._create_train_file(corpus)
         self._upload_train_file()
         self._wait_for_train()

--- a/annif/backend/mixins.py
+++ b/annif/backend/mixins.py
@@ -14,16 +14,16 @@ class ChunkingBackend(metaclass=abc.ABCMeta):
         return self.DEFAULT_PARAMS
 
     @abc.abstractmethod
-    def _suggest_chunks(self, chunktexts, project):
+    def _suggest_chunks(self, chunktexts):
         """Suggest subjects for the chunked text; should be implemented by
         the subclass inheriting this mixin"""
 
         pass  # pragma: no cover
 
-    def _suggest(self, text, project, params):
+    def _suggest(self, text, params):
         self.debug('Suggesting subjects for text "{}..." (len={})'.format(
             text[:20], len(text)))
-        sentences = project.analyzer.tokenize_sentences(text)
+        sentences = self.project.analyzer.tokenize_sentences(text)
         self.debug('Found {} sentences'.format(len(sentences)))
         chunksize = int(params['chunksize'])
         chunktexts = []
@@ -32,5 +32,5 @@ class ChunkingBackend(metaclass=abc.ABCMeta):
         self.debug('Split sentences into {} chunks'.format(len(chunktexts)))
         if len(chunktexts) == 0:  # no input, empty result
             return ListSuggestionResult(
-                hits=[], subject_index=project.subjects)
-        return self._suggest_chunks(chunktexts, project)
+                hits=[], subject_index=self.project.subjects)
+        return self._suggest_chunks(chunktexts)

--- a/annif/backend/nn_ensemble.py
+++ b/annif/backend/nn_ensemble.py
@@ -54,13 +54,13 @@ class NNEnsembleBackend(
         self.debug('loading Keras model from {}'.format(model_filename))
         self._model = load_model(model_filename)
 
-    def _merge_hits_from_sources(self, hits_from_sources, project, params):
+    def _merge_hits_from_sources(self, hits_from_sources, params):
         score_vector = np.array([hits.vector * weight
                                  for hits, weight in hits_from_sources],
                                 dtype=np.float32)
         results = self._model.predict(
             np.expand_dims(score_vector.transpose(), 0))
-        return VectorSuggestionResult(results[0], project.subjects)
+        return VectorSuggestionResult(results[0], self.project.subjects)
 
     def _create_model(self, sources):
         self.info("creating NN ensemble model")

--- a/annif/backend/nn_ensemble.py
+++ b/annif/backend/nn_ensemble.py
@@ -131,6 +131,6 @@ class NNEnsembleBackend(
             self.datadir,
             self.MODEL_FILE)
 
-    def learn(self, corpus, project):
+    def learn(self, corpus):
         self.initialize()
         self._learn(corpus, int(self.params['learn-epochs']))

--- a/annif/backend/pav.py
+++ b/annif/backend/pav.py
@@ -97,7 +97,7 @@ class PAVBackend(ensemble.EnsembleBackend):
             model_filename,
             method=joblib.dump)
 
-    def train(self, corpus, project):
+    def train(self, corpus):
         if corpus.is_empty():
             raise NotSupportedException('training backend {} with no documents'
                                         .format(self.backend_id))

--- a/annif/backend/tfidf.py
+++ b/annif/backend/tfidf.py
@@ -63,22 +63,22 @@ class TFIDFBackend(backend.AnnifBackend):
     VECTORIZER_FILE = 'vectorizer'
     INDEX_FILE = 'tfidf-index'
 
-    def _generate_subjects_from_documents(self, corpus, project):
+    def _generate_subjects_from_documents(self, corpus):
         with tempfile.TemporaryDirectory() as tempdir:
             subject_buffer = {}
-            for subject_id in range(len(project.subjects)):
+            for subject_id in range(len(self.project.subjects)):
                 subject_buffer[subject_id] = SubjectBuffer(tempdir,
                                                            subject_id)
 
             for doc in corpus.documents:
-                tokens = project.analyzer.tokenize_words(doc.text)
+                tokens = self.project.analyzer.tokenize_words(doc.text)
                 for uri in doc.uris:
-                    subject_id = project.subjects.by_uri(uri)
+                    subject_id = self.project.subjects.by_uri(uri)
                     if subject_id is None:
                         continue
                     subject_buffer[subject_id].write(" ".join(tokens))
 
-            for sid in range(len(project.subjects)):
+            for sid in range(len(self.project.subjects)):
                 yield subject_buffer[sid].read()
 
     def _initialize_vectorizer(self):
@@ -118,12 +118,12 @@ class TFIDFBackend(backend.AnnifBackend):
             self.datadir,
             self.INDEX_FILE)
 
-    def train(self, corpus, project):
+    def train(self, corpus):
         if corpus.is_empty():
             raise NotSupportedException(
                 'Cannot train tfidf project with no documents')
         self.info('transforming subject corpus')
-        subjects = self._generate_subjects_from_documents(corpus, project)
+        subjects = self._generate_subjects_from_documents(corpus)
         self.info('creating vectorizer')
         self._vectorizer = TfidfVectorizer()
         veccorpus = self._vectorizer.fit_transform(subjects)

--- a/annif/backend/tfidf.py
+++ b/annif/backend/tfidf.py
@@ -134,11 +134,11 @@ class TFIDFBackend(backend.AnnifBackend):
             method=joblib.dump)
         self._create_index(veccorpus)
 
-    def _suggest(self, text, project, params):
+    def _suggest(self, text, params):
         self.debug('Suggesting subjects for text "{}..." (len={})'.format(
             text[:20], len(text)))
-        tokens = project.analyzer.tokenize_words(text)
+        tokens = self.project.analyzer.tokenize_words(text)
         vectors = self._vectorizer.transform([" ".join(tokens)])
         docsim = self._index[vectors[0]]
-        fullresult = VectorSuggestionResult(docsim, project.subjects)
+        fullresult = VectorSuggestionResult(docsim, self.project.subjects)
         return fullresult.filter(limit=int(self.params['limit']))

--- a/annif/backend/vw_base.py
+++ b/annif/backend/vw_base.py
@@ -104,7 +104,7 @@ class VWBaseBackend(backend.AnnifLearningBackend, metaclass=abc.ABCMeta):
         self._create_train_file(corpus)
         self._create_model()
 
-    def learn(self, corpus, project):
+    def learn(self, corpus):
         self.initialize()
         for example in self._create_examples(corpus):
             self._model.learn(example)

--- a/annif/backend/vw_base.py
+++ b/annif/backend/vw_base.py
@@ -71,22 +71,22 @@ class VWBaseBackend(backend.AnnifLearningBackend, metaclass=abc.ABCMeta):
             for ex in examples:
                 print(ex, file=trainfile)
 
-    def _create_train_file(self, corpus, project):
+    def _create_train_file(self, corpus):
         self.info('creating VW train file')
-        examples = self._create_examples(corpus, project)
+        examples = self._create_examples(corpus)
         annif.util.atomic_save(examples,
                                self.datadir,
                                self.TRAIN_FILE,
                                method=self._write_train_file)
 
     @abc.abstractmethod
-    def _create_examples(self, corpus, project):
+    def _create_examples(self, corpus):
         """This method should be implemented by concrete backends. It
         should return a sequence of strings formatted according to the VW
         input format."""
         pass  # pragma: no cover
 
-    def _create_model(self, project, initial_params={}):
+    def _create_model(self, initial_params={}):
         initial_params = initial_params.copy()  # don't mutate the original
         trainpath = os.path.join(self.datadir, self.TRAIN_FILE)
         initial_params['data'] = trainpath
@@ -99,14 +99,14 @@ class VWBaseBackend(backend.AnnifLearningBackend, metaclass=abc.ABCMeta):
         modelpath = os.path.join(self.datadir, self.MODEL_FILE)
         self._model.save(modelpath)
 
-    def train(self, corpus, project):
+    def train(self, corpus):
         self.info("creating VW model")
-        self._create_train_file(corpus, project)
-        self._create_model(project)
+        self._create_train_file(corpus)
+        self._create_model()
 
     def learn(self, corpus, project):
         self.initialize()
-        for example in self._create_examples(corpus, project):
+        for example in self._create_examples(corpus):
             self._model.learn(example)
         modelpath = os.path.join(self.datadir, self.MODEL_FILE)
         self._model.save(modelpath)

--- a/annif/backend/vw_ensemble.py
+++ b/annif/backend/vw_ensemble.py
@@ -82,7 +82,7 @@ class VWEnsembleBackend(
         pred_score = (self._model.predict(ex) + 1.0) / 2.0
         return raw_score, pred_score
 
-    def _merge_hits_from_sources(self, hits_from_sources, project, params):
+    def _merge_hits_from_sources(self, hits_from_sources, params):
         score_vector = np.array([hits.vector
                                  for hits, _ in hits_from_sources],
                                 dtype=np.float32)
@@ -97,7 +97,7 @@ class VWEnsembleBackend(
                     ((discount_rate * self._subject_freq[subj_id]) + 1)
                 result[subj_id] = (raw_weight * raw_score) + \
                     (1.0 - raw_weight) * pred_score
-        return VectorSuggestionResult(result, project.subjects)
+        return VectorSuggestionResult(result, self.project.subjects)
 
     @property
     def _source_project_ids(self):

--- a/annif/backend/vw_ensemble.py
+++ b/annif/backend/vw_ensemble.py
@@ -168,7 +168,7 @@ class VWEnsembleBackend(
                                self.TRAIN_FILE,
                                method=self._write_train_file)
 
-    def learn(self, corpus, project):
+    def learn(self, corpus):
         self.initialize()
         exampledata = self._create_examples(corpus)
         for subj_id, example in exampledata:

--- a/annif/backend/vw_ensemble.py
+++ b/annif/backend/vw_ensemble.py
@@ -123,10 +123,10 @@ class VWEnsembleBackend(
             score_vectors.append(hits.vector)
         return np.array(score_vectors, dtype=np.float32)
 
-    def _doc_to_example(self, doc, project, source_projects):
+    def _doc_to_example(self, doc, source_projects):
         examples = []
         subjects = annif.corpus.SubjectSet((doc.uris, doc.labels))
-        true = subjects.as_vector(project.subjects)
+        true = subjects.as_vector(self.project.subjects)
         score_vector = self._doc_score_vector(doc, source_projects)
         for subj_id in range(len(true)):
             if true[subj_id] or score_vector[:, subj_id].sum() > 0.0:
@@ -137,12 +137,12 @@ class VWEnsembleBackend(
                 examples.append(ex)
         return examples
 
-    def _create_examples(self, corpus, project):
+    def _create_examples(self, corpus):
         source_projects = [annif.project.get_project(project_id)
                            for project_id in self._source_project_ids]
         examples = []
         for doc in corpus.documents:
-            examples += self._doc_to_example(doc, project, source_projects)
+            examples += self._doc_to_example(doc, source_projects)
         random.shuffle(examples)
         return examples
 
@@ -151,9 +151,9 @@ class VWEnsembleBackend(
         with open(filename, 'w') as freqfile:
             json.dump(subject_freq, freqfile)
 
-    def _create_train_file(self, corpus, project):
+    def _create_train_file(self, corpus):
         self.info('creating VW train file')
-        exampledata = self._create_examples(corpus, project)
+        exampledata = self._create_examples(corpus)
 
         subjects = [subj_id for subj_id, ex in exampledata]
         self._subject_freq = collections.Counter(subjects)
@@ -170,7 +170,7 @@ class VWEnsembleBackend(
 
     def learn(self, corpus, project):
         self.initialize()
-        exampledata = self._create_examples(corpus, project)
+        exampledata = self._create_examples(corpus)
         for subj_id, example in exampledata:
             self._model.learn(example)
             self._subject_freq[subj_id] += 1

--- a/annif/project.py
+++ b/annif/project.py
@@ -103,7 +103,7 @@ class AnnifProject(DatadirMixin):
         if backend_params is None:
             backend_params = {}
         beparams = backend_params.get(self.backend.backend_id, {})
-        hits = self.backend.suggest(text, project=self, params=beparams)
+        hits = self.backend.suggest(text, params=beparams)
         logger.debug(
             'Got %d hits from backend %s',
             len(hits), self.backend.backend_id)

--- a/annif/project.py
+++ b/annif/project.py
@@ -177,7 +177,7 @@ class AnnifProject(DatadirMixin):
         if isinstance(
                 self.backend,
                 annif.backend.backend.AnnifLearningBackend):
-            self.backend.learn(corpus, project=self)
+            self.backend.learn(corpus)
         else:
             raise NotSupportedException("Learning not supported by backend",
                                         project_id=self.project_id)

--- a/annif/project.py
+++ b/annif/project.py
@@ -132,7 +132,7 @@ class AnnifProject(DatadirMixin):
                 backend_class = annif.backend.get_backend(backend_id)
                 self._backend = backend_class(
                     backend_id, config_params=self.config,
-                    datadir=self.datadir)
+                    project=self)
             except ValueError:
                 logger.warning(
                     "Could not create backend %s, "

--- a/annif/project.py
+++ b/annif/project.py
@@ -168,7 +168,7 @@ class AnnifProject(DatadirMixin):
         """train the project using documents from a metadata source"""
 
         corpus.set_subject_index(self.subjects)
-        self.backend.train(corpus, project=self)
+        self.backend.train(corpus)
 
     def learn(self, corpus):
         """further train the project using documents from a metadata source"""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -75,10 +75,11 @@ def document_corpus(subject_index):
 
 
 @pytest.fixture(scope='module')
-def project(subject_index):
+def project(subject_index, datadir):
     proj = unittest.mock.Mock()
     proj.analyzer = annif.analyzer.get_analyzer('snowball(finnish)')
     proj.subjects = subject_index
+    proj.datadir = str(datadir)
     return proj
 
 

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -16,7 +16,7 @@ def test_get_backend_dummy(project):
     dummy_type = annif.backend.get_backend("dummy")
     dummy = dummy_type(backend_id='dummy', config_params={},
                        project=project)
-    result = dummy.suggest(text='this is some text', project=project)
+    result = dummy.suggest(text='this is some text')
     assert len(result) == 1
     assert result[0].uri == 'http://example.org/dummy'
     assert result[0].label == 'dummy'
@@ -36,7 +36,7 @@ def test_learn_dummy(project, tmpdir):
 
     dummy.learn(docdir)
 
-    result = dummy.suggest(text='this is some text', project=project)
+    result = dummy.suggest(text='this is some text')
     assert len(result) == 1
     assert result[0].uri == 'http://example.org/key1'
     assert result[0].label == 'key1'

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -12,10 +12,10 @@ def test_get_backend_nonexistent():
         annif.backend.get_backend("nonexistent")
 
 
-def test_get_backend_dummy(app, project):
+def test_get_backend_dummy(project):
     dummy_type = annif.backend.get_backend("dummy")
     dummy = dummy_type(backend_id='dummy', config_params={},
-                       datadir=app.config['DATADIR'])
+                       project=project)
     result = dummy.suggest(text='this is some text', project=project)
     assert len(result) == 1
     assert result[0].uri == 'http://example.org/dummy'
@@ -23,10 +23,10 @@ def test_get_backend_dummy(app, project):
     assert result[0].score == 1.0
 
 
-def test_learn_dummy(app, project, tmpdir):
+def test_learn_dummy(project, tmpdir):
     dummy_type = annif.backend.get_backend("dummy")
     dummy = dummy_type(backend_id='dummy', config_params={},
-                       datadir=app.config['DATADIR'])
+                       project=project)
 
     tmpdir.join('doc1.txt').write('doc1')
     tmpdir.join('doc1.tsv').write('<http://example.org/key1>\tkey1')
@@ -43,9 +43,9 @@ def test_learn_dummy(app, project, tmpdir):
     assert result[0].score == 1.0
 
 
-def test_fill_params_with_defaults(app):
+def test_fill_params_with_defaults(project):
     dummy_type = annif.backend.get_backend('dummy')
     dummy = dummy_type(backend_id='dummy', config_params={},
-                       datadir=app.config['DATADIR'])
+                       project=project)
     expected_default_params = {'limit': 100}  # From AnnifBackend class
     assert expected_default_params == dummy.params

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -34,7 +34,7 @@ def test_learn_dummy(project, tmpdir):
     tmpdir.join('doc2.tsv').write('<http://example.org/key2>\tkey2')
     docdir = annif.corpus.DocumentDirectory(str(tmpdir))
 
-    dummy.learn(docdir, project)
+    dummy.learn(docdir)
 
     result = dummy.suggest(text='this is some text', project=project)
     assert len(result) == 1

--- a/tests/test_backend_fasttext.py
+++ b/tests/test_backend_fasttext.py
@@ -8,12 +8,12 @@ from annif.exception import NotSupportedException
 fasttext = pytest.importorskip("annif.backend.fasttext")
 
 
-def test_fasttext_default_params(datadir, project):
+def test_fasttext_default_params(project):
     fasttext_type = annif.backend.get_backend("fasttext")
     fasttext = fasttext_type(
         backend_id='fasttext',
         config_params={},
-        datadir=str(datadir))
+        project=project)
 
     expected_default_params = {
         'limit': 100,
@@ -28,7 +28,7 @@ def test_fasttext_default_params(datadir, project):
         assert param in actual_params and actual_params[param] == val
 
 
-def test_fasttext_train(datadir, document_corpus, project):
+def test_fasttext_train(document_corpus, project, datadir):
     fasttext_type = annif.backend.get_backend("fasttext")
     fasttext = fasttext_type(
         backend_id='fasttext',
@@ -38,7 +38,7 @@ def test_fasttext_train(datadir, document_corpus, project):
             'lr': 0.25,
             'epoch': 20,
             'loss': 'hs'},
-        datadir=str(datadir))
+        project=project)
 
     fasttext.train(document_corpus, project)
     assert fasttext._model is not None
@@ -56,7 +56,7 @@ def test_fasttext_train_unknown_subject(tmpdir, datadir, project):
             'lr': 0.25,
             'epoch': 20,
             'loss': 'hs'},
-        datadir=str(datadir))
+        project=project)
 
     tmpfile = tmpdir.join('document.tsv')
     tmpfile.write("nonexistent\thttp://example.com/nonexistent\n" +
@@ -69,7 +69,7 @@ def test_fasttext_train_unknown_subject(tmpdir, datadir, project):
     assert datadir.join('fasttext-model').size() > 0
 
 
-def test_fasttext_train_nodocuments(datadir, project, empty_corpus):
+def test_fasttext_train_nodocuments(project, empty_corpus):
     fasttext_type = annif.backend.get_backend("fasttext")
     fasttext = fasttext_type(
         backend_id='fasttext',
@@ -79,14 +79,14 @@ def test_fasttext_train_nodocuments(datadir, project, empty_corpus):
             'lr': 0.25,
             'epoch': 20,
             'loss': 'hs'},
-        datadir=str(datadir))
+        project=project)
 
     with pytest.raises(NotSupportedException) as excinfo:
         fasttext.train(empty_corpus, project)
     assert 'training backend fasttext with no documents' in str(excinfo.value)
 
 
-def test_fasttext_suggest(datadir, project):
+def test_fasttext_suggest(project):
     fasttext_type = annif.backend.get_backend("fasttext")
     fasttext = fasttext_type(
         backend_id='fasttext',
@@ -97,7 +97,7 @@ def test_fasttext_suggest(datadir, project):
             'lr': 0.25,
             'epoch': 20,
             'loss': 'hs'},
-        datadir=str(datadir))
+        project=project)
 
     results = fasttext.suggest("""Arkeologiaa sanotaan joskus myös
         muinaistutkimukseksi tai muinaistieteeksi. Se on humanistinen tiede

--- a/tests/test_backend_fasttext.py
+++ b/tests/test_backend_fasttext.py
@@ -104,7 +104,7 @@ def test_fasttext_suggest(project):
         tai oikeammin joukko tieteitä, jotka tutkivat ihmisen menneisyyttä.
         Tutkimusta tehdään analysoimalla muinaisjäännöksiä eli niitä jälkiä,
         joita ihmisten toiminta on jättänyt maaperään tai vesistöjen
-        pohjaan.""", project)
+        pohjaan.""")
 
     assert len(results) > 0
     assert 'http://www.yso.fi/onto/yso/p1265' in [

--- a/tests/test_backend_fasttext.py
+++ b/tests/test_backend_fasttext.py
@@ -40,7 +40,7 @@ def test_fasttext_train(document_corpus, project, datadir):
             'loss': 'hs'},
         project=project)
 
-    fasttext.train(document_corpus, project)
+    fasttext.train(document_corpus)
     assert fasttext._model is not None
     assert datadir.join('fasttext-model').exists()
     assert datadir.join('fasttext-model').size() > 0
@@ -63,7 +63,7 @@ def test_fasttext_train_unknown_subject(tmpdir, datadir, project):
                   "arkeologia\thttp://www.yso.fi/onto/yso/p1265")
     document_corpus = annif.corpus.DocumentFile(str(tmpfile))
 
-    fasttext.train(document_corpus, project)
+    fasttext.train(document_corpus)
     assert fasttext._model is not None
     assert datadir.join('fasttext-model').exists()
     assert datadir.join('fasttext-model').size() > 0
@@ -82,7 +82,7 @@ def test_fasttext_train_nodocuments(project, empty_corpus):
         project=project)
 
     with pytest.raises(NotSupportedException) as excinfo:
-        fasttext.train(empty_corpus, project)
+        fasttext.train(empty_corpus)
     assert 'training backend fasttext with no documents' in str(excinfo.value)
 
 

--- a/tests/test_backend_http.py
+++ b/tests/test_backend_http.py
@@ -5,7 +5,7 @@ import unittest.mock
 import annif.backend.http
 
 
-def test_http_suggest(app, project):
+def test_http_suggest(project):
     with unittest.mock.patch('requests.post') as mock_request:
         # create a mock response whose .json() method returns the list that we
         # define here
@@ -20,7 +20,7 @@ def test_http_suggest(app, project):
             config_params={
                 'endpoint': 'http://api.example.org/analyze',
                 'project': 'dummy'},
-            datadir=app.config['DATADIR'])
+            project=project)
         result = http.suggest('this is some text', project=project)
         assert len(result) == 1
         assert result[0].uri == 'http://example.org/http'
@@ -28,7 +28,7 @@ def test_http_suggest(app, project):
         assert result[0].score == 1.0
 
 
-def test_http_suggest_with_results(app, project):
+def test_http_suggest_with_results(project):
     with unittest.mock.patch('requests.post') as mock_request:
         # create a mock response whose .json() method returns the list that we
         # define here
@@ -43,7 +43,7 @@ def test_http_suggest_with_results(app, project):
             config_params={
                 'endpoint': 'http://api.example.org/dummy/analyze',
             },
-            datadir=app.config['DATADIR'])
+            project=project)
         result = http.suggest('this is some text', project=project)
         assert len(result) == 1
         assert result[0].uri == 'http://example.org/http'
@@ -51,7 +51,7 @@ def test_http_suggest_with_results(app, project):
         assert result[0].score == 1.0
 
 
-def test_http_suggest_zero_score(app, project):
+def test_http_suggest_zero_score(project):
     with unittest.mock.patch('requests.post') as mock_request:
         # create a mock response whose .json() method returns the list that we
         # define here
@@ -66,12 +66,12 @@ def test_http_suggest_zero_score(app, project):
             config_params={
                 'endpoint': 'http://api.example.org/analyze',
                 'project': 'dummy'},
-            datadir=app.config['DATADIR'])
+            project=project)
         result = http.suggest('this is some text', project=project)
         assert len(result) == 0
 
 
-def test_http_suggest_error(app, project):
+def test_http_suggest_error(project):
     with unittest.mock.patch('requests.post') as mock_request:
         mock_request.side_effect = requests.exceptions.RequestException(
             'failed')
@@ -82,12 +82,12 @@ def test_http_suggest_error(app, project):
             config_params={
                 'endpoint': 'http://api.example.org/analyze',
                 'project': 'dummy'},
-            datadir=app.config['DATADIR'])
+            project=project)
         result = http.suggest('this is some text', project=project)
         assert len(result) == 0
 
 
-def test_http_suggest_json_fails(app, project):
+def test_http_suggest_json_fails(project):
     with unittest.mock.patch('requests.post') as mock_request:
         # create a mock response whose .json() method returns the list that we
         # define here
@@ -101,12 +101,12 @@ def test_http_suggest_json_fails(app, project):
             config_params={
                 'endpoint': 'http://api.example.org/analyze',
                 'project': 'dummy'},
-            datadir=app.config['DATADIR'])
+            project=project)
         result = http.suggest('this is some text', project=project)
         assert len(result) == 0
 
 
-def test_http_suggest_unexpected_json(app, project):
+def test_http_suggest_unexpected_json(project):
     with unittest.mock.patch('requests.post') as mock_request:
         # create a mock response whose .json() method returns the list that we
         # define here
@@ -120,6 +120,6 @@ def test_http_suggest_unexpected_json(app, project):
             config_params={
                 'endpoint': 'http://api.example.org/analyze',
                 'project': 'dummy'},
-            datadir=app.config['DATADIR'])
+            project=project)
         result = http.suggest('this is some text', project=project)
         assert len(result) == 0

--- a/tests/test_backend_http.py
+++ b/tests/test_backend_http.py
@@ -21,7 +21,7 @@ def test_http_suggest(project):
                 'endpoint': 'http://api.example.org/analyze',
                 'project': 'dummy'},
             project=project)
-        result = http.suggest('this is some text', project=project)
+        result = http.suggest('this is some text')
         assert len(result) == 1
         assert result[0].uri == 'http://example.org/http'
         assert result[0].label == 'http'
@@ -44,7 +44,7 @@ def test_http_suggest_with_results(project):
                 'endpoint': 'http://api.example.org/dummy/analyze',
             },
             project=project)
-        result = http.suggest('this is some text', project=project)
+        result = http.suggest('this is some text')
         assert len(result) == 1
         assert result[0].uri == 'http://example.org/http'
         assert result[0].label == 'http'
@@ -67,7 +67,7 @@ def test_http_suggest_zero_score(project):
                 'endpoint': 'http://api.example.org/analyze',
                 'project': 'dummy'},
             project=project)
-        result = http.suggest('this is some text', project=project)
+        result = http.suggest('this is some text')
         assert len(result) == 0
 
 
@@ -83,7 +83,7 @@ def test_http_suggest_error(project):
                 'endpoint': 'http://api.example.org/analyze',
                 'project': 'dummy'},
             project=project)
-        result = http.suggest('this is some text', project=project)
+        result = http.suggest('this is some text')
         assert len(result) == 0
 
 
@@ -102,7 +102,7 @@ def test_http_suggest_json_fails(project):
                 'endpoint': 'http://api.example.org/analyze',
                 'project': 'dummy'},
             project=project)
-        result = http.suggest('this is some text', project=project)
+        result = http.suggest('this is some text')
         assert len(result) == 0
 
 
@@ -121,5 +121,5 @@ def test_http_suggest_unexpected_json(project):
                 'endpoint': 'http://api.example.org/analyze',
                 'project': 'dummy'},
             project=project)
-        result = http.suggest('this is some text', project=project)
+        result = http.suggest('this is some text')
         assert len(result) == 0

--- a/tests/test_backend_maui.py
+++ b/tests/test_backend_maui.py
@@ -156,7 +156,7 @@ def test_maui_suggest(maui, project):
                                     'label': 'maui',
                                     'probability': 1.0}]})
 
-    result = maui.suggest('this is some text', project=project)
+    result = maui.suggest('this is some text')
     assert len(result) == 1
     assert result[0].uri == 'http://example.org/maui'
     assert result[0].label == 'maui'
@@ -173,7 +173,7 @@ def test_maui_suggest_zero_score(maui, project):
                                     'label': 'maui',
                                     'probability': 0.0}]})
 
-    result = maui.suggest('this is some text', project=project)
+    result = maui.suggest('this is some text')
     assert len(result) == 0
     assert len(responses.calls) == 1
 
@@ -183,7 +183,7 @@ def test_maui_suggest_error(maui, project):
         mock_request.side_effect = requests.exceptions.RequestException(
             'failed')
 
-        result = maui.suggest('this is some text', project=project)
+        result = maui.suggest('this is some text')
         assert len(result) == 0
 
 
@@ -194,7 +194,7 @@ def test_maui_suggest_json_fails(maui, project):
         mock_response.json.side_effect = ValueError("JSON decode failed")
         mock_request.return_value = mock_response
 
-        result = maui.suggest('this is some text', project=project)
+        result = maui.suggest('this is some text')
         assert len(result) == 0
 
 
@@ -204,6 +204,6 @@ def test_maui_suggest_unexpected_json(maui, project):
                   'http://api.example.org/mauiservice/dummy/suggest',
                   json=["spanish inquisition"])
 
-    result = maui.suggest('this is some text', project=project)
+    result = maui.suggest('this is some text')
     assert len(result) == 0
     assert len(responses.calls) == 1

--- a/tests/test_backend_maui.py
+++ b/tests/test_backend_maui.py
@@ -11,7 +11,7 @@ from annif.exception import OperationFailedException
 
 
 @pytest.fixture
-def maui(project):
+def maui(app_project):
     maui_type = annif.backend.get_backend("maui")
     maui = maui_type(
         backend_id='maui',
@@ -19,7 +19,7 @@ def maui(project):
             'endpoint': 'http://api.example.org/mauiservice/',
             'tagger': 'dummy',
             'language': 'en'},
-        project=project)
+        project=app_project)
     return maui
 
 
@@ -33,7 +33,7 @@ def test_maui_train_missing_endpoint(document_corpus, project):
         project=project)
 
     with pytest.raises(ConfigurationException):
-        maui.train(document_corpus, project)
+        maui.train(document_corpus)
 
 
 def test_maui_train_missing_tagger(document_corpus, project):
@@ -46,7 +46,7 @@ def test_maui_train_missing_tagger(document_corpus, project):
         project=project)
 
     with pytest.raises(ConfigurationException):
-        maui.train(document_corpus, project)
+        maui.train(document_corpus)
 
 
 @responses.activate
@@ -82,13 +82,13 @@ def test_maui_initialize_tagger_create_failed(maui):
 
 
 @responses.activate
-def test_maui_upload_vocabulary_failed(maui, app_project):
+def test_maui_upload_vocabulary_failed(maui):
     responses.add(responses.PUT,
                   'http://api.example.org/mauiservice/dummy/vocab',
                   body=requests.exceptions.RequestException())
 
     with pytest.raises(OperationFailedException):
-        maui._upload_vocabulary(app_project)
+        maui._upload_vocabulary()
 
 
 @responses.activate
@@ -114,7 +114,7 @@ def test_maui_wait_for_train_failed(maui):
 
 def test_maui_train_nodocuments(maui, project, empty_corpus):
     with pytest.raises(NotSupportedException) as excinfo:
-        maui.train(empty_corpus, project)
+        maui.train(empty_corpus)
     assert 'training backend maui with no documents' in str(excinfo.value)
 
 
@@ -144,7 +144,7 @@ def test_maui_train(maui, document_corpus, app_project):
                   status=200,
                   json={"completed": True})
 
-    maui.train(document_corpus, app_project)
+    maui.train(document_corpus)
 
 
 @responses.activate

--- a/tests/test_backend_maui.py
+++ b/tests/test_backend_maui.py
@@ -11,7 +11,7 @@ from annif.exception import OperationFailedException
 
 
 @pytest.fixture
-def maui(app):
+def maui(project):
     maui_type = annif.backend.get_backend("maui")
     maui = maui_type(
         backend_id='maui',
@@ -19,31 +19,31 @@ def maui(app):
             'endpoint': 'http://api.example.org/mauiservice/',
             'tagger': 'dummy',
             'language': 'en'},
-        datadir=app.config['DATADIR'])
+        project=project)
     return maui
 
 
-def test_maui_train_missing_endpoint(app, document_corpus, project):
+def test_maui_train_missing_endpoint(document_corpus, project):
     maui_type = annif.backend.get_backend("maui")
     maui = maui_type(
         backend_id='maui',
         config_params={
             'tagger': 'dummy',
             'language': 'en'},
-        datadir=app.config['DATADIR'])
+        project=project)
 
     with pytest.raises(ConfigurationException):
         maui.train(document_corpus, project)
 
 
-def test_maui_train_missing_tagger(app, document_corpus, project):
+def test_maui_train_missing_tagger(document_corpus, project):
     maui_type = annif.backend.get_backend("maui")
     maui = maui_type(
         backend_id='maui',
         config_params={
             'endpoint': 'http://api.example.org/mauiservice/',
             'language': 'en'},
-        datadir=app.config['DATADIR'])
+        project=project)
 
     with pytest.raises(ConfigurationException):
         maui.train(document_corpus, project)

--- a/tests/test_backend_nn_ensemble.py
+++ b/tests/test_backend_nn_ensemble.py
@@ -19,7 +19,7 @@ def test_nn_ensemble_suggest_no_model(project):
         project=project)
 
     with pytest.raises(NotInitializedException):
-        results = nn_ensemble.suggest("example text", project)
+        results = nn_ensemble.suggest("example text")
 
 
 def test_nn_ensemble_train_and_learn(app, tmpdir):
@@ -85,7 +85,7 @@ def test_nn_ensemble_suggest(app, app_project):
             tiede tai oikeammin joukko tieteitä, jotka tutkivat ihmisen
             menneisyyttä. Tutkimusta tehdään analysoimalla muinaisjäännöksiä
             eli niitä jälkiä, joita ihmisten toiminta on jättänyt maaperään
-            tai vesistöjen pohjaan.""", app_project)
+            tai vesistöjen pohjaan.""")
 
     assert nn_ensemble._model is not None
     assert len(results) > 0

--- a/tests/test_backend_nn_ensemble.py
+++ b/tests/test_backend_nn_ensemble.py
@@ -2,6 +2,7 @@
 
 import time
 import pytest
+import py.path
 import annif.backend
 import annif.corpus
 import annif.project
@@ -21,7 +22,8 @@ def test_nn_ensemble_suggest_no_model(project):
         results = nn_ensemble.suggest("example text", project)
 
 
-def test_nn_ensemble_train_and_learn(app, datadir, tmpdir, project):
+def test_nn_ensemble_train_and_learn(app, tmpdir):
+    project = annif.project.get_project('dummy-en')
     nn_ensemble_type = annif.backend.get_backend("nn_ensemble")
     nn_ensemble = nn_ensemble_type(
         backend_id='nn_ensemble',
@@ -33,10 +35,11 @@ def test_nn_ensemble_train_and_learn(app, datadir, tmpdir, project):
                   "another\thttp://example.org/dummy\n" +
                   "none\thttp://example.org/none")
     document_corpus = annif.corpus.DocumentFile(str(tmpfile))
-    project = annif.project.get_project('dummy-en')
 
     with app.app_context():
-        nn_ensemble.train(document_corpus, project)
+        nn_ensemble.train(document_corpus)
+
+    datadir = py.path.local(project.datadir)
     assert datadir.join('nn-model.h5').exists()
     assert datadir.join('nn-model.h5').size() > 0
 
@@ -53,12 +56,12 @@ def test_nn_ensemble_train_and_learn(app, datadir, tmpdir, project):
     assert modelfile.size() != old_size or modelfile.mtime() != old_mtime
 
 
-def test_nn_ensemble_initialize(app, project):
+def test_nn_ensemble_initialize(app, app_project):
     nn_ensemble_type = annif.backend.get_backend("nn_ensemble")
     nn_ensemble = nn_ensemble_type(
         backend_id='nn_ensemble',
         config_params={'sources': 'dummy-en'},
-        project=project)
+        project=app_project)
 
     assert nn_ensemble._model is None
     with app.app_context():
@@ -69,12 +72,12 @@ def test_nn_ensemble_initialize(app, project):
         nn_ensemble.initialize()
 
 
-def test_nn_ensemble_suggest(app, project):
+def test_nn_ensemble_suggest(app, app_project):
     nn_ensemble_type = annif.backend.get_backend("nn_ensemble")
     nn_ensemble = nn_ensemble_type(
         backend_id='nn_ensemble',
         config_params={'sources': 'dummy-en'},
-        project=project)
+        project=app_project)
 
     with app.app_context():
         results = nn_ensemble.suggest("""Arkeologiaa sanotaan joskus myös
@@ -82,7 +85,7 @@ def test_nn_ensemble_suggest(app, project):
             tiede tai oikeammin joukko tieteitä, jotka tutkivat ihmisen
             menneisyyttä. Tutkimusta tehdään analysoimalla muinaisjäännöksiä
             eli niitä jälkiä, joita ihmisten toiminta on jättänyt maaperään
-            tai vesistöjen pohjaan.""", project)
+            tai vesistöjen pohjaan.""", app_project)
 
     assert nn_ensemble._model is not None
     assert len(results) > 0

--- a/tests/test_backend_nn_ensemble.py
+++ b/tests/test_backend_nn_ensemble.py
@@ -10,23 +10,23 @@ from annif.exception import NotInitializedException
 pytest.importorskip("annif.backend.nn_ensemble")
 
 
-def test_nn_ensemble_suggest_no_model(datadir, project):
+def test_nn_ensemble_suggest_no_model(project):
     nn_ensemble_type = annif.backend.get_backend('nn_ensemble')
     nn_ensemble = nn_ensemble_type(
         backend_id='nn_ensemble',
         config_params={'sources': 'dummy-en'},
-        datadir=str(datadir))
+        project=project)
 
     with pytest.raises(NotInitializedException):
         results = nn_ensemble.suggest("example text", project)
 
 
-def test_nn_ensemble_train_and_learn(app, datadir, tmpdir):
+def test_nn_ensemble_train_and_learn(app, datadir, tmpdir, project):
     nn_ensemble_type = annif.backend.get_backend("nn_ensemble")
     nn_ensemble = nn_ensemble_type(
         backend_id='nn_ensemble',
         config_params={'sources': 'dummy-en'},
-        datadir=str(datadir))
+        project=project)
 
     tmpfile = tmpdir.join('document.tsv')
     tmpfile.write("dummy\thttp://example.org/dummy\n" +
@@ -53,12 +53,12 @@ def test_nn_ensemble_train_and_learn(app, datadir, tmpdir):
     assert modelfile.size() != old_size or modelfile.mtime() != old_mtime
 
 
-def test_nn_ensemble_initialize(app, datadir):
+def test_nn_ensemble_initialize(app, project):
     nn_ensemble_type = annif.backend.get_backend("nn_ensemble")
     nn_ensemble = nn_ensemble_type(
         backend_id='nn_ensemble',
         config_params={'sources': 'dummy-en'},
-        datadir=str(datadir))
+        project=project)
 
     assert nn_ensemble._model is None
     with app.app_context():
@@ -69,21 +69,20 @@ def test_nn_ensemble_initialize(app, datadir):
         nn_ensemble.initialize()
 
 
-def test_nn_ensemble_suggest(app, datadir):
+def test_nn_ensemble_suggest(app, project):
     nn_ensemble_type = annif.backend.get_backend("nn_ensemble")
     nn_ensemble = nn_ensemble_type(
         backend_id='nn_ensemble',
         config_params={'sources': 'dummy-en'},
-        datadir=str(datadir))
+        project=project)
 
-    project = annif.project.get_project('dummy-en')
-
-    results = nn_ensemble.suggest("""Arkeologiaa sanotaan joskus myös
-        muinaistutkimukseksi tai muinaistieteeksi. Se on humanistinen tiede
-        tai oikeammin joukko tieteitä, jotka tutkivat ihmisen menneisyyttä.
-        Tutkimusta tehdään analysoimalla muinaisjäännöksiä eli niitä jälkiä,
-        joita ihmisten toiminta on jättänyt maaperään tai vesistöjen
-        pohjaan.""", project)
+    with app.app_context():
+        results = nn_ensemble.suggest("""Arkeologiaa sanotaan joskus myös
+            muinaistutkimukseksi tai muinaistieteeksi. Se on humanistinen
+            tiede tai oikeammin joukko tieteitä, jotka tutkivat ihmisen
+            menneisyyttä. Tutkimusta tehdään analysoimalla muinaisjäännöksiä
+            eli niitä jälkiä, joita ihmisten toiminta on jättänyt maaperään
+            tai vesistöjen pohjaan.""", project)
 
     assert nn_ensemble._model is not None
     assert len(results) > 0

--- a/tests/test_backend_nn_ensemble.py
+++ b/tests/test_backend_nn_ensemble.py
@@ -51,7 +51,7 @@ def test_nn_ensemble_train_and_learn(app, tmpdir):
 
     time.sleep(0.1)  # make sure the timestamp has a chance to increase
 
-    nn_ensemble.learn(document_corpus, project)
+    nn_ensemble.learn(document_corpus)
 
     assert modelfile.size() != old_size or modelfile.mtime() != old_mtime
 

--- a/tests/test_backend_pav.py
+++ b/tests/test_backend_pav.py
@@ -35,7 +35,7 @@ def test_pav_train(app, datadir, tmpdir, project):
     document_corpus = annif.corpus.DocumentFile(str(tmpfile))
 
     with app.app_context():
-        pav.train(document_corpus, project)
+        pav.train(document_corpus)
     assert datadir.join('pav-model-dummy-fi').exists()
     assert datadir.join('pav-model-dummy-fi').size() > 0
 
@@ -48,7 +48,7 @@ def test_pav_train_nodocuments(project, empty_corpus):
         project=project)
 
     with pytest.raises(NotSupportedException) as excinfo:
-        pav.train(empty_corpus, project)
+        pav.train(empty_corpus)
     assert 'training backend pav with no documents' in str(excinfo.value)
 
 

--- a/tests/test_backend_pav.py
+++ b/tests/test_backend_pav.py
@@ -80,7 +80,7 @@ def test_pav_suggest(app, project):
         tai oikeammin joukko tieteitä, jotka tutkivat ihmisen menneisyyttä.
         Tutkimusta tehdään analysoimalla muinaisjäännöksiä eli niitä jälkiä,
         joita ihmisten toiminta on jättänyt maaperään tai vesistöjen
-        pohjaan.""", project)
+        pohjaan.""")
 
     assert len(pav._models['dummy-fi']) == 1
     assert len(results) > 0

--- a/tests/test_backend_pav.py
+++ b/tests/test_backend_pav.py
@@ -6,12 +6,12 @@ import annif.corpus
 from annif.exception import NotSupportedException
 
 
-def test_pav_default_params(datadir, document_corpus, project):
+def test_pav_default_params(document_corpus, project):
     pav_type = annif.backend.get_backend("pav")
     pav = pav_type(
         backend_id='pav',
         config_params={},
-        datadir=str(datadir))
+        project=project)
 
     expected_default_params = {
         'min-docs': 10,
@@ -26,7 +26,7 @@ def test_pav_train(app, datadir, tmpdir, project):
     pav = pav_type(
         backend_id='pav',
         config_params={'limit': 50, 'min-docs': 2, 'sources': 'dummy-fi'},
-        datadir=str(datadir))
+        project=project)
 
     tmpfile = tmpdir.join('document.tsv')
     tmpfile.write("dummy\thttp://example.org/dummy\n" +
@@ -40,24 +40,24 @@ def test_pav_train(app, datadir, tmpdir, project):
     assert datadir.join('pav-model-dummy-fi').size() > 0
 
 
-def test_pav_train_nodocuments(datadir, project, empty_corpus):
+def test_pav_train_nodocuments(project, empty_corpus):
     pav_type = annif.backend.get_backend("pav")
     pav = pav_type(
         backend_id='pav',
         config_params={'limit': 50, 'min-docs': 2, 'sources': 'dummy-fi'},
-        datadir=str(datadir))
+        project=project)
 
     with pytest.raises(NotSupportedException) as excinfo:
         pav.train(empty_corpus, project)
     assert 'training backend pav with no documents' in str(excinfo.value)
 
 
-def test_pav_initialize(app, datadir):
+def test_pav_initialize(app, project):
     pav_type = annif.backend.get_backend("pav")
     pav = pav_type(
         backend_id='pav',
         config_params={'limit': 50, 'min-docs': 2, 'sources': 'dummy-fi'},
-        datadir=str(datadir))
+        project=project)
 
     assert pav._models is None
     with app.app_context():
@@ -68,12 +68,12 @@ def test_pav_initialize(app, datadir):
         pav.initialize()
 
 
-def test_pav_suggest(app, datadir, project):
+def test_pav_suggest(app, project):
     pav_type = annif.backend.get_backend("pav")
     pav = pav_type(
         backend_id='pav',
         config_params={'limit': 50, 'min-docs': 2, 'sources': 'dummy-fi'},
-        datadir=str(datadir))
+        project=project)
 
     results = pav.suggest("""Arkeologiaa sanotaan joskus myös
         muinaistutkimukseksi tai muinaistieteeksi. Se on humanistinen tiede

--- a/tests/test_backend_tfidf.py
+++ b/tests/test_backend_tfidf.py
@@ -48,7 +48,7 @@ def test_tfidf_suggest(project):
         tai oikeammin joukko tieteitä, jotka tutkivat ihmisen menneisyyttä.
         Tutkimusta tehdään analysoimalla muinaisjäännöksiä eli niitä jälkiä,
         joita ihmisten toiminta on jättänyt maaperään tai vesistöjen
-        pohjaan.""", project)
+        pohjaan.""")
 
     assert len(results) == 10
     assert 'http://www.yso.fi/onto/yso/p1265' in [
@@ -63,6 +63,6 @@ def test_tfidf_suggest_unknown(project):
         config_params={'limit': 10},
         project=project)
 
-    results = tfidf.suggest("abcdefghijk", project)  # unknown word
+    results = tfidf.suggest("abcdefghijk")  # unknown word
 
     assert len(results) == 0

--- a/tests/test_backend_tfidf.py
+++ b/tests/test_backend_tfidf.py
@@ -30,7 +30,7 @@ def test_tfidf_train(datadir, document_corpus, project):
         config_params={'limit': 10},
         project=project)
 
-    tfidf.train(document_corpus, project)
+    tfidf.train(document_corpus)
     assert len(tfidf._index) > 0
     assert datadir.join('tfidf-index').exists()
     assert datadir.join('tfidf-index').size() > 0

--- a/tests/test_backend_tfidf.py
+++ b/tests/test_backend_tfidf.py
@@ -8,20 +8,12 @@ import pytest
 import unittest.mock
 
 
-@pytest.fixture(scope='module')
-def project(document_corpus, subject_index):
-    proj = unittest.mock.Mock()
-    proj.analyzer = annif.analyzer.get_analyzer('snowball(finnish)')
-    proj.subjects = subject_index
-    return proj
-
-
-def test_tfidf_default_params(datadir, project):
+def test_tfidf_default_params(project):
     tfidf_type = annif.backend.get_backend("tfidf")
     tfidf = tfidf_type(
         backend_id='tfidf',
         config_params={},
-        datadir=str(datadir))
+        project=project)
 
     expected_default_params = {
         'limit': 100  # From AnnifBackend class
@@ -36,7 +28,7 @@ def test_tfidf_train(datadir, document_corpus, project):
     tfidf = tfidf_type(
         backend_id='tfidf',
         config_params={'limit': 10},
-        datadir=str(datadir))
+        project=project)
 
     tfidf.train(document_corpus, project)
     assert len(tfidf._index) > 0
@@ -44,12 +36,12 @@ def test_tfidf_train(datadir, document_corpus, project):
     assert datadir.join('tfidf-index').size() > 0
 
 
-def test_tfidf_suggest(datadir, project):
+def test_tfidf_suggest(project):
     tfidf_type = annif.backend.get_backend("tfidf")
     tfidf = tfidf_type(
         backend_id='tfidf',
         config_params={'limit': 10},
-        datadir=str(datadir))
+        project=project)
 
     results = tfidf.suggest("""Arkeologiaa sanotaan joskus myös
         muinaistutkimukseksi tai muinaistieteeksi. Se on humanistinen tiede
@@ -64,12 +56,12 @@ def test_tfidf_suggest(datadir, project):
     assert 'arkeologia' in [result.label for result in results]
 
 
-def test_tfidf_suggest_unknown(datadir, project):
+def test_tfidf_suggest_unknown(project):
     tfidf_type = annif.backend.get_backend("tfidf")
     tfidf = tfidf_type(
         backend_id='tfidf',
         config_params={'limit': 10},
-        datadir=str(datadir))
+        project=project)
 
     results = tfidf.suggest("abcdefghijk", project)  # unknown word
 

--- a/tests/test_backend_vw_ensemble.py
+++ b/tests/test_backend_vw_ensemble.py
@@ -11,12 +11,12 @@ from annif.exception import NotInitializedException
 pytest.importorskip("annif.backend.vw_ensemble")
 
 
-def test_vw_ensemble_default_params(datadir, project):
+def test_vw_ensemble_default_params(project):
     vw_type = annif.backend.get_backend("vw_ensemble")
     vw = vw_type(
         backend_id='vw_ensemble',
         config_params={},
-        datadir=str(datadir))
+        project=project)
 
     expected_default_params = {
         'limit': 100,
@@ -28,23 +28,23 @@ def test_vw_ensemble_default_params(datadir, project):
         assert param in actual_params and actual_params[param] == val
 
 
-def test_vw_ensemble_suggest_no_model(datadir, project):
+def test_vw_ensemble_suggest_no_model(project):
     vw_ensemble_type = annif.backend.get_backend('vw_ensemble')
     vw_ensemble = vw_ensemble_type(
         backend_id='vw_ensemble',
         config_params={'sources': 'dummy-en'},
-        datadir=str(datadir))
+        project=project)
 
     with pytest.raises(NotInitializedException):
         results = vw_ensemble.suggest("example text", project)
 
 
-def test_vw_ensemble_train_and_learn(app, datadir, tmpdir):
+def test_vw_ensemble_train_and_learn(app, datadir, tmpdir, project):
     vw_ensemble_type = annif.backend.get_backend("vw_ensemble")
     vw_ensemble = vw_ensemble_type(
         backend_id='vw_ensemble',
         config_params={'sources': 'dummy-en'},
-        datadir=str(datadir))
+        project=project)
 
     tmpfile = tmpdir.join('document.tsv')
     tmpfile.write("dummy\thttp://example.org/dummy\n" +
@@ -80,12 +80,12 @@ def test_vw_ensemble_train_and_learn(app, datadir, tmpdir):
         assert sum(json.load(freqf).values()) != old_totalfreq
 
 
-def test_vw_ensemble_initialize(app, datadir):
+def test_vw_ensemble_initialize(app, project):
     vw_ensemble_type = annif.backend.get_backend("vw_ensemble")
     vw_ensemble = vw_ensemble_type(
         backend_id='vw_ensemble',
         config_params={'sources': 'dummy-en'},
-        datadir=str(datadir))
+        project=project)
 
     assert vw_ensemble._model is None
     with app.app_context():
@@ -96,62 +96,60 @@ def test_vw_ensemble_initialize(app, datadir):
         vw_ensemble.initialize()
 
 
-def test_vw_ensemble_suggest(app, datadir):
+def test_vw_ensemble_suggest(app, project):
     vw_ensemble_type = annif.backend.get_backend("vw_ensemble")
     vw_ensemble = vw_ensemble_type(
         backend_id='vw_ensemble',
         config_params={'sources': 'dummy-en'},
-        datadir=str(datadir))
+        project=project)
 
-    project = annif.project.get_project('dummy-en')
-
-    results = vw_ensemble.suggest("""Arkeologiaa sanotaan joskus myös
-        muinaistutkimukseksi tai muinaistieteeksi. Se on humanistinen tiede
-        tai oikeammin joukko tieteitä, jotka tutkivat ihmisen menneisyyttä.
-        Tutkimusta tehdään analysoimalla muinaisjäännöksiä eli niitä jälkiä,
-        joita ihmisten toiminta on jättänyt maaperään tai vesistöjen
-        pohjaan.""", project)
+    with app.app_context():
+        results = vw_ensemble.suggest("""Arkeologiaa sanotaan joskus myös
+            muinaistutkimukseksi tai muinaistieteeksi. Se on humanistinen
+            tiede tai oikeammin joukko tieteitä, jotka tutkivat ihmisen
+            menneisyyttä. Tutkimusta tehdään analysoimalla muinaisjäännöksiä
+            eli niitä jälkiä, joita ihmisten toiminta on jättänyt maaperään
+            tai vesistöjen pohjaan.""", project)
 
     assert vw_ensemble._model is not None
     assert len(results) > 0
 
 
-def test_vw_ensemble_suggest_set_discount_rate(app, datadir):
+def test_vw_ensemble_suggest_set_discount_rate(app, project):
     vw_ensemble_type = annif.backend.get_backend("vw_ensemble")
     vw_ensemble = vw_ensemble_type(
         backend_id='vw_ensemble',
         config_params={'sources': 'dummy-en', 'discount_rate': '0.02'},
-        datadir=str(datadir))
+        project=project)
 
-    project = annif.project.get_project('dummy-en')
-
-    results = vw_ensemble.suggest("""Arkeologiaa sanotaan joskus myös
-        muinaistutkimukseksi tai muinaistieteeksi. Se on humanistinen tiede
-        tai oikeammin joukko tieteitä, jotka tutkivat ihmisen menneisyyttä.
-        Tutkimusta tehdään analysoimalla muinaisjäännöksiä eli niitä jälkiä,
-        joita ihmisten toiminta on jättänyt maaperään tai vesistöjen
-        pohjaan.""", project)
+    with app.app_context():
+        results = vw_ensemble.suggest("""Arkeologiaa sanotaan joskus myös
+            muinaistutkimukseksi tai muinaistieteeksi. Se on humanistinen
+            tiede tai oikeammin joukko tieteitä, jotka tutkivat ihmisen
+            menneisyyttä. Tutkimusta tehdään analysoimalla muinaisjäännöksiä
+            eli niitä jälkiä, joita ihmisten toiminta on jättänyt maaperään
+            tai vesistöjen pohjaan.""", project)
 
     assert len(results) > 0
 
 
-def test_vw_ensemble_format_example(datadir):
+def test_vw_ensemble_format_example(project):
     vw_ensemble_type = annif.backend.get_backend("vw_ensemble")
     vw_ensemble = vw_ensemble_type(
         backend_id='vw_ensemble',
         config_params={'sources': 'dummy-en'},
-        datadir=str(datadir))
+        project=project)
 
     ex = vw_ensemble._format_example(0, [0.5])
     assert ex == ' |0 dummy-en:0.500000'
 
 
-def test_vw_ensemble_format_example_avoid_sci_notation(datadir):
+def test_vw_ensemble_format_example_avoid_sci_notation(project):
     vw_ensemble_type = annif.backend.get_backend("vw_ensemble")
     vw_ensemble = vw_ensemble_type(
         backend_id='vw_ensemble',
         config_params={'sources': 'dummy-en'},
-        datadir=str(datadir))
+        project=project)
 
     ex = vw_ensemble._format_example(0, [7.24e-05])
     assert ex == ' |0 dummy-en:0.000072'

--- a/tests/test_backend_vw_ensemble.py
+++ b/tests/test_backend_vw_ensemble.py
@@ -75,7 +75,7 @@ def test_vw_ensemble_train_and_learn(app, tmpdir):
 
     time.sleep(0.1)  # make sure the timestamp has a chance to increase
 
-    vw_ensemble.learn(document_corpus, project)
+    vw_ensemble.learn(document_corpus)
 
     assert modelfile.size() != old_size or modelfile.mtime() != old_mtime
     with open(str(freqfile)) as freqf:

--- a/tests/test_backend_vw_ensemble.py
+++ b/tests/test_backend_vw_ensemble.py
@@ -37,7 +37,7 @@ def test_vw_ensemble_suggest_no_model(project):
         project=project)
 
     with pytest.raises(NotInitializedException):
-        results = vw_ensemble.suggest("example text", project)
+        results = vw_ensemble.suggest("example text")
 
 
 def test_vw_ensemble_train_and_learn(app, tmpdir):
@@ -111,7 +111,7 @@ def test_vw_ensemble_suggest(app, app_project):
             tiede tai oikeammin joukko tieteitä, jotka tutkivat ihmisen
             menneisyyttä. Tutkimusta tehdään analysoimalla muinaisjäännöksiä
             eli niitä jälkiä, joita ihmisten toiminta on jättänyt maaperään
-            tai vesistöjen pohjaan.""", app_project)
+            tai vesistöjen pohjaan.""")
 
     assert vw_ensemble._model is not None
     assert len(results) > 0
@@ -130,7 +130,7 @@ def test_vw_ensemble_suggest_set_discount_rate(app, app_project):
             tiede tai oikeammin joukko tieteitä, jotka tutkivat ihmisen
             menneisyyttä. Tutkimusta tehdään analysoimalla muinaisjäännöksiä
             eli niitä jälkiä, joita ihmisten toiminta on jättänyt maaperään
-            tai vesistöjen pohjaan.""", app_project)
+            tai vesistöjen pohjaan.""")
 
     assert len(results) > 0
 

--- a/tests/test_backend_vw_multi.py
+++ b/tests/test_backend_vw_multi.py
@@ -44,7 +44,7 @@ def test_vw_multi_suggest_no_model(project):
         project=project)
 
     with pytest.raises(NotInitializedException):
-        results = vw.suggest("example text", project)
+        results = vw.suggest("example text")
 
 
 def test_vw_multi_train_and_learn(datadir, document_corpus, project):
@@ -178,7 +178,7 @@ def test_vw_multi_suggest(project):
         tai oikeammin joukko tieteitä, jotka tutkivat ihmisen menneisyyttä.
         Tutkimusta tehdään analysoimalla muinaisjäännöksiä eli niitä jälkiä,
         joita ihmisten toiminta on jättänyt maaperään tai vesistöjen
-        pohjaan.""", project)
+        pohjaan.""")
 
     assert len(results) > 0
     assert 'http://www.yso.fi/onto/yso/p1265' in [
@@ -193,7 +193,7 @@ def test_vw_multi_suggest_empty(project):
         config_params={'chunksize': 4},
         project=project)
 
-    results = vw.suggest("...", project)
+    results = vw.suggest("...")
 
     assert len(results) == 0
 
@@ -205,7 +205,7 @@ def test_vw_multi_suggest_multiple_passes(project):
         config_params={'chunksize': 4, 'passes': 2},
         project=project)
 
-    results = vw.suggest("...", project)
+    results = vw.suggest("...")
 
     assert len(results) == 0
 
@@ -239,7 +239,7 @@ def test_vw_multi_suggest_ect(project):
         tai oikeammin joukko tieteitä, jotka tutkivat ihmisen menneisyyttä.
         Tutkimusta tehdään analysoimalla muinaisjäännöksiä eli niitä jälkiä,
         joita ihmisten toiminta on jättänyt maaperään tai vesistöjen
-        pohjaan.""", project)
+        pohjaan.""")
 
     assert len(results) > 0
 
@@ -273,7 +273,7 @@ def test_vw_multi_suggest_log_multi(project):
         tai oikeammin joukko tieteitä, jotka tutkivat ihmisen menneisyyttä.
         Tutkimusta tehdään analysoimalla muinaisjäännöksiä eli niitä jälkiä,
         joita ihmisten toiminta on jättänyt maaperään tai vesistöjen
-        pohjaan.""", project)
+        pohjaan.""")
 
     assert len(results) > 0
 
@@ -307,7 +307,7 @@ def test_vw_multi_suggest_multilabel_oaa(project):
         tai oikeammin joukko tieteitä, jotka tutkivat ihmisen menneisyyttä.
         Tutkimusta tehdään analysoimalla muinaisjäännöksiä eli niitä jälkiä,
         joita ihmisten toiminta on jättänyt maaperään tai vesistöjen
-        pohjaan.""", project)
+        pohjaan.""")
 
     # weak assertion, but often multilabel_oaa produces zero hits
     assert len(results) >= 0

--- a/tests/test_backend_vw_multi.py
+++ b/tests/test_backend_vw_multi.py
@@ -57,7 +57,7 @@ def test_vw_multi_train_and_learn(datadir, document_corpus, project):
             'loss_function': 'hinge'},
         project=project)
 
-    vw.train(document_corpus, project)
+    vw.train(document_corpus)
     assert vw._model is not None
     assert datadir.join('vw-model').exists()
     assert datadir.join('vw-model').size() > 0
@@ -83,7 +83,7 @@ def test_vw_multi_train_and_learn_nodocuments(datadir, project, empty_corpus):
             'loss_function': 'hinge'},
         project=project)
 
-    vw.train(empty_corpus, project)
+    vw.train(empty_corpus)
     assert datadir.join('vw-train.txt').exists()
     assert datadir.join('vw-train.txt').size() == 0
 
@@ -108,7 +108,7 @@ def test_vw_multi_train_from_project(app, datadir, document_corpus, project):
         project=project)
 
     with app.app_context():
-        vw.train(document_corpus, project)
+        vw.train(document_corpus)
     assert vw._model is not None
     assert datadir.join('vw-model').exists()
     assert datadir.join('vw-model').size() > 0
@@ -124,7 +124,7 @@ def test_vw_multi_train_multiple_passes(datadir, document_corpus, project):
             'passes': 2},
         project=project)
 
-    vw.train(document_corpus, project)
+    vw.train(document_corpus)
     assert vw._model is not None
     assert datadir.join('vw-model').exists()
     assert datadir.join('vw-model').size() > 0
@@ -141,7 +141,7 @@ def test_vw_multi_train_invalid_algorithm(document_corpus, project):
         project=project)
 
     with pytest.raises(ConfigurationException):
-        vw.train(document_corpus, project)
+        vw.train(document_corpus)
 
 
 def test_vw_multi_train_invalid_loss_function(project, vw_corpus):
@@ -152,7 +152,7 @@ def test_vw_multi_train_invalid_loss_function(project, vw_corpus):
         project=project)
 
     with pytest.raises(ConfigurationException):
-        vw.train(vw_corpus, project)
+        vw.train(vw_corpus)
 
 
 def test_vw_multi_train_invalid_learning_rate(project, vw_corpus):
@@ -163,7 +163,7 @@ def test_vw_multi_train_invalid_learning_rate(project, vw_corpus):
         project=project)
 
     with pytest.raises(ConfigurationException):
-        vw.train(vw_corpus, project)
+        vw.train(vw_corpus)
 
 
 def test_vw_multi_suggest(project):
@@ -220,7 +220,7 @@ def test_vw_multi_train_ect(datadir, document_corpus, project):
             'algorithm': 'ect'},
         project=project)
 
-    vw.train(document_corpus, project)
+    vw.train(document_corpus)
     assert vw._model is not None
     assert datadir.join('vw-model').exists()
     assert datadir.join('vw-model').size() > 0
@@ -254,7 +254,7 @@ def test_vw_multi_train_log_multi(datadir, document_corpus, project):
             'algorithm': 'log_multi'},
         project=project)
 
-    vw.train(document_corpus, project)
+    vw.train(document_corpus)
     assert vw._model is not None
     assert datadir.join('vw-model').exists()
     assert datadir.join('vw-model').size() > 0
@@ -288,7 +288,7 @@ def test_vw_multi_train_multilabel_oaa(datadir, document_corpus, project):
             'algorithm': 'multilabel_oaa'},
         project=project)
 
-    vw.train(document_corpus, project)
+    vw.train(document_corpus)
     assert vw._model is not None
     assert datadir.join('vw-model').exists()
     assert datadir.join('vw-model').size() > 0

--- a/tests/test_backend_vw_multi.py
+++ b/tests/test_backend_vw_multi.py
@@ -68,7 +68,7 @@ def test_vw_multi_train_and_learn(datadir, document_corpus, project):
     old_size = modelfile.size()
     old_mtime = modelfile.mtime()
 
-    vw.learn(document_corpus, project)
+    vw.learn(document_corpus)
 
     assert modelfile.size() != old_size or modelfile.mtime() != old_mtime
 
@@ -92,7 +92,7 @@ def test_vw_multi_train_and_learn_nodocuments(datadir, project, empty_corpus):
 
     old_size = modelfile.size()
 
-    vw.learn(empty_corpus, project)
+    vw.learn(empty_corpus)
 
     assert modelfile.size() == old_size
     assert datadir.join('vw-train.txt').size() == 0

--- a/tests/test_backend_vw_multi.py
+++ b/tests/test_backend_vw_multi.py
@@ -18,12 +18,12 @@ def vw_corpus(tmpdir):
     return annif.corpus.DocumentFile(str(tmpfile))
 
 
-def test_vw_multi_default_params(datadir, project):
+def test_vw_multi_default_params(project):
     vw_type = annif.backend.get_backend("vw_multi")
     vw = vw_type(
         backend_id='vw_multi',
         config_params={},
-        datadir=str(datadir))
+        project=project)
 
     expected_default_params = {
         'limit': 100,
@@ -36,12 +36,12 @@ def test_vw_multi_default_params(datadir, project):
         assert param in actual_params and actual_params[param] == val
 
 
-def test_vw_multi_suggest_no_model(datadir, project):
+def test_vw_multi_suggest_no_model(project):
     vw_type = annif.backend.get_backend('vw_multi')
     vw = vw_type(
         backend_id='vw_multi',
         config_params={'chunksize': 4},
-        datadir=str(datadir))
+        project=project)
 
     with pytest.raises(NotInitializedException):
         results = vw.suggest("example text", project)
@@ -55,7 +55,7 @@ def test_vw_multi_train_and_learn(datadir, document_corpus, project):
             'chunksize': 4,
             'learning_rate': 0.5,
             'loss_function': 'hinge'},
-        datadir=str(datadir))
+        project=project)
 
     vw.train(document_corpus, project)
     assert vw._model is not None
@@ -81,7 +81,7 @@ def test_vw_multi_train_and_learn_nodocuments(datadir, project, empty_corpus):
             'chunksize': 4,
             'learning_rate': 0.5,
             'loss_function': 'hinge'},
-        datadir=str(datadir))
+        project=project)
 
     vw.train(empty_corpus, project)
     assert datadir.join('vw-train.txt').exists()
@@ -105,7 +105,7 @@ def test_vw_multi_train_from_project(app, datadir, document_corpus, project):
         config_params={
             'chunksize': 4,
             'inputs': '_text_,dummy-en'},
-        datadir=str(datadir))
+        project=project)
 
     with app.app_context():
         vw.train(document_corpus, project)
@@ -122,7 +122,7 @@ def test_vw_multi_train_multiple_passes(datadir, document_corpus, project):
             'chunksize': 4,
             'learning_rate': 0.5,
             'passes': 2},
-        datadir=str(datadir))
+        project=project)
 
     vw.train(document_corpus, project)
     assert vw._model is not None
@@ -130,7 +130,7 @@ def test_vw_multi_train_multiple_passes(datadir, document_corpus, project):
     assert datadir.join('vw-model').size() > 0
 
 
-def test_vw_multi_train_invalid_algorithm(datadir, document_corpus, project):
+def test_vw_multi_train_invalid_algorithm(document_corpus, project):
     vw_type = annif.backend.get_backend('vw_multi')
     vw = vw_type(
         backend_id='vw_multi',
@@ -138,40 +138,40 @@ def test_vw_multi_train_invalid_algorithm(datadir, document_corpus, project):
             'chunksize': 4,
             'learning_rate': 0.5,
             'algorithm': 'invalid'},
-        datadir=str(datadir))
+        project=project)
 
     with pytest.raises(ConfigurationException):
         vw.train(document_corpus, project)
 
 
-def test_vw_multi_train_invalid_loss_function(datadir, project, vw_corpus):
+def test_vw_multi_train_invalid_loss_function(project, vw_corpus):
     vw_type = annif.backend.get_backend('vw_multi')
     vw = vw_type(
         backend_id='vw_multi',
         config_params={'chunksize': 4, 'loss_function': 'invalid'},
-        datadir=str(datadir))
+        project=project)
 
     with pytest.raises(ConfigurationException):
         vw.train(vw_corpus, project)
 
 
-def test_vw_multi_train_invalid_learning_rate(datadir, project, vw_corpus):
+def test_vw_multi_train_invalid_learning_rate(project, vw_corpus):
     vw_type = annif.backend.get_backend('vw_multi')
     vw = vw_type(
         backend_id='vw_multi',
         config_params={'chunksize': 4, 'learning_rate': 'high'},
-        datadir=str(datadir))
+        project=project)
 
     with pytest.raises(ConfigurationException):
         vw.train(vw_corpus, project)
 
 
-def test_vw_multi_suggest(datadir, project):
+def test_vw_multi_suggest(project):
     vw_type = annif.backend.get_backend('vw_multi')
     vw = vw_type(
         backend_id='vw_multi',
         config_params={'chunksize': 4, 'probabilities': 1},
-        datadir=str(datadir))
+        project=project)
 
     results = vw.suggest("""Arkeologiaa sanotaan joskus myös
         muinaistutkimukseksi tai muinaistieteeksi. Se on humanistinen tiede
@@ -186,24 +186,24 @@ def test_vw_multi_suggest(datadir, project):
     assert 'arkeologia' in [result.label for result in results]
 
 
-def test_vw_multi_suggest_empty(datadir, project):
+def test_vw_multi_suggest_empty(project):
     vw_type = annif.backend.get_backend('vw_multi')
     vw = vw_type(
         backend_id='vw_multi',
         config_params={'chunksize': 4},
-        datadir=str(datadir))
+        project=project)
 
     results = vw.suggest("...", project)
 
     assert len(results) == 0
 
 
-def test_vw_multi_suggest_multiple_passes(datadir, project):
+def test_vw_multi_suggest_multiple_passes(project):
     vw_type = annif.backend.get_backend('vw_multi')
     vw = vw_type(
         backend_id='vw_multi',
         config_params={'chunksize': 4, 'passes': 2},
-        datadir=str(datadir))
+        project=project)
 
     results = vw.suggest("...", project)
 
@@ -218,7 +218,7 @@ def test_vw_multi_train_ect(datadir, document_corpus, project):
             'chunksize': 4,
             'learning_rate': 0.5,
             'algorithm': 'ect'},
-        datadir=str(datadir))
+        project=project)
 
     vw.train(document_corpus, project)
     assert vw._model is not None
@@ -226,13 +226,13 @@ def test_vw_multi_train_ect(datadir, document_corpus, project):
     assert datadir.join('vw-model').size() > 0
 
 
-def test_vw_multi_suggest_ect(datadir, project):
+def test_vw_multi_suggest_ect(project):
     vw_type = annif.backend.get_backend('vw_multi')
     vw = vw_type(
         backend_id='vw_multi',
         config_params={'chunksize': 1,
                        'algorithm': 'ect'},
-        datadir=str(datadir))
+        project=project)
 
     results = vw.suggest("""Arkeologiaa sanotaan joskus myös
         muinaistutkimukseksi tai muinaistieteeksi. Se on humanistinen tiede
@@ -252,7 +252,7 @@ def test_vw_multi_train_log_multi(datadir, document_corpus, project):
             'chunksize': 4,
             'learning_rate': 0.5,
             'algorithm': 'log_multi'},
-        datadir=str(datadir))
+        project=project)
 
     vw.train(document_corpus, project)
     assert vw._model is not None
@@ -260,13 +260,13 @@ def test_vw_multi_train_log_multi(datadir, document_corpus, project):
     assert datadir.join('vw-model').size() > 0
 
 
-def test_vw_multi_suggest_log_multi(datadir, project):
+def test_vw_multi_suggest_log_multi(project):
     vw_type = annif.backend.get_backend('vw_multi')
     vw = vw_type(
         backend_id='vw_multi',
         config_params={'chunksize': 1,
                        'algorithm': 'log_multi'},
-        datadir=str(datadir))
+        project=project)
 
     results = vw.suggest("""Arkeologiaa sanotaan joskus myös
         muinaistutkimukseksi tai muinaistieteeksi. Se on humanistinen tiede
@@ -286,7 +286,7 @@ def test_vw_multi_train_multilabel_oaa(datadir, document_corpus, project):
             'chunksize': 4,
             'learning_rate': 0.5,
             'algorithm': 'multilabel_oaa'},
-        datadir=str(datadir))
+        project=project)
 
     vw.train(document_corpus, project)
     assert vw._model is not None
@@ -294,13 +294,13 @@ def test_vw_multi_train_multilabel_oaa(datadir, document_corpus, project):
     assert datadir.join('vw-model').size() > 0
 
 
-def test_vw_multi_suggest_multilabel_oaa(datadir, project):
+def test_vw_multi_suggest_multilabel_oaa(project):
     vw_type = annif.backend.get_backend('vw_multi')
     vw = vw_type(
         backend_id='vw_multi',
         config_params={'chunksize': 1,
                        'algorithm': 'multilabel_oaa'},
-        datadir=str(datadir))
+        project=project)
 
     results = vw.suggest("""Arkeologiaa sanotaan joskus myös
         muinaistutkimukseksi tai muinaistieteeksi. Se on humanistinen tiede

--- a/tests/test_backend_vw_multi.py
+++ b/tests/test_backend_vw_multi.py
@@ -310,4 +310,4 @@ def test_vw_multi_suggest_multilabel_oaa(project):
         pohjaan.""")
 
     # weak assertion, but often multilabel_oaa produces zero hits
-    assert len(results) >= 0
+    assert results is not None


### PR DESCRIPTION
This PR changes the way backends access the project object. Before this PR, the project was passed as a parameter to the `train`, `learn` and `suggest` methods and the backend didn't store a permanent reference to the project. (In early versions, projects and backends were more independent than they currently are, and a single backend could be attached to multiple projects.)

With this change, the project is passed to the backend as a constructor parameter and stored in a field `self.project`. There is no need to pass it around internally within backends, which simplifies the code quite a lot.