### PR TITLE
Upgrade omikuji 0.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,9 +31,8 @@ install:
 # (tensorflow 2.0.0 isn't available for python 3.8 anyway)
 - if [[ $TRAVIS_PYTHON_VERSION != '3.8' ]]; then pip install .[nn]; fi
 # Install the optional Omikuji dependency
-# - except for one Python version (3.8) so that we can test also without them
-# (omikuji doesn't offer pre-built python 3.8 wheels as of version 0.1.3)
-- if [[ $TRAVIS_PYTHON_VERSION != '3.8' ]]; then pip install .[omikuji]; fi
+# - except for one Python version (3.6) so that we can test also without them
+- if [[ $TRAVIS_PYTHON_VERSION != '3.6' ]]; then pip install .[omikuji]; fi
 # For Python 3.5, also install optional dependencies that were not specified in Pipfile
 # For other Python versions we will only run the tests that depend on pure Python modules
 # - fastText dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ RUN apt-get update \
 		voikko \
 		vowpalwabbit==8.7.* \
 		tensorflow==2.0.* \
-		omikuji==0.1.3 \
+		omikuji==0.2.* \
 	# Clean up:
 	&& rm -rf /var/lib/apt/lists/* /usr/include/* \
 	&& rm -rf /root/.cache/pip*/*

--- a/annif/backend/omikuji.py
+++ b/annif/backend/omikuji.py
@@ -26,7 +26,7 @@ class OmikujiBackend(mixins.TfidfVectorizerMixin, backend.AnnifBackend):
         'cluster_balanced': True,
         'cluster_k': 2,
         'max_depth': 20,
-        'collapse_every_n_layers': 0
+        'collapse_every_n_layers': 0,
     }
 
     def default_params(self):
@@ -90,6 +90,8 @@ class OmikujiBackend(mixins.TfidfVectorizerMixin, backend.AnnifBackend):
             self.params['cluster_balanced'])
         hyper_param.cluster_k = int(self.params['cluster_k'])
         hyper_param.max_depth = int(self.params['max_depth'])
+        hyper_param.collapse_every_n_layers = int(
+            self.params['collapse_every_n_layers'])
 
         self._model = omikuji.Model.train_on_data(train_path, hyper_param)
         if os.path.exists(model_path):

--- a/annif/backend/omikuji.py
+++ b/annif/backend/omikuji.py
@@ -26,6 +26,7 @@ class OmikujiBackend(mixins.TfidfVectorizerMixin, backend.AnnifBackend):
         'cluster_balanced': True,
         'cluster_k': 2,
         'max_depth': 20,
+        'collapse_every_n_layers': 0
     }
 
     def default_params(self):

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
         'voikko': ['voikko'],
         'vw': ['vowpalwabbit==8.7.*'],
         'nn': ['tensorflow==2.0.*'],
-        'omikuji': ['omikuji==0.1.3'],
+        'omikuji': ['omikuji==0.2.*'],
     },
     entry_points={
         'console_scripts': ['annif=annif.cli:cli']},


### PR DESCRIPTION
This PR updates the Omikuji dependency to version 0.2.
* adds support for `collapse_every_n_layers` hyperparameter, needed for AttentionXML style layer collapsing
* enables Omikuji for Python 3.8