### PR TITLE
Misc rtd enhancements

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -11,8 +11,6 @@ pytest-flask = "*"
 "pytest-pep8" = "*"
 swagger-tester = "*"
 bumpversion = "*"
-sphinx = "*"
-sphinx-rtd-theme = "*"
 responses = "*"
 
 [packages]
@@ -28,7 +26,6 @@ gensim = "==3.8.*"
 scikit-learn = "==0.22.*"
 rdflib = "*"
 gunicorn = "!=20.0.0"
-sphinxcontrib-apidoc = "*"
 numpy = "==1.17.*"
 
 [requires]

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 [![BCH compliance](https://bettercodehub.com/edge/badge/NatLibFi/Annif?branch=master)](https://bettercodehub.com/)
 [![LGTM: Python](https://img.shields.io/lgtm/grade/python/g/NatLibFi/Annif.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/NatLibFi/Annif/context:python)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=NatLibFi_Annif&metric=alert_status)](https://sonarcloud.io/dashboard?id=NatLibFi_Annif)
+[![docs](https://readthedocs.org/projects/annif/badge/?version=latest)](https://annif.readthedocs.io/en/latest/index.html)
 
 Annif is an automated subject indexing toolkit. It was originally created as
 a statistical automated indexing tool that used metadata from the

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,7 +26,7 @@ author = 'Osma Suominen'
 release = re.sub(
     '^v',
     '',
-    os.popen('git describe --tags --abbrev=0').read().strip()
+    os.popen('git describe --tags').read().strip()
 )
 # The short X.Y version.
 version = release

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,5 @@
+sphinx = "*"
+sphinx-rtd-theme = "*"
 sphinxcontrib-apidoc==0.3.0
 flask
 PyYAML>=5.1

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
-sphinx = "*"
-sphinx-rtd-theme = "*"
+sphinx
+sphinx-rtd-theme
 sphinxcontrib-apidoc==0.3.0
 flask
 PyYAML>=5.1


### PR DESCRIPTION
Three small enhancements for docs:
1. Move all `sphinx` packages from `Pipfile` to `docs/requirements.txt` as they are needed only in RTD builds.
2. Add RTD build status badge to `README.md`.
3. Show relese tag tailed with commit hash in the "latest" doc version, like `0.46.0-19-g8dd52d0` instead of just `0.46.0` (which is shown in "stable" doc version).