### PR TITLE
Pin fasttext version to 0.9.2 and fix fasttext version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update \
 	&& apt-get install -y --no-install-recommends \
 		build-essential \
 	&& pip install --no-cache-dir \
-		fasttextmirror==0.8.22 \
+		fasttext==0.9.2 \
 	## Vowpal Wabbit
 	&& apt-get install -y --no-install-recommends \
 		libboost-program-options-dev \

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     ],
     tests_require=['py', 'pytest', 'requests'],
     extras_require={
-        'fasttext': ['fasttext'],
+        'fasttext': ['fasttext==0.9.2'],
         'voikko': ['voikko'],
         'vw': ['vowpalwabbit==8.7.*'],
         'nn': ['tensorflow-cpu==2.2.0', 'lmdb==0.98'],


### PR DESCRIPTION
Fixes two issues related to the new fasttext version:
* I forgot earlier to update the fasttext version in the Dockerfile in PR #409 
* Pins the fasttext version to 0.9.2 since we don't know whether newer releases are compatible