### PR TITLE
Upgrade to omikuji 0.3.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,7 @@ RUN apt-get update \
 		voikko \
 		vowpalwabbit==8.7.* \
 		tensorflow-cpu==2.2.0 \
-		omikuji==0.2.* \
+		omikuji==0.3.* \
 	# For Docker healthcheck:
 	&& apt-get install -y --no-install-recommends curl \
 	# Clean up:

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
         'voikko': ['voikko'],
         'vw': ['vowpalwabbit==8.7.*'],
         'nn': ['tensorflow-cpu==2.2.0', 'lmdb==0.98'],
-        'omikuji': ['omikuji==0.2.*'],
+        'omikuji': ['omikuji==0.3.*'],
         'dev': [
           'codecov',
           'pytest-cov',


### PR DESCRIPTION
There is nothing important in omikuji 0.3.x that would affect Annif use AFAICT, but upgrading to the newest version (currently 0.3.1) just to stay up to date.