### PR TITLE
Use LMDB and sparse vectors in nn_ensemble backend

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ install:
 - pip install --upgrade pytest
 - pipenv install --dev --skip-lock
 - travis_wait 30 python -m nltk.downloader punkt
-# Install the optional neural network dependencies (Keras and TensorFlow)
+# Install the optional neural network dependencies (TensorFlow and LMDB)
 # - except for one Python version (3.8) so that we can test also without them
 # (tensorflow 2.0.0 isn't available for python 3.8 anyway)
 - if [[ $TRAVIS_PYTHON_VERSION != '3.8' ]]; then pip install .[nn]; fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,9 @@ RUN apt-get update \
 	&& ln -sf /usr/lib/x86_64-linux-gnu/libboost_python-py35.so \
 		/usr/lib/x86_64-linux-gnu/libboost_python3.so \
 	&& pip install --no-cache-dir \
-		vowpalwabbit==8.7.*
+		vowpalwabbit==8.7.* \
+        ## LMDB
+        && pip install --no-cache-dir lmdb==0.98
 
 
 

--- a/annif/backend/nn_ensemble.py
+++ b/annif/backend/nn_ensemble.py
@@ -3,6 +3,7 @@ projects."""
 
 
 from io import BytesIO
+import shutil
 import os.path
 import numpy as np
 from scipy.sparse import csr_matrix
@@ -173,6 +174,8 @@ class NNEnsembleBackend(
 
     def _fit_model(self, corpus, epochs):
         lmdb_path = os.path.join(self.datadir, self.LMDB_FILE)
+        if corpus != 'cached' and os.path.exists(lmdb_path):
+            shutil.rmtree(lmdb_path)
         env = lmdb.open(lmdb_path, map_size=self.LMDB_MAP_SIZE, writemap=True)
         with env.begin(write=True, buffers=True) as txn:
             seq = LMDBSequence(txn, batch_size=32)

--- a/annif/backend/nn_ensemble.py
+++ b/annif/backend/nn_ensemble.py
@@ -6,7 +6,7 @@ from io import BytesIO
 import shutil
 import os.path
 import numpy as np
-from scipy.sparse import csr_matrix
+from scipy.sparse import csr_matrix, csc_matrix
 import joblib
 import lmdb
 from tensorflow.keras.layers import Input, Dense, Add, Flatten, Lambda, Dropout
@@ -49,7 +49,7 @@ class LMDBSequence(Sequence):
         key = idx_to_key(self._counter)
         self._counter += 1
         # convert the sample into a sparse matrix and serialize it as bytes
-        sample = (csr_matrix(inputs), csr_matrix(targets))
+        sample = (csc_matrix(inputs), csr_matrix(targets))
         buf = BytesIO()
         joblib.dump(sample, buf)
         buf.seek(0)

--- a/annif/backend/nn_ensemble.py
+++ b/annif/backend/nn_ensemble.py
@@ -2,10 +2,15 @@
 projects."""
 
 
+from io import BytesIO
 import os.path
 import numpy as np
+from scipy.sparse import csr_matrix
+import joblib
+import lmdb
 from tensorflow.keras.layers import Input, Dense, Add, Flatten, Lambda, Dropout
 from tensorflow.keras.models import Model, load_model
+from tensorflow.keras.utils import Sequence
 import tensorflow.keras.backend as K
 import annif.corpus
 import annif.project
@@ -16,6 +21,57 @@ from . import backend
 from . import ensemble
 
 
+class LMDBSequence(Sequence):
+    """A sequence of samples stored in a LMDB database."""
+    def __init__(self, txn, batch_size):
+        self._txn = txn
+        cursor = txn.cursor()
+        if cursor.last():
+            self._counter = int(cursor.key())
+        else:  # empty database
+            self._counter = 0
+        self._batch_size = batch_size
+
+    @staticmethod
+    def int_to_key(val):
+        return b'%08d' % val
+
+    @staticmethod
+    def key_to_int(key):
+        return int(key)
+
+    def add_sample(self, inputs, targets):
+        # use zero-padded 8-digit key
+        key = self.int_to_key(self._counter)
+        self._counter += 1
+        # convert the sample into a sparse matrix and serialize it as bytes
+        sample = (csr_matrix(inputs), csr_matrix(targets))
+        buf = BytesIO()
+        joblib.dump(sample, buf)
+        buf.seek(0)
+        self._txn.put(key, buf.read())
+
+    def __getitem__(self, idx):
+        """get a particular batch of samples"""
+        cursor = self._txn.cursor()
+        first_key = idx * self._batch_size
+        last_key = first_key + self._batch_size
+        cursor.set_key(self.int_to_key(first_key))
+        input_arrays = []
+        target_arrays = []
+        for key, value in cursor.iternext():
+            if self.key_to_int(key) >= last_key:
+                break
+            input_csr, target_csr = joblib.load(BytesIO(value))
+            input_arrays.append(input_csr.toarray())
+            target_arrays.append(target_csr.toarray().flatten())
+        return np.array(input_arrays), np.array(target_arrays)
+
+    def __len__(self):
+        """return the number of available batches"""
+        return int(np.ceil(self._counter / self._batch_size))
+        
+
 class NNEnsembleBackend(
         backend.AnnifLearningBackend,
         ensemble.EnsembleBackend):
