### PR TITLE
Fix for spurious "analyzer setting is missing" errors under WSGI

### DIFF
--- a/annif/project.py
+++ b/annif/project.py
@@ -62,13 +62,10 @@ class AnnifProject(DatadirMixin):
     def _initialize_analyzer(self):
         if not self.analyzer_spec:
             return  # not configured, so assume it's not needed
-        try:
-            analyzer = self.analyzer
-            logger.debug("Project '%s': initialized analyzer: %s",
-                         self.project_id,
-                         str(analyzer))
-        except AnnifException as err:
-            logger.warning(err.format_message())
+        analyzer = self.analyzer
+        logger.debug("Project '%s': initialized analyzer: %s",
+                     self.project_id,
+                     str(analyzer))
 
     def _initialize_subjects(self):
         try:

--- a/annif/project.py
+++ b/annif/project.py
@@ -60,6 +60,8 @@ class AnnifProject(DatadirMixin):
                 project_id=self.project_id)
 
     def _initialize_analyzer(self):
+        if not self.analyzer_spec:
+            return  # not configured, so assume it's not needed
         try:
             analyzer = self.analyzer
             logger.debug("Project '%s': initialized analyzer: %s",


### PR DESCRIPTION
When starting Annif as a WSGI server using gunicorn, I noticed errors like this:

```
Misconfigured project 'maui-fi': analyzer setting is missing (and needed by the backend)
Misconfigured project 'nn-ensemble-fi': analyzer setting is missing (and needed by the backend)
```

These are incorrect - maui and nn_ensemble don't need an analyzer since they're not directly processing text. This PR fixes the problem that caused these messages.