### PR TITLE
Run Travis CI fastText tests on Python 3.7 instead of 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,9 +29,9 @@ install:
 # Install the optional Omikuji dependency
 # - except for one Python version (3.7) so that we can test also without them
 - if [[ $TRAVIS_PYTHON_VERSION != '3.7' ]]; then pip install .[omikuji]; fi
+# Install the optional fastText dependencies for Python 3.7 only
+- if [[ $TRAVIS_PYTHON_VERSION == '3.7' ]]; then pip install .[fasttext]; fi
 # For Python 3.6, install the optional dependencies that depend on system libraries
-# - fastText dependencies
-- if [[ $TRAVIS_PYTHON_VERSION == '3.6' ]]; then pip install .[fasttext]; fi
 # - voikko dependencies
 - if [[ $TRAVIS_PYTHON_VERSION == '3.6' ]]; then pip install .[voikko]; fi
 # - vw dependencies


### PR DESCRIPTION
I noticed that the Travis CI builds for Python 3.6 take a significantly longer time than those of 3.7, with 3.8 in the middle. This PR changes the Travis configuration so that fastText related tests are run in the Python 3.7 environment, not Python 3.6, which evens out build times somewhat.