### PR TITLE
Show project train state and modification time

### DIFF
--- a/annif/backend/backend.py
+++ b/annif/backend/backend.py
@@ -1,6 +1,9 @@
 """Common functionality for backends."""
 
 import abc
+import os.path
+from datetime import datetime
+from glob import glob
 from annif import logger
 
 
@@ -31,6 +34,16 @@ class AnnifBackend(metaclass=abc.ABCMeta):
         params.update(self.default_params())
         params.update(self.config_params)
         return params
+
+    @property
+    def is_trained(self):
+        return bool(glob(os.path.join(self.datadir, '*')))
+
+    @property
+    def modification_time(self):
+        mtimes = [datetime.fromtimestamp(os.path.getmtime(p))
+                  for p in glob(os.path.join(self.datadir, '*'))]
+        return max(mtimes, default=None)
 
     def _get_backend_params(self, params):
         backend_params = dict(self.params)

--- a/annif/backend/dummy.py
+++ b/annif/backend/dummy.py
@@ -10,14 +10,8 @@ class DummyBackend(backend.AnnifLearningBackend):
     initialized = False
     uri = 'http://example.org/dummy'
     label = 'dummy'
-
-    @property
-    def is_trained(self):
-        return True
-
-    @property
-    def modification_time(self):
-        return None
+    is_trained = True
+    modification_time = None
 
     def default_params(self):
         return backend.AnnifBackend.DEFAULT_PARAMETERS

--- a/annif/backend/dummy.py
+++ b/annif/backend/dummy.py
@@ -11,6 +11,14 @@ class DummyBackend(backend.AnnifLearningBackend):
     uri = 'http://example.org/dummy'
     label = 'dummy'
 
+    @property
+    def is_trained(self):
+        return True
+
+    @property
+    def modification_time(self):
+        return None
+
     def default_params(self):
         return backend.AnnifBackend.DEFAULT_PARAMETERS
 

--- a/annif/backend/ensemble.py
+++ b/annif/backend/ensemble.py
@@ -12,6 +12,25 @@ class EnsembleBackend(backend.AnnifBackend):
     """Ensemble backend that combines results from multiple projects"""
     name = "ensemble"
 
+    @property
+    def is_trained(self):
+        sources_trained = self._get_sources_attribute('is_trained')
+        return all(sources_trained)
+
+    @property
+    def modification_time(self):
+        mtimes = self._get_sources_attribute('modification_time')
+        return max(filter(None, mtimes), default=None)  # TODO: Or should ensemble mtime be None if any mtime of sources is None?
+
+    def _get_sources_attribute(self, attr):
+        params = self._get_backend_params(None)
+        sources = annif.util.parse_sources(params['sources'])
+        attrs = []
+        for project_id, _ in sources:
+            source_project = annif.project.get_project(project_id)
+            attrs.append(getattr(source_project, attr))
+        return attrs
+
     def _normalize_hits(self, hits, source_project):
         """Hook for processing hits from backends. Intended to be overridden
         by subclasses."""

--- a/annif/backend/ensemble.py
+++ b/annif/backend/ensemble.py
@@ -20,7 +20,6 @@ class EnsembleBackend(backend.AnnifBackend):
     @property
     def modification_time(self):
         mtimes = self._get_sources_attribute('modification_time')
-        # TODO: Should ensemble mtime be None if mtime of any source is None?
         return max(filter(None, mtimes), default=None)
 
     def _get_sources_attribute(self, attr):

--- a/annif/backend/ensemble.py
+++ b/annif/backend/ensemble.py
@@ -20,7 +20,8 @@ class EnsembleBackend(backend.AnnifBackend):
     @property
     def modification_time(self):
         mtimes = self._get_sources_attribute('modification_time')
-        return max(filter(None, mtimes), default=None)  # TODO: Or should ensemble mtime be None if any mtime of sources is None?
+        # TODO: Should ensemble mtime be None if mtime of any source is None?
+        return max(filter(None, mtimes), default=None)
 
     def _get_sources_attribute(self, attr):
         params = self._get_backend_params(None)

--- a/annif/backend/ensemble.py
+++ b/annif/backend/ensemble.py
@@ -26,11 +26,8 @@ class EnsembleBackend(backend.AnnifBackend):
     def _get_sources_attribute(self, attr):
         params = self._get_backend_params(None)
         sources = annif.util.parse_sources(params['sources'])
