### PR TITLE
Install CPU-only version of Tensorflow

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ RUN apt-get update \
 	&& pip install --no-cache-dir \
 		voikko \
 		vowpalwabbit==8.7.* \
-		tensorflow==2.2.0 \
+		tensorflow-cpu==2.2.0 \
 		omikuji==0.2.* \
 	# For Docker healthcheck:
 	&& apt-get install -y --no-install-recommends curl \

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
         'fasttext': ['fasttextmirror==0.8.22'],
         'voikko': ['voikko'],
         'vw': ['vowpalwabbit==8.7.*'],
-        'nn': ['tensorflow==2.2.0', 'lmdb==0.98'],
+        'nn': ['tensorflow-cpu==2.2.0', 'lmdb==0.98'],
         'omikuji': ['omikuji==0.2.*'],
         'dev': [
           'codecov',


### PR DESCRIPTION
Tensorflow 2.1 introduced [GPU support that comes by default](https://github.com/tensorflow/tensorflow/releases/tag/v2.1.0). 

Currently Annif does not benefit from the GPU support (some needed libraries are not even installed in the Docker image), but the Tensorflow with GPU support takes quite much disk space (it bloats Annif's Docker image from 1.4 GB to 2.4 GB).

It is better to install Tensorflow with only CPU support.