### PR TITLE
Implement --cached option for train command

### DIFF
--- a/annif/backend/fasttext.py
+++ b/annif/backend/fasttext.py
@@ -116,10 +116,14 @@ class FastTextBackend(mixins.ChunkingBackend, backend.AnnifBackend):
         self._model.save_model(modelpath)
 
     def _train(self, corpus, params):
-        if corpus.is_empty():
-            raise NotSupportedException('training backend {} with no documents'
-                                        .format(self.backend_id))
-        self._create_train_file(corpus)
+        if corpus != 'cached':
+            if corpus.is_empty():
+                raise NotSupportedException(
+                    'training backend {} with no documents' .format(
+                        self.backend_id))
+            self._create_train_file(corpus)
+        else:
+            self.info("Reusing cached training data from previous run.")
         self._create_model(params)
 
     def _predict_chunks(self, chunktexts, limit):

--- a/annif/backend/maui.py
+++ b/annif/backend/maui.py
@@ -102,6 +102,9 @@ class MauiBackend(backend.AnnifBackend):
             time.sleep(1)
 
     def _train(self, corpus, params):
+        if corpus == 'cached':
+            raise NotSupportedException(
+                'Training maui project from cached data not supported.')
         if corpus.is_empty():
             raise NotSupportedException('training backend {} with no documents'
                                         .format(self.backend_id))

--- a/annif/backend/nn_ensemble.py
+++ b/annif/backend/nn_ensemble.py
@@ -92,6 +92,9 @@ class NNEnsembleBackend(
         self.debug("Created model: \n" + "\n".join(summary))
 
     def _train(self, corpus, params):
+        if corpus == 'cached':
+            raise NotSupportedException(
+                'Training nn_ensemble project from cached data not supported.')
         sources = annif.util.parse_sources(self.params['sources'])
         self._create_model(sources)
         self._fit_model(corpus, epochs=int(params['epochs']))

--- a/annif/backend/nn_ensemble.py
+++ b/annif/backend/nn_ensemble.py
@@ -10,7 +10,7 @@ import tensorflow.keras.backend as K
 import annif.corpus
 import annif.project
 import annif.util
-from annif.exception import NotInitializedException
+from annif.exception import NotInitializedException, NotSupportedException
 from annif.suggestion import VectorSuggestionResult
 from . import backend
 from . import ensemble

--- a/annif/backend/omikuji.py
+++ b/annif/backend/omikuji.py
@@ -99,14 +99,17 @@ class OmikujiBackend(mixins.TfidfVectorizerMixin, backend.AnnifBackend):
         self._model.save(os.path.join(self.datadir, self.MODEL_FILE))
 
     def _train(self, corpus, params):
-        if corpus.is_empty():
-            raise NotSupportedException(
-                'Cannot train omikuji project with no documents')
-        input = (doc.text for doc in corpus.documents)
-        vecparams = {'min_df': int(params['min_df']),
-                     'tokenizer': self.project.analyzer.tokenize_words}
-        veccorpus = self.create_vectorizer(input, vecparams)
-        self._create_train_file(veccorpus, corpus)
+        if corpus != 'cached':
+            if corpus.is_empty():
+                raise NotSupportedException(
+                    'Cannot train omikuji project with no documents')
+            input = (doc.text for doc in corpus.documents)
+            vecparams = {'min_df': int(params['min_df']),
+                         'tokenizer': self.project.analyzer.tokenize_words}
+            veccorpus = self.create_vectorizer(input, vecparams)
+            self._create_train_file(veccorpus, corpus)
+        else:
+            self.info("Reusing cached training data from previous run.")
         self._create_model(params)
 
     def _suggest(self, text, params):

--- a/annif/backend/pav.py
+++ b/annif/backend/pav.py
@@ -98,6 +98,9 @@ class PAVBackend(ensemble.EnsembleBackend):
             method=joblib.dump)
 
     def _train(self, corpus, params):
+        if corpus == 'cached':
+            raise NotSupportedException(
+                'Training pav project from cached data not supported.')
         if corpus.is_empty():
             raise NotSupportedException('training backend {} with no documents'
                                         .format(self.backend_id))

--- a/annif/backend/tfidf.py
+++ b/annif/backend/tfidf.py
@@ -105,6 +105,9 @@ class TFIDFBackend(mixins.TfidfVectorizerMixin, backend.AnnifBackend):
             self.INDEX_FILE)
 
     def _train(self, corpus, params):
+        if corpus == 'cached':
+            raise NotSupportedException(
+                'Training tfidf project from cached data not supported.')
         if corpus.is_empty():
             raise NotSupportedException(
                 'Cannot train tfidf project with no documents')