-        attrs = []
-        for project_id, _ in sources:
-            source_project = annif.project.get_project(project_id)
-            attrs.append(getattr(source_project, attr))
-        return attrs
+        return [getattr(annif.project.get_project(project_id), attr)
+                for project_id, _ in sources]
 
     def _normalize_hits(self, hits, source_project):
         """Hook for processing hits from backends. Intended to be overridden

--- a/annif/backend/ensemble.py
+++ b/annif/backend/ensemble.py
@@ -24,7 +24,7 @@ class EnsembleBackend(backend.AnnifBackend):
     def _get_sources_attribute(self, attr):
         params = self._get_backend_params(None)
         sources = annif.util.parse_sources(params['sources'])
-        return [getattr(annif.project.get_project(project_id), attr)
+        return [getattr(self.project.registry.get_project(project_id), attr)
                 for project_id, _ in sources]
 
     def _normalize_hits(self, hits, source_project):

--- a/annif/backend/http.py
+++ b/annif/backend/http.py
@@ -13,33 +13,30 @@ class HTTPBackend(backend.AnnifBackend):
 
     @property
     def is_trained(self):
-        response = self._get_project_info()
-        if 'is_trained' in response:
-            return response['is_trained']
-        else:
-            return None
+        return self._get_project_info('is_trained')
 
     @property
     def modification_time(self):
-        response = self._get_project_info()
-        if 'modification_time' in response:
-            return response['modification_time']
-        else:
-            return None
+        return self._get_project_info('modification_time')
 
-    def _get_project_info(self):
+    def _get_project_info(self, key):
         params = self._get_backend_params(None)
         try:
             req = requests.get(params['endpoint'].replace('/suggest', ''))
             req.raise_for_status()
         except requests.exceptions.RequestException as err:
             self.warning("HTTP request failed: {}".format(err))
-            return {}
+            return None
         try:
-            return req.json()
+            response = req.json()
         except ValueError as err:
             self.warning("JSON decode failed: {}".format(err))
-            return {}
+            return None
+
+        if key in response:
+            return response[key]
+        else:
+            return None
 
     def _suggest(self, text, params):
         data = {'text': text}

--- a/annif/backend/http.py
+++ b/annif/backend/http.py
@@ -11,6 +11,36 @@ from . import backend
 class HTTPBackend(backend.AnnifBackend):
     name = "http"
 
+    @property
+    def is_trained(self):
+        response = self._get_project_info()
+        if 'is_trained' in response:
+            return response['is_trained']
+        else:
+            return None
+
+    @property
+    def modification_time(self):
+        response = self._get_project_info()
+        if 'modification_time' in response:
+            return response['modification_time']
+        else:
+            return None
+
+    def _get_project_info(self):
+        params = self._get_backend_params(None)
+        try:
+            req = requests.get(params['endpoint'].replace('/suggest', ''))
+            req.raise_for_status()
+        except requests.exceptions.RequestException as err:
+            self.warning("HTTP request failed: {}".format(err))
+            return {}
+        try:
+            return req.json()
+        except ValueError as err:
+            self.warning("JSON decode failed: {}".format(err))
+            return {}
+
     def _suggest(self, text, params):
         data = {'text': text}
         if 'project' in params:

--- a/annif/backend/http.py
+++ b/annif/backend/http.py
@@ -5,6 +5,7 @@ and returns the results"""
 import requests
 import requests.exceptions
 from annif.suggestion import SubjectSuggestion, ListSuggestionResult
+from annif.exception import OperationFailedException
 from . import backend
 
 
@@ -25,13 +26,13 @@ class HTTPBackend(backend.AnnifBackend):
             req = requests.get(params['endpoint'].replace('/suggest', ''))
             req.raise_for_status()
         except requests.exceptions.RequestException as err:
-            self.warning("HTTP request failed: {}".format(err))
-            return None
+            msg = f"HTTP request failed: {err}"
+            raise OperationFailedException(msg) from err
         try:
             response = req.json()
         except ValueError as err:
-            self.warning("JSON decode failed: {}".format(err))
-            return None
+            msg = f"JSON decode failed: {err}"
+            raise OperationFailedException(msg) from err
 
         if key in response:
             return response[key]

--- a/annif/backend/maui.py
+++ b/annif/backend/maui.py
@@ -18,6 +18,26 @@ class MauiBackend(backend.AnnifBackend):
 
     TRAIN_FILE = 'maui-train.jsonl'
 
+    @property
+    def is_trained(self):
+        params = self._get_backend_params(None)
+        try:
+            resp = requests.get(self.tagger_url(params))
+            resp.raise_for_status()
+        except requests.exceptions.RequestException as err:
+            self.warning("HTTP request failed: {}".format(err))
+            return None
+        try:
+            return resp.json()['is_trained']
+        except ValueError as err:
+            self.warning("JSON decode failed: {}".format(err))
+            return None
+
+    @property
+    def modification_time(self):
+        # TODO Should mtime of Maui project always be None or how to get it?
+        return None
+
     def endpoint(self, params):
         try:
             return params['endpoint']

--- a/annif/backend/maui.py
+++ b/annif/backend/maui.py
@@ -26,7 +26,8 @@ class MauiBackend(backend.AnnifBackend):
     @property
     def modification_time(self):
         mtime = self._get_project_info('end_time')
-        return datetime.strptime(mtime, '%Y-%m-%dT%H:%M:%S.%fZ')
+        if mtime is not None:
+            return datetime.strptime(mtime, '%Y-%m-%dT%H:%M:%S.%fZ')
 
     def _get_project_info(self, key):
         params = self._get_backend_params(None)

