### PR TITLE
Remove duplicated be param option

### DIFF
--- a/annif/backend/maui.py
+++ b/annif/backend/maui.py
@@ -39,7 +39,7 @@ class MauiBackend(backend.AnnifBackend):
 
     def _initialize_tagger(self, params):
         self.info(
-            "Initializing Maui Service tagger '{}'".format(
+            "Initializing Maui Server tagger '{}'".format(
                 self.tagger(params)))
 
         # try to delete the tagger in case it already exists

--- a/annif/cli.py
+++ b/annif/cli.py
@@ -308,8 +308,6 @@ def run_eval(project_id, paths, limit, threshold, backend_param):
 @cli.command('optimize')
 @click.argument('project_id')
 @click.argument('paths', type=click.Path(exists=True), nargs=-1)
-@click.option('--backend-param', '-b', multiple=True,
-              help='Backend parameters to override')
 @backend_param_option
 @common_options
 def run_optimize(project_id, paths, backend_param):


### PR DESCRIPTION
The option to override BE params was added as a decorator to most CLI commands in #289, but the option was already existing in the optimize command, and I did not notice to remove it at that time. This led only to duplication of the option in the CLI help message.

Also updates the log message about initializing Maui Service tagger to Maui Server, left from #344 .