--- a/annif/backend/vw_multi.py
+++ b/annif/backend/vw_multi.py
@@ -230,8 +230,10 @@ class VWMultiBackend(mixins.ChunkingBackend, backend.AnnifLearningBackend):
                                method=self._write_train_file)
 
     def _train(self, corpus, params):
-        self.info("creating VW model")
-        self._create_train_file(corpus)
+        if corpus != 'cached':
+            self._create_train_file(corpus)
+        else:
+            self.info("Reusing cached training data from previous run.")
         self._create_model(params)
 
     def _learn(self, corpus, params):

--- a/annif/cli.py
+++ b/annif/cli.py
@@ -178,15 +178,23 @@ def run_loadvoc(project_id, subjectfile):
 @cli.command('train')
 @click.argument('project_id')
 @click.argument('paths', type=click.Path(exists=True), nargs=-1)
+@click.option('--cached/--no-cached', default=False,
+              help='Reuse preprocessed training data from previous run')
 @backend_param_option
 @common_options
-def run_train(project_id, paths, backend_param):
+def run_train(project_id, paths, cached, backend_param):
     """
     Train a project on a collection of documents.
     """
     proj = get_project(project_id)
     backend_params = parse_backend_params(backend_param, proj)
-    documents = open_documents(paths)
+    if cached:
+        if len(paths) > 0:
+            raise click.UsageError(
+                "Corpus paths cannot be given when using --cached option.")
+        documents = 'cached'
+    else:
+        documents = open_documents(paths)
     proj.train(documents, backend_params)
 
 

--- a/annif/project.py
+++ b/annif/project.py
@@ -164,7 +164,8 @@ class AnnifProject(DatadirMixin):
 
     def train(self, corpus, backend_params=None):
         """train the project using documents from a metadata source"""
-        corpus.set_subject_index(self.subjects)
+        if corpus != 'cached':
+            corpus.set_subject_index(self.subjects)
         if backend_params is None:
             backend_params = {}
         beparams = backend_params.get(self.backend.backend_id, {})

--- a/tests/test_backend_fasttext.py
+++ b/tests/test_backend_fasttext.py
@@ -47,6 +47,26 @@ def test_fasttext_train(document_corpus, project, datadir):
     assert datadir.join('fasttext-model').size() > 0
 
 