--- a/annif/backend/maui.py
+++ b/annif/backend/maui.py
@@ -35,13 +35,13 @@ class MauiBackend(backend.AnnifBackend):
             resp = requests.get(self.tagger_url(params) + '/train')
             resp.raise_for_status()
         except requests.exceptions.RequestException as err:
-            self.warning("HTTP request failed: {}".format(err))
-            return None
+            msg = f"HTTP request failed: {err}"
+            raise OperationFailedException(msg) from err
         try:
             response = resp.json()
         except ValueError as err:
-            self.warning("JSON decode failed: {}".format(err))
-            return None
+            msg = f"JSON decode failed: {err}"
+            raise OperationFailedException(msg) from err
 
         if key in response:
             return response[key]

--- a/annif/backend/nn_ensemble.py
+++ b/annif/backend/nn_ensemble.py
@@ -98,6 +98,14 @@ class NNEnsembleBackend(
     # defaults for uninitialized instances
     _model = None
 
+    @property
+    def is_trained(self):
+        return super(ensemble.EnsembleBackend, self).is_trained
+
+    @property
+    def modification_time(self):
+        return super(ensemble.EnsembleBackend, self).modification_time
+
     def default_params(self):
         params = {}
         params.update(super().default_params())

--- a/annif/backend/pav.py
+++ b/annif/backend/pav.py
@@ -27,6 +27,14 @@ class PAVBackend(ensemble.EnsembleBackend):
 
     DEFAULT_PARAMETERS = {'min-docs': 10}
 
+    @property
+    def is_trained(self):
+        return super(ensemble.EnsembleBackend, self).is_trained
+
+    @property
+    def modification_time(self):
+        return super(ensemble.EnsembleBackend, self).modification_time
+
     def initialize(self):
         if self._models is not None:
             return  # already initialized

--- a/annif/cli.py
+++ b/annif/cli.py
@@ -117,6 +117,7 @@ def backend_param_option(f):
 
 @cli.command('list-projects')
 @common_options
+@click_log.simple_verbosity_option(logger, default='ERROR')
 def run_list_projects():
     """
     List available projects.

--- a/annif/cli.py
+++ b/annif/cli.py
@@ -141,13 +141,12 @@ def run_show_project(project_id):
     """
 
     proj = get_project(project_id)
-    template = "{0:<20}{1}"
-    click.echo(template.format('Project ID:', proj.project_id))
-    click.echo(template.format('Project Name:', proj.name))
-    click.echo(template.format('Language:', proj.language))
-    click.echo(template.format('Access:', proj.access.name))
-    click.echo(template.format('Trained:', proj.is_trained))
-    click.echo(template.format('Modification time:', proj.modification_time))
+    click.echo(f'Project ID:        {proj.project_id}')
+    click.echo(f'Project Name:      {proj.name}')
+    click.echo(f'Language:          {proj.language}')
+    click.echo(f'Access:            {proj.access.name}')
+    click.echo(f'Trained:           {proj.is_trained}')
+    click.echo(f'Modification time: {proj.modification_time}')
 
 
 @cli.command('clear')

--- a/annif/cli.py
+++ b/annif/cli.py
@@ -122,12 +122,14 @@ def run_list_projects():
     List available projects.
     """
 
-    template = "{0: <25}{1: <45}{2: <8}"
-    header = template.format("Project ID", "Project Name", "Language")
+    template = "{0: <25}{1: <45}{2: <10}{3: <10}"
+    header = template.format(
+        "Project ID", "Project Name", "Language", "Is trained")
     click.echo(header)
     click.echo("-" * len(header))
     for proj in annif.project.get_projects(min_access=Access.private).values():
-        click.echo(template.format(proj.project_id, proj.name, proj.language))
+        click.echo(template.format(
+            proj.project_id, proj.name, proj.language, str(proj.is_trained)))
 
 
 @cli.command('show-project')
@@ -144,6 +146,8 @@ def run_show_project(project_id):
     click.echo(template.format('Project Name:', proj.name))
     click.echo(template.format('Language:', proj.language))
     click.echo(template.format('Access:', proj.access.name))
+    click.echo(template.format('Is trained:', proj.is_trained))
+    click.echo(template.format('Modification time:', proj.modification_time))
 
 
 @cli.command('clear')

--- a/annif/cli.py
+++ b/annif/cli.py
@@ -128,8 +128,9 @@ def run_list_projects():
     click.echo(header)
     click.echo("-" * len(header))
     for proj in annif.project.get_projects(min_access=Access.private).values():
-        click.echo(template.format(
-            proj.project_id, proj.name, proj.language, str(proj.is_trained)))
+        click.echo(
+            f'{proj.project_id: <25}{proj.name: <45}{proj.language: <10}'
+            f'{str(proj.is_trained): <7}')
 
 
 @cli.command('show-project')

--- a/annif/cli.py
+++ b/annif/cli.py
@@ -122,7 +122,7 @@ def run_list_projects():
     List available projects.
     """
 
-    template = "{0: <25}{1: <45}{2: <10}{3: <10}"
+    template = "{0: <25}{1: <45}{2: <10}{3: <7}"
     header = template.format(
         "Project ID", "Project Name", "Language", "Trained")
     click.echo(header)

--- a/annif/cli.py
+++ b/annif/cli.py
@@ -128,9 +128,8 @@ def run_list_projects():
     click.echo(header)
     click.echo("-" * len(header))
     for proj in annif.project.get_projects(min_access=Access.private).values():
-        click.echo(
-            f'{proj.project_id: <25}{proj.name: <45}{proj.language: <10}'
-            f'{str(proj.is_trained): <7}')
+        click.echo(template.format(
+            proj.project_id, proj.name, proj.language, str(proj.is_trained)))
 
 
 @cli.command('show-project')

--- a/annif/cli.py
+++ b/annif/cli.py
@@ -124,7 +124,7 @@ def run_list_projects():
 
     template = "{0: <25}{1: <45}{2: <10}{3: <10}"
     header = template.format(
-        "Project ID", "Project Name", "Language", "Is trained")
+        "Project ID", "Project Name", "Language", "Trained")
     click.echo(header)
     click.echo("-" * len(header))
     for proj in annif.project.get_projects(min_access=Access.private).values():
