### PR TITLE
Disable build dryruns for pushes

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -23,7 +23,6 @@ steps:
       dry_run: true
     when:
       event:
-      - push
       - pull_request
 
   - name: build_and_publish_builder


### PR DESCRIPTION
It is unnecessary to run Docker builds for every push to all branches (especially as a build dryrun is made for PR anyway), and apparently it has the negative consequence of stressing the Drone server and its network leading to timeout errors in the builds. 

Even for PRs the build dryruns are a bit questionable, running build&tests would be more meaningful, see #315.