### PR TITLE
Add encrypted secrets for pushing Docker image to quay.io from new Dr…

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -63,3 +63,12 @@ steps:
       - master
       event:
       - tag
+
+---
+kind: secret
+name: docker_username
+data: oheObzdd1LO5wRaJ3s4KjTWv28czYEykUEff28/wnElY3+2yeBCNa4QnY+4g8iUtv+ChwleiPoDoeQ==
+---
+kind: secret
+name: docker_password
+data: AVT0+HVr3/gGKoinBv2ebQBVQ59WErQw48YEEQvY+y7vfFQPjS7M8jkoiNCcPATfT1/qg3pbGl3Da0JlBqw+UxLB2y5OeF7ABrj3lpWdIE1QcPy/E/TdKc7QCGg=


### PR DESCRIPTION
…one instance

The current Drone instance (common to Kansalliskirjasto) will be shut down 15.5.2020. A new Drone instance is set up for Yhteentoimivuuspalvelut and building Annif's Docker images is already enabled in there, but that instance does not support storing secrets on the Drone server - they need to be in the config file. See https://workgroups.helsinki.fi/pages/viewpage.action?pageId=109032307.