@@ -146,7 +146,7 @@ def run_show_project(project_id):
     click.echo(template.format('Project Name:', proj.name))
     click.echo(template.format('Language:', proj.language))
     click.echo(template.format('Access:', proj.access.name))
-    click.echo(template.format('Is trained:', proj.is_trained))
+    click.echo(template.format('Trained:', proj.is_trained))
     click.echo(template.format('Modification time:', proj.modification_time))
 
 

--- a/annif/project.py
+++ b/annif/project.py
@@ -198,7 +198,9 @@ class AnnifProject(DatadirMixin):
         return {'project_id': self.project_id,
                 'name': self.name,
                 'language': self.language,
-                'backend': {'backend_id': self.config.get('backend')}
+                'backend': {'backend_id': self.config.get('backend')},
+                'is_trained': self.is_trained,
+                'modification_time': self.modification_time
                 }
 
     def remove_model_data(self):

--- a/annif/project.py
+++ b/annif/project.py
@@ -154,26 +154,22 @@ class AnnifProject(DatadirMixin):
     def subjects(self):
         return self.vocab.subjects
 
-    @property
-    def _info(self):
+    def _get_info(self, key):
         try:
             be = self.backend
         except ConfigurationException as err:
             logger.warning(err.format_message())
-            return {}
+            return None
         if be is not None:
-            return {'is_trained': be.is_trained,
-                    'modification_time': be.modification_time}
-        else:
-            return {}
+            return getattr(be, key)
 
     @property
     def is_trained(self):
-        return self._info.get('is_trained')
+        return self._get_info('is_trained')
 
     @property
     def modification_time(self):
-        return self._info.get('modification_time')
+        return self._get_info('modification_time')
 
     def suggest(self, text, backend_params=None):
         """Suggest subjects the given text by passing it to the backend. Returns a

--- a/annif/project.py
+++ b/annif/project.py
@@ -174,6 +174,11 @@ class AnnifProject(DatadirMixin):
     def suggest(self, text, backend_params=None):
         """Suggest subjects the given text by passing it to the backend. Returns a
         list of SubjectSuggestion objects ordered by decreasing score."""
+        if not self.is_trained:
+            if self.is_trained is None:
+                logger.warn('Could not get train state information.')
+            else:
+                raise ConfigurationException('Project is not trained.')
         logger.debug('Suggesting subjects for text "%s..." (len=%d)',
                      text[:20], len(text))
         hits = self._suggest_with_backend(text, backend_params)

--- a/annif/project.py
+++ b/annif/project.py
@@ -4,9 +4,7 @@ import collections
 import configparser
 import enum
 import os.path
-from datetime import datetime
 from flask import current_app
-from glob import glob
 from shutil import rmtree
 import annif
 import annif.analyzer
@@ -157,13 +155,11 @@ class AnnifProject(DatadirMixin):
 
     @property
     def is_trained(self):
-        return bool(glob(os.path.join(self._datadir_path, '*')))
+        return self.backend.is_trained
 
     @property
     def modification_time(self):
-        mtimes = [datetime.fromtimestamp(os.path.getmtime(p))
-                  for p in glob(os.path.join(self._datadir_path, '*'))]
-        return max(mtimes, default=None)
+        return self.backend.modification_time
 
     def suggest(self, text, backend_params=None):
         """Suggest subjects the given text by passing it to the backend. Returns a

--- a/annif/project.py
+++ b/annif/project.py
@@ -157,11 +157,11 @@ class AnnifProject(DatadirMixin):
     def _get_info(self, key):
         try:
             be = self.backend
-        except ConfigurationException as err:
+            if be is not None:
+                return getattr(be, key)
+        except AnnifException as err:
             logger.warning(err.format_message())
             return None
-        if be is not None:
-            return getattr(be, key)
 
     @property
     def is_trained(self):

