### PR TITLE
Improved error handling in maui backend

### DIFF
--- a/annif/backend/maui.py
+++ b/annif/backend/maui.py
@@ -62,9 +62,14 @@ class MauiBackend(backend.AnnifBackend):
         try:
             resp = requests.put(self.tagger_url(params) + '/vocab',
                                 data=self.project.vocab.as_skos())
+            try:
+                json = resp.json()
+            except ValueError:
+                json = None
             resp.raise_for_status()
         except requests.exceptions.RequestException as err:
-            raise OperationFailedException(err)
+            msg = "Uploading vocabulary failed: {}".format(json)
+            raise OperationFailedException(msg) from err
 
     def _create_train_file(self, corpus):
         self.info("Creating train file")

--- a/annif/suggestion.py
+++ b/annif/suggestion.py
@@ -166,7 +166,10 @@ class ListSuggestionResult(SuggestionResult):
     def create_from_index(cls, hits, subject_index):
         subject_suggestions = []
         for hit in hits:
-            subject = subject_index[subject_index.by_uri(hit.uri)]
+            subject_id = subject_index.by_uri(hit.uri)
+            if subject_id is None:
+                continue
+            subject = subject_index[subject_id]
             subject_suggestions.append(
                 SubjectSuggestion(uri=hit.uri,
                                   label=subject[1],

--- a/tests/test_backend_maui.py
+++ b/tests/test_backend_maui.py
@@ -92,11 +92,16 @@ def test_maui_initialize_tagger_create_failed(maui, maui_params):
 
 @responses.activate
 def test_maui_upload_vocabulary_failed(maui, maui_params):
+    json = {"status": 400,
+            "status_text": "Bad Request",
+            "message": "No stemmer class registered for language 'nl'"}
     responses.add(responses.PUT,
                   'http://api.example.org/mauiservice/dummy/vocab',
-                  body=requests.exceptions.RequestException())
+                  json=json,
+                  status=400)
 
-    with pytest.raises(OperationFailedException):
+    msg_re = r"No stemmer class registered"
+    with pytest.raises(OperationFailedException, match=msg_re):
         maui._upload_vocabulary(params=maui_params)
 
 

--- a/tests/test_backend_maui.py
+++ b/tests/test_backend_maui.py
@@ -230,6 +230,20 @@ def test_maui_suggest_zero_score(maui, project):
     assert len(responses.calls) == 1
 
 
+@responses.activate
+def test_maui_suggest_unknown_uri(maui, project):
+    responses.add(responses.POST,
+                  'http://api.example.org/mauiservice/dummy/suggest',
+                  json={'title': '1 recommendation from dummy',
+                        'topics': [{'id': 'http://example.org/unknown',
+                                    'label': 'unknown',
+                                    'probability': 1.0}]})
+
+    result = maui.suggest('this is some text')
+    assert len(result) == 0
+    assert len(responses.calls) == 1
+
+
 def test_maui_suggest_error(maui, project):
     with unittest.mock.patch('requests.post') as mock_request:
         mock_request.side_effect = requests.exceptions.RequestException(

--- a/tests/test_backend_maui.py
+++ b/tests/test_backend_maui.py
@@ -100,14 +100,9 @@ def test_maui_initialize_tagger_create_error(maui, maui_params):
                         "message": "The resource does not exist"})
     responses.add(responses.POST,
                   'http://api.example.org/mauiservice/',
-                  status=400,
-                  json={"status": 400,
-                        "status_text": "Bad Request",
-                        "field": "id",
-                        "message": "Missing POST parameter: id"})
+                  status=500)
 
-    msg_re = r'Missing POST parameter'
-    with pytest.raises(OperationFailedException, match=msg_re):
+    with pytest.raises(OperationFailedException):
         maui._initialize_tagger(params=maui_params)
 
 

--- a/tests/test_backend_maui.py
+++ b/tests/test_backend_maui.py
@@ -91,6 +91,27 @@ def test_maui_initialize_tagger_create_failed(maui, maui_params):
 
 
 @responses.activate
+def test_maui_initialize_tagger_create_error(maui, maui_params):
+    responses.add(responses.DELETE,
+                  'http://api.example.org/mauiservice/dummy',
+                  status=404,
+                  json={"status": 404,
+                        "status_text": "Not Found",
+                        "message": "The resource does not exist"})
+    responses.add(responses.POST,
+                  'http://api.example.org/mauiservice/',
+                  status=400,
+                  json={"status": 400,
+                        "status_text": "Bad Request",
+                        "field": "id",
+                        "message": "Missing POST parameter: id"})
+
+    msg_re = r'Missing POST parameter'
+    with pytest.raises(OperationFailedException, match=msg_re):
+        maui._initialize_tagger(params=maui_params)
+
+
+@responses.activate
 def test_maui_upload_vocabulary_failed(maui, maui_params):
     json = {"status": 400,
             "status_text": "Bad Request",


### PR DESCRIPTION
This PR changes the way failed operations are handled in the Maui backend

* The error messages from Maui Server are now reported to the user. Fixes #401
* Don't break if Maui Server returns bad or unknown URIs (e.g. due to [this bug](https://github.com/NatLibFi/maui/issues/5)). Fixes #389
* Exception nesting is now done properly