@@ -25,6 +81,8 @@ class NNEnsembleBackend(
     name = "nn_ensemble"
 
     MODEL_FILE = "nn-model.h5"
+    LMDB_FILE = 'nn-train.mdb'
+    LMDB_MAP_SIZE = 1024 * 1024 * 1024
 
     DEFAULT_PARAMS = {
         'nodes': 100,
@@ -99,35 +157,32 @@ class NNEnsembleBackend(
         self._create_model(sources)
         self._fit_model(corpus, epochs=int(params['epochs']))
 
-    def _corpus_to_vectors(self, corpus):
+    def _corpus_to_vectors(self, corpus, seq):
         # pass corpus through all source projects
         sources = [(annif.project.get_project(project_id), weight)
                    for project_id, weight
                    in annif.util.parse_sources(self.params['sources'])]
 
-        score_vectors = []
-        true_vectors = []
         for doc in corpus.documents:
             doc_scores = []
             for source_project, weight in sources:
                 hits = source_project.suggest(doc.text)
                 doc_scores.append(hits.vector * weight)
-            score_vectors.append(np.array(doc_scores,
-                                          dtype=np.float32).transpose())
+            score_vector = np.array(doc_scores,
+                                    dtype=np.float32).transpose()
             subjects = annif.corpus.SubjectSet((doc.uris, doc.labels))
-            true_vectors.append(subjects.as_vector(self.project.subjects))
-        # collect the results into a single vector, considering weights
-        scores = np.array(score_vectors, dtype=np.float32)
-        # collect the gold standard values into another vector
-        true = np.array(true_vectors, dtype=np.float32)
-        return (scores, true)
+            true_vector = subjects.as_vector(self.project.subjects)
+            seq.add_sample(score_vector, true_vector)
 
     def _fit_model(self, corpus, epochs):
-        scores, true = self._corpus_to_vectors(corpus)
+        lmdb_path = os.path.join(self.datadir, self.LMDB_FILE)
+        env = lmdb.open(lmdb_path, map_size=self.LMDB_MAP_SIZE, writemap=True)
+        with env.begin(write=True, buffers=True) as txn:
+            seq = LMDBSequence(txn, batch_size=32)
+            self._corpus_to_vectors(corpus, seq)
 
-        # fit the model
-        self._model.fit(scores, true, batch_size=32, verbose=True,
-                        epochs=epochs)
+            # fit the model
+            self._model.fit(seq, verbose=True, epochs=epochs)
 
         annif.util.atomic_save(
             self._model,

--- a/annif/backend/nn_ensemble.py
+++ b/annif/backend/nn_ensemble.py
@@ -15,7 +15,7 @@ import tensorflow.keras.backend as K
 import annif.corpus
 import annif.project
 import annif.util
-from annif.exception import NotInitializedException, NotSupportedException
+from annif.exception import NotInitializedException
 from annif.suggestion import VectorSuggestionResult
 from . import backend
 from . import ensemble

--- a/annif/backend/nn_ensemble.py
+++ b/annif/backend/nn_ensemble.py
@@ -56,12 +56,11 @@ class LMDBSequence(Sequence):
         """get a particular batch of samples"""
         cursor = self._txn.cursor()
         first_key = idx * self._batch_size
-        last_key = first_key + self._batch_size
         cursor.set_key(self.idx_to_key(first_key))
         input_arrays = []
         target_arrays = []
         for key, value in cursor.iternext():
-            if self.key_to_idx(key) >= last_key:
+            if self.key_to_idx(key) >= (first_key + self._batch_size):
                 break
             input_csr, target_csr = joblib.load(BytesIO(value))
             input_arrays.append(input_csr.toarray())

--- a/annif/backend/nn_ensemble.py
+++ b/annif/backend/nn_ensemble.py
@@ -23,6 +23,7 @@ from . import ensemble
 
 class LMDBSequence(Sequence):
     """A sequence of samples stored in a LMDB database."""
+
     def __init__(self, txn, batch_size):
         self._txn = txn
         cursor = txn.cursor()
@@ -70,7 +71,7 @@ class LMDBSequence(Sequence):
     def __len__(self):
         """return the number of available batches"""
         return int(np.ceil(self._counter / self._batch_size))
-        
+
 
 class NNEnsembleBackend(
         backend.AnnifLearningBackend,

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
         'fasttext': ['fasttext', 'fasttextmirror==0.8.22'],
         'voikko': ['voikko'],
         'vw': ['vowpalwabbit==8.7.*'],
-        'nn': ['tensorflow==2.0.*'],
+        'nn': ['tensorflow==2.0.*', 'lmdb==0.98'],
         'omikuji': ['omikuji==0.2.*'],
     },
     entry_points={

--- a/tests/test_backend_nn_ensemble.py
+++ b/tests/test_backend_nn_ensemble.py
@@ -23,23 +23,12 @@ def test_nn_ensemble_suggest_no_model(project):
         results = nn_ensemble.suggest("example text")
 
 
-def test_nn_ensemble_train_cached(project):
-    nn_ensemble_type = annif.backend.get_backend('nn_ensemble')
-    nn_ensemble = nn_ensemble_type(
-        backend_id='nn_ensemble',
-        config_params={'sources': 'dummy-en'},
-        project=project)
-
-    with pytest.raises(NotSupportedException):
-        nn_ensemble.train("cached")
-
-
 def test_nn_ensemble_train_and_learn(app, tmpdir):
     project = annif.project.get_project('dummy-en')
     nn_ensemble_type = annif.backend.get_backend("nn_ensemble")
     nn_ensemble = nn_ensemble_type(
         backend_id='nn_ensemble',
-        config_params={'sources': 'dummy-en'},
+        config_params={'sources': 'dummy-en', 'epochs': 1},
         project=project)
 
     tmpfile = tmpdir.join('document.tsv')
@@ -68,12 +57,33 @@ def test_nn_ensemble_train_and_learn(app, tmpdir):
     assert modelfile.size() != old_size or modelfile.mtime() != old_mtime
 
 
+def test_nn_ensemble_train_cached(app):
+    # make sure we have the cached training data from the previous test
+    project = annif.project.get_project('dummy-en')
+    datadir = py.path.local(project.datadir)
+    assert datadir.join('nn-train.mdb').exists()
+
+    datadir.join('nn-model.h5').remove()
+
+    nn_ensemble_type = annif.backend.get_backend('nn_ensemble')
+    nn_ensemble = nn_ensemble_type(
+        backend_id='nn_ensemble',
+        config_params={'sources': 'dummy-en', 'epochs': 2},
+        project=project)
+
+    with app.app_context():
+        nn_ensemble.train("cached")
+
+    assert datadir.join('nn-model.h5').exists()
+    assert datadir.join('nn-model.h5').size() > 0
+
+
 def test_nn_ensemble_train_and_learn_params(app, tmpdir, capfd):
     project = annif.project.get_project('dummy-en')
     nn_ensemble_type = annif.backend.get_backend("nn_ensemble")
     nn_ensemble = nn_ensemble_type(
         backend_id='nn_ensemble',
-        config_params={'sources': 'dummy-en'},
+        config_params={'sources': 'dummy-en', 'epochs': 3},
         project=project)
 
     tmpfile = tmpdir.join('document.tsv')

--- a/tests/test_backend_nn_ensemble.py
+++ b/tests/test_backend_nn_ensemble.py
@@ -12,6 +12,12 @@ from annif.exception import NotSupportedException
 pytest.importorskip("annif.backend.nn_ensemble")
 
 
+def test_lmdb_sequence_idx_to_key_to_idx():
+    seq_class = annif.backend.nn_ensemble.LMDBSequence
+    assert seq_class.idx_to_key(42) == b'00000042'
+    assert seq_class.key_to_idx(b'00000042') == 42
+
+
 def test_nn_ensemble_suggest_no_model(project):
     nn_ensemble_type = annif.backend.get_backend('nn_ensemble')
     nn_ensemble = nn_ensemble_type(

--- a/tests/test_backend_nn_ensemble.py
+++ b/tests/test_backend_nn_ensemble.py
@@ -34,7 +34,7 @@ def test_nn_ensemble_train_and_learn(app, tmpdir):
     tmpfile = tmpdir.join('document.tsv')
     tmpfile.write("dummy\thttp://example.org/dummy\n" +
                   "another\thttp://example.org/dummy\n" +
-                  "none\thttp://example.org/none")
+                  "none\thttp://example.org/none\n" * 40)
     document_corpus = annif.corpus.DocumentFile(str(tmpfile))
 
     with app.app_context():

--- a/tests/test_backend_nn_ensemble.py
+++ b/tests/test_backend_nn_ensemble.py
@@ -12,10 +12,9 @@ from annif.exception import NotSupportedException
 pytest.importorskip("annif.backend.nn_ensemble")
 
 
-def test_lmdb_sequence_idx_to_key_to_idx():
-    seq_class = annif.backend.nn_ensemble.LMDBSequence
-    assert seq_class.idx_to_key(42) == b'00000042'
-    assert seq_class.key_to_idx(b'00000042') == 42
+def test_lmdb_idx_to_key_to_idx():
+    assert annif.backend.nn_ensemble.idx_to_key(42) == b'00000042'
+    assert annif.backend.nn_ensemble.key_to_idx(b'00000042') == 42
 
 
 def test_nn_ensemble_suggest_no_model(project):


### PR DESCRIPTION
Before this PR, the nn_ensemble backend collected score and label (target) vectors in memory, which took a lot of RAM when there are thousands of documents, multiple source projects and a large vocabulary such as YSO. This PR makes the nn_ensemble backend instead spool those vectors into an on-disk, memory-mapped LMDB database instead (implemented as a keras.utils.Sequential subclass). The vectors are also compressed by representing them as SciPy sparse vectors.

The LMDB training data can also be reused in later training rounds by using the recently introduced `--cached` option, although this functionality is not yet implemented in the initial commit.

Fixes #363