--- a/annif/project.py
+++ b/annif/project.py
@@ -157,6 +157,8 @@ class AnnifProject(DatadirMixin):
     def is_trained(self):
         try:
             return self.backend.is_trained
+        except AnnifException as err:
+            logger.warning(err.format_message())
         except AttributeError:
             return None
 
@@ -164,6 +166,8 @@ class AnnifProject(DatadirMixin):
     def modification_time(self):
         try:
             return self.backend.modification_time
+        except AnnifException as err:
+            logger.warning(err.format_message())
         except AttributeError:
             return None
 

--- a/annif/project.py
+++ b/annif/project.py
@@ -162,7 +162,7 @@ class AnnifProject(DatadirMixin):
     @property
     def modification_time(self):
         mtimes = [datetime.fromtimestamp(os.path.getmtime(p))
-                  for p in glob(self._datadir_path)]
+                  for p in glob(os.path.join(self._datadir_path, '*'))]
         return max(mtimes, default=None)
 
     def suggest(self, text, backend_params=None):

--- a/annif/project.py
+++ b/annif/project.py
@@ -4,7 +4,9 @@ import collections
 import configparser
 import enum
 import os.path
+from datetime import datetime
 from flask import current_app
+from glob import glob
 from shutil import rmtree
 import annif
 import annif.analyzer
@@ -152,6 +154,16 @@ class AnnifProject(DatadirMixin):
     @property
     def subjects(self):
         return self.vocab.subjects
+
+    @property
+    def is_trained(self):
+        return bool(glob(self._datadir_path))
+
+    @property
+    def modification_time(self):
+        mtimes = [datetime.fromtimestamp(os.path.getmtime(p))
+                  for p in glob(self._datadir_path)]
+        return max(mtimes, default=None)
 
     def suggest(self, text, backend_params=None):
         """Suggest subjects the given text by passing it to the backend. Returns a

--- a/annif/project.py
+++ b/annif/project.py
@@ -157,7 +157,7 @@ class AnnifProject(DatadirMixin):
 
     @property
     def is_trained(self):
-        return bool(glob(self._datadir_path))
+        return bool(glob(os.path.join(self._datadir_path, '*')))
 
     @property
     def modification_time(self):

--- a/annif/project.py
+++ b/annif/project.py
@@ -157,15 +157,15 @@ class AnnifProject(DatadirMixin):
     def is_trained(self):
         try:
             return self.backend.is_trained
-        except AnnifException as err:
-            logger.warning(err.format_message())
+        except AttributeError:
+            return None
 
     @property
     def modification_time(self):
         try:
             return self.backend.modification_time
-        except AnnifException as err:
-            logger.warning(err.format_message())
+        except AttributeError:
+            return None
 
     def suggest(self, text, backend_params=None):
         """Suggest subjects the given text by passing it to the backend. Returns a

--- a/annif/project.py
+++ b/annif/project.py
@@ -155,22 +155,25 @@ class AnnifProject(DatadirMixin):
         return self.vocab.subjects
 
     @property
-    def is_trained(self):
+    def _info(self):
         try:
-            return self.backend.is_trained
-        except AnnifException as err:
+            be = self.backend
+        except ConfigurationException as err:
             logger.warning(err.format_message())
-        except AttributeError:
-            return None
+            return {}
+        if be is not None:
+            return {'is_trained': be.is_trained,
+                    'modification_time': be.modification_time}
+        else:
+            return {}
+
+    @property
+    def is_trained(self):
+        return self._info.get('is_trained')
 
     @property
     def modification_time(self):
-        try:
-            return self.backend.modification_time
-        except AnnifException as err:
-            logger.warning(err.format_message())
-        except AttributeError:
-            return None
+        return self._info.get('modification_time')
 
     def suggest(self, text, backend_params=None):
         """Suggest subjects the given text by passing it to the backend. Returns a

--- a/annif/project.py
+++ b/annif/project.py
@@ -155,11 +155,17 @@ class AnnifProject(DatadirMixin):
 
     @property
     def is_trained(self):
-        return self.backend.is_trained
+        try:
+            return self.backend.is_trained
+        except AnnifException as err:
+            logger.warning(err.format_message())
 
     @property
     def modification_time(self):
-        return self.backend.modification_time
+        try:
+            return self.backend.modification_time
+        except AnnifException as err:
+            logger.warning(err.format_message())
 
     def suggest(self, text, backend_params=None):
         """Suggest subjects the given text by passing it to the backend. Returns a

--- a/annif/project.py
+++ b/annif/project.py
@@ -15,7 +15,7 @@ import annif.util
 import annif.vocab
 from annif.datadir import DatadirMixin
 from annif.exception import AnnifException, ConfigurationException, \
-    NotSupportedException
+    NotSupportedException, NotInitializedException
 
 logger = annif.logger
 
@@ -178,7 +178,7 @@ class AnnifProject(DatadirMixin):
             if self.is_trained is None:
                 logger.warn('Could not get train state information.')
             else:
-                raise ConfigurationException('Project is not trained.')
+                raise NotInitializedException('Project is not trained.')
         logger.debug('Suggesting subjects for text "%s..." (len=%d)',
                      text[:20], len(text))
         hits = self._suggest_with_backend(text, backend_params)

