### PR TITLE
Fix silently failing rtd builds

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -15,6 +15,12 @@ sphinx:
 # Optionally set the version of Python and requirements required to build your docs
 python:
    install:
+      - method: pip
+      path: .
+      extra_requirements:
+        - voikko
+        - nn
+        - omikuji
       - requirements: docs/requirements.txt
       - method: setuptools
         path: .

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -14,14 +14,14 @@ sphinx:
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-   install:
-      - method: pip
+  install:
+    - method: pip
       path: .
       extra_requirements:
         - voikko
         - nn
         - omikuji
-      - requirements: docs/requirements.txt
-      - method: setuptools
-        path: .
-   system_packages: true
+    - requirements: docs/requirements.txt
+    - method: setuptools
+      path: .
+  system_packages: true

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -66,4 +66,4 @@ html_theme = 'sphinx_rtd_theme'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = ['']

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
 sphinxcontrib-apidoc==0.3.0
 flask
 PyYAML>=5.1
+Werkzeug==0.16.1


### PR DESCRIPTION
This PR fixes three issues related to readthedocs builds.

1. Since the release of [Werkzeug 1.0.0](https://pypi.org/project/Werkzeug/#history) on Feb 6 2020 builds of Annif documentation in RTD have been silently totally failing (not outputting docstring contents at all). [RTD logs](https://readthedocs.org/api/v2/build/10687085.txt) showed only warnings like:
    ```
    WARNING: autodoc: failed to import module 'cli' from module 'annif'; the following exception was raised:
    cannot import name 'FileStorage' from 'werkzeug' (/home/docs/checkouts/readthedocs.org/user_builds/annif/envs/move-sphinx-packages-to-docs-requirements.txt/lib/python3.7/site-packages/werkzeug/__init__.py)
    ```
    As discussed [here](https://github.com/zalando/connexion/issues/1149), for now this is fixed by pinning Werkzeug to 0.16.1. in `docs/requirements.txt` used by RTD. 

2. Even before Feb 6th, docstring content failed to be outputted for those modules that tried to import packages that were not installed:
    ```
    WARNING: autodoc: failed to import module 'voikko' from module 'annif.analyzer'; the following exception was raised:
    No module named 'voikko'
    WARNING: autodoc: failed to import module 'fasttext' from module 'annif.backend'; the following exception was raised:
    No module named 'fastText'
    WARNING: autodoc: failed to import module 'nn_ensemble' from module 'annif.backend'; the following exception was raised:
    No module named 'lmdb'
    WARNING: autodoc: failed to import module 'omikuji' from module 'annif.backend'; the following exception was raised:
    No module named 'omikuji'
    WARNING: autodoc: failed to import module 'vw_multi' from module 'annif.backend'; the following exception was raised:
    No module named 'vowpalwabbit'
    ```
    This is mitigated by installing Voikko, NN, and Omikuji "extra" packages. fastText and VW would need system packages to be installed, which I did not manage to do in RTD build pipeline.

3. The following warning in RTD log is prevented by not attempting the copy: 
    ```
    copying static files... WARNING: html_static_path entry '/home/docs/checkouts/readthedocs.org/user_builds/annif/checkouts/latest/docs/_static' does not exist
    ```



Note for future: Some confusion arised due to the fact that in the RTD build pipeline connexion version `2018.0.dev1` gets installed, but when e.g. building Docker image `2.6.0` is installed as expected. See the [issue](https://github.com/zalando/connexion/issues/1155). 