### PR TITLE
Enable https in Swagger

### DIFF
--- a/annif/swagger/annif.yaml
+++ b/annif/swagger/annif.yaml
@@ -4,6 +4,7 @@ info:
   version: v1
 schemes:
   - http
+  - https
 basePath: /v1
 parameters:
   project_id:

--- a/annif/swagger/annif.yaml
+++ b/annif/swagger/annif.yaml
@@ -2,9 +2,6 @@ swagger: '2.0'
 info:
   title: Annif REST API
   version: v1
-schemes:
-  - http
-  - https
 basePath: /v1
 parameters:
   project_id:


### PR DESCRIPTION
`annif.dev.finto.fi` was updated to use `https` instead of `http`, and this change allows Swagger use it.