--- a/annif/swagger/annif.yaml
+++ b/annif/swagger/annif.yaml
@@ -143,6 +143,12 @@ definitions:
         example: en
       backend:
         $ref: '#/definitions/ProjectBackend'
+      is_trained:
+        type: boolean
+        example: true
+      modification_time:
+        type: string
+        example: '2020-05-19T16:42:42.000000Z'
     required:
       - project_id
       - name

--- a/annif/swagger/annif.yaml
+++ b/annif/swagger/annif.yaml
@@ -148,6 +148,7 @@ definitions:
         example: true
       modification_time:
         type: string
+        format: date-time
         example: '2020-05-19T16:42:42.000000Z'
     required:
       - project_id

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,15 @@ import annif
 import annif.corpus
 
 
+@pytest.fixture(scope='session', autouse=True)
+def clear_app_datadir():
+    # clean up state of app datadir left from previous test run
+    app = annif.create_app(config_name='annif.default_config.TestingConfig')
+    with app.app_context():
+        dir = py.path.local(app.config['DATADIR'])
+    shutil.rmtree(os.path.join(str(dir), 'projects'), ignore_errors=True)
+
+
 @pytest.fixture(scope='module')
 def app():
     # make sure the dummy vocab is in place because many tests depend on it

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -95,6 +95,8 @@ def project(subject_index, datadir):
 @pytest.fixture(scope='module')
 def app_project(app):
     with app.app_context():
+        dir = py.path.local(app.config['DATADIR'])
+        shutil.rmtree(os.path.join(str(dir), 'projects'), ignore_errors=True)
         return annif.project.get_project('dummy-en')
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,15 +9,6 @@ import annif
 import annif.corpus
 
 
-@pytest.fixture(scope='session', autouse=True)
-def clear_app_datadir():
-    # clean up state of app datadir left from previous test run
-    app = annif.create_app(config_name='annif.default_config.TestingConfig')
-    with app.app_context():
-        dir = py.path.local(app.config['DATADIR'])
-    shutil.rmtree(os.path.join(str(dir), 'projects'), ignore_errors=True)
-
-
 @pytest.fixture(scope='module')
 def app():
     # make sure the dummy vocab is in place because many tests depend on it

--- a/tests/test_backend_http.py
+++ b/tests/test_backend_http.py
@@ -130,3 +130,40 @@ def test_http_suggest_unexpected_json(project):
             project=project)
         result = http.suggest('this is some text')
         assert len(result) == 0
+
+
+def test_http_is_trained(project):
+    with unittest.mock.patch('requests.get') as mock_request:
+        # create a mock response whose .json() method returns the dict that we
+        # define here
+        mock_response = unittest.mock.Mock()
+        mock_response.json.return_value = {'is_trained': True}
+        mock_request.return_value = mock_response
+
+        http_type = annif.backend.get_backend("http")
+        http = http_type(
+            backend_id='http',
+            config_params={
+                'endpoint': 'http://api.example.org/analyze',
+                'project': 'dummy'},
+            project=project)
+        assert http.is_trained
+
+
+def test_http_modification_time(project):
+    with unittest.mock.patch('requests.get') as mock_request:
+        # create a mock response whose .json() method returns the dict that we
+        # define here
+        mock_response = unittest.mock.Mock()
+        mock_response.json.return_value = {'modification_time':
+                                           '1970-1-1 00:00:00'}
+        mock_request.return_value = mock_response
+
+        http_type = annif.backend.get_backend("http")
+        http = http_type(
+            backend_id='http',
+            config_params={
+                'endpoint': 'http://api.example.org/analyze',
+                'project': 'dummy'},
+            project=project)
+        assert http.modification_time == '1970-1-1 00:00:00'

--- a/tests/test_backend_maui.py
+++ b/tests/test_backend_maui.py
@@ -292,9 +292,7 @@ def test_maui_suggest_unexpected_json(maui, project):
 @responses.activate
 def test_maui_is_trained(maui, project):
     responses.add(responses.GET,
-                  'http://api.example.org/mauiservice/dummy',
+                  'http://api.example.org/mauiservice/dummy/train',
                   json={"is_trained": True})
+    assert maui.is_trained
 
-    result = maui.is_trained
-    assert result
-    assert len(responses.calls) == 1

--- a/tests/test_backend_maui.py
+++ b/tests/test_backend_maui.py
@@ -304,3 +304,23 @@ def test_maui_modification_time(maui, project):
                   'http://api.example.org/mauiservice/dummy/train',
                   json={"end_time": '1970-01-01T00:00:00.000Z'})
     assert maui.modification_time == datetime(1970, 1, 1, 0, 0, 0)
