### PR TITLE
Show notations in web UI results list

### DIFF
--- a/annif/templates/home.html
+++ b/annif/templates/home.html
@@ -130,7 +130,7 @@ Vue.component('annif-results', {
   <ul class="list-group list-group-flush" id="results">\
     <li class="list-group-item p-0" v-for="result in results">\
       <meter class="mr-2" v-bind:value="result.score"></meter>\
-      <a v-bind:href="result.uri"><% result.label %> <% result.notation %></a>\
+      <a v-bind:href="result.uri"><% result.notation %> <% result.label %></a>\
     </li>\
   </ul>\
 </div>'

--- a/annif/templates/home.html
+++ b/annif/templates/home.html
@@ -130,7 +130,7 @@ Vue.component('annif-results', {
   <ul class="list-group list-group-flush" id="results">\
     <li class="list-group-item p-0" v-for="result in results">\
       <meter class="mr-2" v-bind:value="result.score"></meter>\
-      <a v-bind:href="result.uri"><% result.label %></a>\
+      <a v-bind:href="result.uri"><% result.label %> <% result.notation %></a>\
     </li>\
   </ul>\
 </div>'


### PR DESCRIPTION
Fixes #390. 

Now notations are just added after label, for example: 
![image](https://user-images.githubusercontent.com/34240031/77410523-a60ad700-6dc3-11ea-8f70-f60623b75211.png)


Should notations be somehow more distinctly separated from the labels, e.g. `[42.42]`? 

Or maybe it would be better to show them before the label? Like this:
![image](https://user-images.githubusercontent.com/34240031/77411056-89bb6a00-6dc4-11ea-85d0-68dc3bfcc89c.png)