+def test_fasttext_train_cached(project, datadir):
+    assert datadir.join('fasttext-train.txt').exists()
+    datadir.join('fasttext-model').remove()
+    fasttext_type = annif.backend.get_backend("fasttext")
+    fasttext = fasttext_type(
+        backend_id='fasttext',
+        config_params={
+            'limit': 50,
+            'dim': 100,
+            'lr': 0.25,
+            'epoch': 20,
+            'loss': 'hs'},
+        project=project)
+
+    fasttext.train("cached")
+    assert fasttext._model is not None
+    assert datadir.join('fasttext-model').exists()
+    assert datadir.join('fasttext-model').size() > 0
+
+
 def test_fasttext_train_unknown_subject(tmpdir, datadir, project):
     fasttext_type = annif.backend.get_backend("fasttext")
     fasttext = fasttext_type(

--- a/tests/test_backend_maui.py
+++ b/tests/test_backend_maui.py
@@ -27,6 +27,11 @@ def maui(app_project, maui_params):
     return maui
 
 
+def test_maui_train_cached(maui, maui_params):
+    with pytest.raises(NotSupportedException):
+        maui.train("cached")
+
+
 def test_maui_train_missing_endpoint(document_corpus, project):
     maui_type = annif.backend.get_backend("maui")
     maui = maui_type(

--- a/tests/test_backend_maui.py
+++ b/tests/test_backend_maui.py
@@ -27,7 +27,7 @@ def maui(app_project, maui_params):
     return maui
 
 
-def test_maui_train_cached(maui, maui_params):
+def test_maui_train_cached(maui):
     with pytest.raises(NotSupportedException):
         maui.train("cached")
 

--- a/tests/test_backend_nn_ensemble.py
+++ b/tests/test_backend_nn_ensemble.py
@@ -7,6 +7,7 @@ import annif.backend
 import annif.corpus
 import annif.project
 from annif.exception import NotInitializedException
+from annif.exception import NotSupportedException
 
 pytest.importorskip("annif.backend.nn_ensemble")
 
@@ -20,6 +21,17 @@ def test_nn_ensemble_suggest_no_model(project):
 
     with pytest.raises(NotInitializedException):
         results = nn_ensemble.suggest("example text")
+
+
+def test_nn_ensemble_train_cached(project):
+    nn_ensemble_type = annif.backend.get_backend('nn_ensemble')
+    nn_ensemble = nn_ensemble_type(
+        backend_id='nn_ensemble',
+        config_params={'sources': 'dummy-en'},
+        project=project)
+
+    with pytest.raises(NotSupportedException):
+        nn_ensemble.train("cached")
 
 
 def test_nn_ensemble_train_and_learn(app, tmpdir):

--- a/tests/test_backend_omikuji.py
+++ b/tests/test_backend_omikuji.py
@@ -78,6 +78,20 @@ def test_omikuji_train(datadir, document_corpus, project):
     assert datadir.join('omikuji-model').listdir()  # non-empty dir
 
 
+def test_omikuji_train_cached(datadir, project):
+    assert datadir.join('omikuji-train.txt').exists()
+    datadir.join('omikuji-model').remove()
+    omikuji_type = annif.backend.get_backend('omikuji')
+    omikuji = omikuji_type(
+        backend_id='omikuji',
+        config_params={},
+        project=project)
+    omikuji.train("cached")
+    assert omikuji._model is not None
+    assert datadir.join('omikuji-model').exists()
+    assert datadir.join('omikuji-model').listdir()  # non-empty dir
+
+
 def test_omikuji_train_nodocuments(datadir, project, empty_corpus):
     omikuji_type = annif.backend.get_backend('omikuji')
     omikuji = omikuji_type(

--- a/tests/test_backend_pav.py
+++ b/tests/test_backend_pav.py
@@ -41,6 +41,17 @@ def test_pav_train(app, datadir, tmpdir, project):
     assert datadir.join('pav-model-dummy-fi').size() > 0
 
 
+def test_pav_train_cached(project):
+    pav_type = annif.backend.get_backend("pav")
+    pav = pav_type(
+        backend_id='pav',
+        config_params={'limit': 50, 'min-docs': 2, 'sources': 'dummy-fi'},
+        project=project)
+
+    with pytest.raises(NotSupportedException):
+        pav.train("cached")
+
+
 def test_pav_train_nodocuments(project, empty_corpus):
     pav_type = annif.backend.get_backend("pav")
     pav = pav_type(

--- a/tests/test_backend_vw_multi.py
+++ b/tests/test_backend_vw_multi.py
@@ -188,7 +188,7 @@ def test_vw_multi_train_params(project, vw_corpus, caplog):
             assert "'learning_rate': 42.1" in line
 
 
-def test_vw_multi_train_cached(project, vw_corpus):
+def test_vw_multi_train_cached(datadir, project, vw_corpus):
     assert datadir.join('vw-train.txt').exists()
     datadir.join('vw-model').remove()
     vw_type = annif.backend.get_backend('vw_multi')

--- a/tests/test_backend_vw_multi.py
+++ b/tests/test_backend_vw_multi.py
@@ -188,6 +188,20 @@ def test_vw_multi_train_params(project, vw_corpus, caplog):
             assert "'learning_rate': 42.1" in line
 
 
+def test_vw_multi_train_cached(project, vw_corpus):
+    assert datadir.join('vw-train.txt').exists()
+    datadir.join('vw-model').remove()
+    vw_type = annif.backend.get_backend('vw_multi')
+    vw = vw_type(
+        backend_id='vw_multi',
+        config_params={'chunksize': 4, 'learning_rate': 0.5},
+        project=project)
+    vw.train("cached")
+    assert vw._model is not None
+    assert datadir.join('vw-model').exists()
+    assert datadir.join('vw-model').size() > 0
+
+
 def test_vw_multi_suggest(project):
     vw_type = annif.backend.get_backend('vw_multi')
     vw = vw_type(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -224,6 +224,15 @@ def test_train_multiple(testdatadir):
     assert testdatadir.join('projects/tfidf-fi/tfidf-index').size() > 0
 
 
+def test_train_cached(testdatadir):
+    result = runner.invoke(annif.cli.cli,
+                           ['train', '--cached', 'tfidf-fi'])
+    assert result.exception
+    assert result.exit_code == 1
+    assert 'Training tfidf project from cached data not supported.' \
+           in result.output
+
+
 def test_train_param_override_algo_notsupported():
     pytest.importorskip('annif.backend.vw_multi')
     docfile = os.path.join(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -233,6 +233,20 @@ def test_train_cached(testdatadir):
            in result.output
 
 
+def test_train_cached_with_corpus(testdatadir):
+    docfile = os.path.join(
+        os.path.dirname(__file__),
+        'corpora',
+        'archaeology',
+        'documents.tsv')
+    result = runner.invoke(annif.cli.cli,
+                           ['train', '--cached', 'tfidf-fi', docfile])
+    assert result.exception
+    assert result.exit_code == 2
+    assert 'Corpus paths cannot be given when using --cached option.' \
+           in result.output
+
+
 def test_train_param_override_algo_notsupported():
     pytest.importorskip('annif.backend.vw_multi')
     docfile = os.path.join(


### PR DESCRIPTION
Real support is implemented for now only in fasttext, omikuji and vw_multi backends.
Fixes #342 