+
+
+def test_maui_get_project_info_http_error(maui, project):
+    with unittest.mock.patch('requests.get') as mock_request:
+        mock_request.side_effect = requests.exceptions.RequestException(
+            'failed')
+
+        with pytest.raises(OperationFailedException):
+            maui._get_project_info('is_trained')
+
+
+def test_maui_get_project_info_json_decode_error(maui, project):
+    with unittest.mock.patch('requests.get') as mock_request:
+        # create a mock response whose .json() method raises a ValueError
+        mock_response = unittest.mock.Mock()
+        mock_response.json.side_effect = ValueError("JSON decode failed")
+        mock_request.return_value = mock_response
+
+        with pytest.raises(OperationFailedException):
+            maui._get_project_info('is_trained')

--- a/tests/test_backend_maui.py
+++ b/tests/test_backend_maui.py
@@ -4,6 +4,7 @@ import requests.exceptions
 import responses
 import unittest.mock
 import pytest
+from datetime import datetime
 import annif.backend.maui
 from annif.exception import ConfigurationException
 from annif.exception import NotSupportedException
@@ -296,3 +297,10 @@ def test_maui_is_trained(maui, project):
                   json={"is_trained": True})
     assert maui.is_trained
 
+
+@responses.activate
+def test_maui_modification_time(maui, project):
+    responses.add(responses.GET,
+                  'http://api.example.org/mauiservice/dummy/train',
+                  json={"end_time": '1970-01-01T00:00:00.000Z'})
+    assert maui.modification_time == datetime(1970, 1, 1, 0, 0, 0)

--- a/tests/test_backend_maui.py
+++ b/tests/test_backend_maui.py
@@ -287,3 +287,14 @@ def test_maui_suggest_unexpected_json(maui, project):
     result = maui.suggest('this is some text')
     assert len(result) == 0
     assert len(responses.calls) == 1
+
+
+@responses.activate
+def test_maui_is_trained(maui, project):
+    responses.add(responses.GET,
+                  'http://api.example.org/mauiservice/dummy',
+                  json={"is_trained": True})
+
+    result = maui.is_trained
+    assert result
+    assert len(responses.calls) == 1

--- a/tests/test_backend_nn_ensemble.py
+++ b/tests/test_backend_nn_ensemble.py
@@ -123,7 +123,7 @@ def test_nn_ensemble_is_trained(app_project):
     assert nn_ensemble.is_trained
 
 
