### PR TITLE
Remove "fasttext" package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     ],
     tests_require=['py', 'pytest', 'requests'],
     extras_require={
-        'fasttext': ['fasttext', 'fasttextmirror==0.8.22'],
+        'fasttext': ['fasttextmirror==0.8.22'],
         'voikko': ['voikko'],
         'vw': ['vowpalwabbit==8.7.*'],
         'nn': ['tensorflow==2.0.*', 'lmdb==0.98'],


### PR DESCRIPTION
The following issue was [reported in Annif users mailing list](https://groups.google.com/d/msgid/annif-users/CADt3EczfLFxCn3jdkN9D3DP1O6erC0U0aLyiEjPHyUJDCXKktg%40mail.gmail.com?utm_medium=email&utm_source=footer):
```
$ cat doc.txt | annif suggest fasttext-en
[...]
TypeError: multilinePredict(): incompatible function arguments. The following argument types are supported:
    1. (self: fasttext_pybind.fasttext, arg0: List[str], arg1: int, arg2: float, arg3: str) -> List[List[Tuple[float, str]]]

Invoked with: <fasttext_pybind.fasttext object at 0x7fb7f47c7ca8>, ['a lot of words\n'], 100, 0.0
```

This is due to multiple versions of fasttext packages being installed, which is fixed by removing the wrong one.