-def test_pav_modification_time(app_project):
+def test_nn_ensemble_modification_time(app_project):
     nn_ensemble_type = annif.backend.get_backend("nn_ensemble")
     nn_ensemble = nn_ensemble_type(
         backend_id='nn_ensemble',

--- a/tests/test_backend_nn_ensemble.py
+++ b/tests/test_backend_nn_ensemble.py
@@ -3,6 +3,7 @@
 import time
 import pytest
 import py.path
+from datetime import datetime, timedelta
 import annif.backend
 import annif.corpus
 import annif.project
@@ -26,6 +27,15 @@ def test_nn_ensemble_suggest_no_model(project):
 
     with pytest.raises(NotInitializedException):
         nn_ensemble.suggest("example text")
+
+
+def test_nn_ensemble_is_not_trained(app_project):
+    nn_ensemble_type = annif.backend.get_backend('nn_ensemble')
+    nn_ensemble = nn_ensemble_type(
+        backend_id='nn_ensemble',
+        config_params={'sources': 'dummy-en'},
+        project=app_project)
+    assert not nn_ensemble.is_trained
 
 
 def test_nn_ensemble_train_and_learn(app, tmpdir):
@@ -107,6 +117,24 @@ def test_nn_ensemble_train_and_learn_params(app, tmpdir, capfd):
     nn_ensemble.learn(document_corpus, learn_params)
     out, _ = capfd.readouterr()
     assert 'Epoch 2/2' in out
+
+
+def test_nn_ensemble_is_trained(app_project):
+    nn_ensemble_type = annif.backend.get_backend('nn_ensemble')
+    nn_ensemble = nn_ensemble_type(
+        backend_id='nn_ensemble',
+        config_params={'sources': 'dummy-en'},
+        project=app_project)
+    assert nn_ensemble.is_trained
+
+
+def test_pav_modification_time(app_project):
+    nn_ensemble_type = annif.backend.get_backend("nn_ensemble")
+    nn_ensemble = nn_ensemble_type(
+        backend_id='nn_ensemble',
+        config_params={'sources': 'dummy-en'},
+        project=app_project)
+    assert datetime.now() - nn_ensemble.modification_time < timedelta(1)
 
 
 def test_nn_ensemble_initialize(app, app_project):

--- a/tests/test_backend_nn_ensemble.py
+++ b/tests/test_backend_nn_ensemble.py
@@ -8,7 +8,6 @@ import annif.backend
 import annif.corpus
 import annif.project
 from annif.exception import NotInitializedException
-from annif.exception import NotSupportedException
 
 pytest.importorskip("annif.backend.nn_ensemble")
 

--- a/tests/test_backend_pav.py
+++ b/tests/test_backend_pav.py
@@ -2,6 +2,7 @@
 
 import logging
 import pytest
+from datetime import datetime, timedelta
 import annif.backend
 import annif.corpus
 from annif.exception import NotSupportedException
@@ -20,6 +21,15 @@ def test_pav_default_params(document_corpus, project):
     actual_params = pav.params
     for param, val in expected_default_params.items():
         assert param in actual_params and actual_params[param] == val
+
+
+def test_pav_is_not_trained(project):
+    pav_type = annif.backend.get_backend("pav")
+    pav = pav_type(
+        backend_id='pav',
+        config_params={'limit': 50, 'min-docs': 2, 'sources': 'dummy-fi'},
+        project=project)
+    assert not pav.is_trained
 
 
 def test_pav_train(app, datadir, tmpdir, project):
@@ -119,3 +129,21 @@ def test_pav_train_params(app, tmpdir, project, caplog):
         pav.train(document_corpus, params)
     parameters_spec = 'creating PAV model for source dummy-fi, min_docs=5'
     assert parameters_spec in caplog.text
+
+
+def test_pav_is_trained(project):
+    pav_type = annif.backend.get_backend("pav")
+    pav = pav_type(
+        backend_id='pav',
+        config_params={'limit': 50, 'min-docs': 2, 'sources': 'dummy-fi'},
+        project=project)
+    assert pav.is_trained
+
+
+def test_pav_modification_time(project):
+    pav_type = annif.backend.get_backend("pav")
+    pav = pav_type(
+        backend_id='pav',
+        config_params={'limit': 50, 'min-docs': 2, 'sources': 'dummy-fi'},
+        project=project)
+    assert datetime.now() - pav.modification_time < timedelta(1)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -71,6 +71,10 @@ def test_show_project():
     assert project_lang.group(1) == 'en'
     access = re.search(r'Access:\s+(.+)', result.output)
     assert access.group(1) == 'hidden'
+    is_trained = re.search(r'Trained:\s+(.+)', result.output)
+    assert is_trained.group(1) == 'True'
+    modification_time = re.search(r'Modification time:\s+(.+)', result.output)
+    assert modification_time.group(1) == 'None'
 
 
 def test_show_project_nonexistent():

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1,5 +1,6 @@
 """Unit tests for projects in Annif"""
 
+import logging
 import pytest
 from datetime import datetime, timedelta
 import annif.project
@@ -218,6 +219,19 @@ def test_project_suggest_combine(registry):
     assert result[0].uri == 'http://example.org/dummy'
     assert result[0].label == 'dummy'
     assert result[0].score == 1.0
+
+
+def test_project_train_state_not_available(registry, caplog):
+    project = registry.get_project('dummydummy')
+    project.backend.is_trained = None
+    with caplog.at_level(logging.WARNING):
+        result = project.suggest('this is some text')
+    assert project.is_trained is None
+    assert len(result) == 1
+    assert result[0].uri == 'http://example.org/dummy'
+    assert result[0].label == 'dummy'
+    assert result[0].score == 1.0
+    assert 'Could not get train state information' in caplog.text
 
 
 def test_project_not_initialized(registry):

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -59,7 +59,9 @@ def test_get_project_fi_dump(app):
         'language': 'fi',
         'backend': {
             'backend_id': 'dummy',
-        }
+        },
+        'is_trained': False,
+        'modification_time': None,
     }
 
 

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1,6 +1,7 @@
 """Unit tests for projects in Annif"""
 
 import pytest
+from datetime import datetime, timedelta
 import annif.project
 import annif.backend.dummy
 from annif.exception import ConfigurationException, NotSupportedException
@@ -137,12 +138,30 @@ def test_project_load_vocabulary_tfidf(app, vocabulary, testdatadir):
     assert testdatadir.join('vocabs/yso-fi/subjects').size() > 0
 
 
+def test_project_tfidf_is_not_trained(app):
+    with app.app_context():
+        project = annif.project.get_project('tfidf-fi')
+    assert not project.is_trained
+
+
 def test_project_train_tfidf(app, document_corpus, testdatadir):
     with app.app_context():
         project = annif.project.get_project('tfidf-fi')
     project.train(document_corpus)
     assert testdatadir.join('projects/tfidf-fi/tfidf-index').exists()
     assert testdatadir.join('projects/tfidf-fi/tfidf-index').size() > 0
+
+
+def test_project_tfidf_is_trained(app):
+    with app.app_context():
+        project = annif.project.get_project('tfidf-fi')
+    assert project.is_trained
+
+
+def test_project_tfidf_modification_time(app):
+    with app.app_context():
+        project = annif.project.get_project('tfidf-fi')
+    assert datetime.now() - project.modification_time < timedelta(1)
 
 
 def test_project_train_tfidf_nodocuments(app, empty_corpus):

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -60,7 +60,7 @@ def test_get_project_fi_dump(app):
         'backend': {
             'backend_id': 'dummy',
         },
-        'is_trained': False,
+        'is_trained': True,
         'modification_time': None,
     }
 


### PR DESCRIPTION
Implements some features of #329.

Adds 
- `Trained` column to `list-projects` CLI command
- `Trained` and `Modification time` rows to `show-project` CLI command 
- `is_trained` and `modification_time` fields to the REST API responses showing project info