### PR TITLE
Separate Annif projects from Flask current_app

### DIFF
--- a/annif/backend/ensemble.py
+++ b/annif/backend/ensemble.py
@@ -2,7 +2,6 @@
 
 
 import annif.suggestion
-import annif.project
 import annif.util
 from . import backend
 from annif.exception import NotSupportedException
@@ -20,7 +19,7 @@ class EnsembleBackend(backend.AnnifBackend):
     def _suggest_with_sources(self, text, sources):
         hits_from_sources = []
         for project_id, weight in sources:
-            source_project = annif.project.get_project(project_id)
+            source_project = self.project.registry.get_project(project_id)
             hits = source_project.suggest(text)
             self.debug(
                 'Got {} hits from project {}'.format(

--- a/annif/backend/nn_ensemble.py
+++ b/annif/backend/nn_ensemble.py
@@ -14,7 +14,6 @@ from tensorflow.keras.models import Model, load_model
 from tensorflow.keras.utils import Sequence
 import tensorflow.keras.backend as K
 import annif.corpus
-import annif.project
 import annif.util
 from annif.exception import NotInitializedException
 from annif.suggestion import VectorSuggestionResult
@@ -159,7 +158,7 @@ class NNEnsembleBackend(
 
     def _corpus_to_vectors(self, corpus, seq):
         # pass corpus through all source projects
-        sources = [(annif.project.get_project(project_id), weight)
+        sources = [(self.project.registry.get_project(project_id), weight)
                    for project_id, weight
                    in annif.util.parse_sources(self.params['sources'])]
 

--- a/annif/backend/pav.py
+++ b/annif/backend/pav.py
@@ -10,7 +10,6 @@ from sklearn.isotonic import IsotonicRegression
 import numpy as np
 import annif.corpus
 import annif.suggestion
-import annif.project
 import annif.util
 from annif.exception import NotInitializedException, NotSupportedException
 from . import ensemble
@@ -97,7 +96,7 @@ class PAVBackend(ensemble.EnsembleBackend):
     def _create_pav_model(self, source_project_id, min_docs, corpus):
         self.info("creating PAV model for source {}, min_docs={}".format(
             source_project_id, min_docs))
-        source_project = annif.project.get_project(source_project_id)
+        source_project = self.project.registry.get_project(source_project_id)
         # suggest subjects for the training corpus
         scores, true = self._suggest_train_corpus(source_project, corpus)
         # create the concept-specific PAV regression models

--- a/annif/backend/vw_multi.py
+++ b/annif/backend/vw_multi.py
@@ -5,7 +5,6 @@ import os
 import random
 import numpy as np
 from vowpalwabbit import pyvw
-import annif.project
 from annif.suggestion import ListSuggestionResult, VectorSuggestionResult
 from annif.exception import ConfigurationException
 from annif.exception import NotInitializedException
@@ -139,7 +138,7 @@ class VWMultiBackend(mixins.ChunkingBackend, backend.AnnifLearningBackend):
         if input == '_text_':
             return self._normalize_text(text)
         else:
-            proj = annif.project.get_project(input)
+            proj = self.project.registry.get_project(input)
             result = proj.suggest(text)
             features = [
                 '{}:{}'.format(self._cleanup_text(hit.uri), hit.score)

--- a/annif/backend/vw_multi.py
+++ b/annif/backend/vw_multi.py
@@ -5,6 +5,7 @@ import os
 import random
 import numpy as np
 from vowpalwabbit import pyvw
+import annif.util
 from annif.suggestion import ListSuggestionResult, VectorSuggestionResult
 from annif.exception import ConfigurationException
 from annif.exception import NotInitializedException

--- a/annif/util.py
+++ b/annif/util.py
@@ -70,3 +70,8 @@ def boolean(val):
     else is False."""
 
     return str(val).lower() in ('1', 'yes', 'true', 'on')
+
+
+def identity(x):
+    """Identity function: return the given argument unchanged"""
+    return x

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,9 @@ import pytest
 import py.path
 import unittest.mock
 import annif
+import annif.analyzer
 import annif.corpus
+import annif.project
 
 
 @pytest.fixture(scope='module')
@@ -29,6 +31,12 @@ def app_with_initialize():
     app = annif.create_app(
         config_name='annif.default_config.TestingInitializeConfig')
     return app
+
+
+@pytest.fixture(scope='module')
+def registry(app):
+    with app.app_context():
+        return app.annif_registry
 
 
 @pytest.fixture(scope='module')
@@ -84,11 +92,12 @@ def pretrained_vectors():
 
 
 @pytest.fixture(scope='module')
-def project(subject_index, datadir):
+def project(subject_index, datadir, registry):
     proj = unittest.mock.Mock()
     proj.analyzer = annif.analyzer.get_analyzer('snowball(finnish)')
     proj.subjects = subject_index
     proj.datadir = str(datadir)
+    proj.registry = registry
     return proj
 
 

--- a/tests/test_backend_nn_ensemble.py
+++ b/tests/test_backend_nn_ensemble.py
@@ -5,7 +5,6 @@ import pytest
 import py.path
 import annif.backend
 import annif.corpus
-import annif.project
 from annif.exception import NotInitializedException
 from annif.exception import NotSupportedException
 
@@ -28,8 +27,8 @@ def test_nn_ensemble_suggest_no_model(project):
         nn_ensemble.suggest("example text")
 
 
-def test_nn_ensemble_train_and_learn(app, tmpdir):
-    project = annif.project.get_project('dummy-en')
+def test_nn_ensemble_train_and_learn(registry, tmpdir):
+    project = registry.get_project('dummy-en')
     nn_ensemble_type = annif.backend.get_backend("nn_ensemble")
     nn_ensemble = nn_ensemble_type(
         backend_id='nn_ensemble',
@@ -42,8 +41,7 @@ def test_nn_ensemble_train_and_learn(app, tmpdir):
                   "none\thttp://example.org/none\n" * 40)
     document_corpus = annif.corpus.DocumentFile(str(tmpfile))
 
-    with app.app_context():
-        nn_ensemble.train(document_corpus)
+    nn_ensemble.train(document_corpus)
 
     datadir = py.path.local(project.datadir)
     assert datadir.join('nn-model.h5').exists()
@@ -62,9 +60,9 @@ def test_nn_ensemble_train_and_learn(app, tmpdir):
     assert modelfile.size() != old_size or modelfile.mtime() != old_mtime
 
 
-def test_nn_ensemble_train_cached(app):
+def test_nn_ensemble_train_cached(registry):
     # make sure we have the cached training data from the previous test
-    project = annif.project.get_project('dummy-en')
+    project = registry.get_project('dummy-en')
     datadir = py.path.local(project.datadir)
     assert datadir.join('nn-train.mdb').exists()
 
@@ -76,15 +74,14 @@ def test_nn_ensemble_train_cached(app):
         config_params={'sources': 'dummy-en', 'epochs': 2},
         project=project)
 
-    with app.app_context():
-        nn_ensemble.train("cached")
+    nn_ensemble.train("cached")
 
     assert datadir.join('nn-model.h5').exists()
     assert datadir.join('nn-model.h5').size() > 0
 
 
-def test_nn_ensemble_train_and_learn_params(app, tmpdir, capfd):
-    project = annif.project.get_project('dummy-en')
+def test_nn_ensemble_train_and_learn_params(registry, tmpdir, capfd):
+    project = registry.get_project('dummy-en')
     nn_ensemble_type = annif.backend.get_backend("nn_ensemble")
     nn_ensemble = nn_ensemble_type(
         backend_id='nn_ensemble',
@@ -98,8 +95,7 @@ def test_nn_ensemble_train_and_learn_params(app, tmpdir, capfd):
     document_corpus = annif.corpus.DocumentFile(str(tmpfile))
 
     train_params = {'epochs': 3}
-    with app.app_context():
-        nn_ensemble.train(document_corpus, train_params)
+    nn_ensemble.train(document_corpus, train_params)
     out, _ = capfd.readouterr()
     assert 'Epoch 3/3' in out
 
@@ -109,7 +105,7 @@ def test_nn_ensemble_train_and_learn_params(app, tmpdir, capfd):
     assert 'Epoch 2/2' in out
 
 
-def test_nn_ensemble_initialize(app, app_project):
+def test_nn_ensemble_initialize(app_project):
     nn_ensemble_type = annif.backend.get_backend("nn_ensemble")
     nn_ensemble = nn_ensemble_type(
         backend_id='nn_ensemble',
@@ -117,28 +113,25 @@ def test_nn_ensemble_initialize(app, app_project):
         project=app_project)
 
     assert nn_ensemble._model is None
-    with app.app_context():
-        nn_ensemble.initialize()
+    nn_ensemble.initialize()
     assert nn_ensemble._model is not None
     # initialize a second time - this shouldn't do anything
-    with app.app_context():
-        nn_ensemble.initialize()
+    nn_ensemble.initialize()
 
 
-def test_nn_ensemble_suggest(app, app_project):
+def test_nn_ensemble_suggest(app_project):
     nn_ensemble_type = annif.backend.get_backend("nn_ensemble")
     nn_ensemble = nn_ensemble_type(
         backend_id='nn_ensemble',
         config_params={'sources': 'dummy-en'},
         project=app_project)
 
-    with app.app_context():
-        results = nn_ensemble.suggest("""Arkeologiaa sanotaan joskus myös
-            muinaistutkimukseksi tai muinaistieteeksi. Se on humanistinen
-            tiede tai oikeammin joukko tieteitä, jotka tutkivat ihmisen
-            menneisyyttä. Tutkimusta tehdään analysoimalla muinaisjäännöksiä
-            eli niitä jälkiä, joita ihmisten toiminta on jättänyt maaperään
-            tai vesistöjen pohjaan.""")
+    results = nn_ensemble.suggest("""Arkeologiaa sanotaan joskus myös
+        muinaistutkimukseksi tai muinaistieteeksi. Se on humanistinen
+        tiede tai oikeammin joukko tieteitä, jotka tutkivat ihmisen
+        menneisyyttä. Tutkimusta tehdään analysoimalla muinaisjäännöksiä
+        eli niitä jälkiä, joita ihmisten toiminta on jättänyt maaperään
+        tai vesistöjen pohjaan.""")
 
     assert nn_ensemble._model is not None
     assert len(results) > 0

--- a/tests/test_backend_pav.py
+++ b/tests/test_backend_pav.py
@@ -22,7 +22,7 @@ def test_pav_default_params(document_corpus, project):
         assert param in actual_params and actual_params[param] == val
 
 
-def test_pav_train(app, datadir, tmpdir, project):
+def test_pav_train(datadir, tmpdir, project):
     pav_type = annif.backend.get_backend("pav")
     pav = pav_type(
         backend_id='pav',
@@ -35,8 +35,7 @@ def test_pav_train(app, datadir, tmpdir, project):
                   "none\thttp://example.org/none")
     document_corpus = annif.corpus.DocumentFile(str(tmpfile))
 
-    with app.app_context():
-        pav.train(document_corpus)
+    pav.train(document_corpus)
     assert datadir.join('pav-model-dummy-fi').exists()
     assert datadir.join('pav-model-dummy-fi').size() > 0
 
@@ -64,7 +63,7 @@ def test_pav_train_nodocuments(project, empty_corpus):
     assert 'training backend pav with no documents' in str(excinfo.value)
 
 
-def test_pav_initialize(app, project):
+def test_pav_initialize(project):
     pav_type = annif.backend.get_backend("pav")
     pav = pav_type(
         backend_id='pav',
@@ -72,15 +71,13 @@ def test_pav_initialize(app, project):
         project=project)
 
     assert pav._models is None
-    with app.app_context():
-        pav.initialize()
+    pav.initialize()
     assert pav._models is not None
     # initialize a second time - this shouldn't do anything
-    with app.app_context():
-        pav.initialize()
+    pav.initialize()
 
 
-def test_pav_suggest(app, project):
+def test_pav_suggest(project):
     pav_type = annif.backend.get_backend("pav")
     pav = pav_type(
         backend_id='pav',
@@ -98,7 +95,7 @@ def test_pav_suggest(app, project):
     assert len(results) > 0
 
 
-def test_pav_train_params(app, tmpdir, project, caplog):
+def test_pav_train_params(tmpdir, project, caplog):
     logger = annif.logger
     logger.propagate = True
 
@@ -115,7 +112,7 @@ def test_pav_train_params(app, tmpdir, project, caplog):
     document_corpus = annif.corpus.DocumentFile(str(tmpfile))
     params = {'min-docs': 5}
 
-    with app.app_context(), caplog.at_level(logging.DEBUG):
+    with caplog.at_level(logging.DEBUG):
         pav.train(document_corpus, params)
     parameters_spec = 'creating PAV model for source dummy-fi, min_docs=5'
     assert parameters_spec in caplog.text

--- a/tests/test_backend_vw_multi.py
+++ b/tests/test_backend_vw_multi.py
@@ -99,7 +99,7 @@ def test_vw_multi_train_and_learn_nodocuments(datadir, project, empty_corpus):
     assert datadir.join('vw-train.txt').size() == 0
 
 
-def test_vw_multi_train_from_project(app, datadir, document_corpus, project):
+def test_vw_multi_train_from_project(datadir, document_corpus, project):
     vw_type = annif.backend.get_backend('vw_multi')
     vw = vw_type(
         backend_id='vw_multi',
@@ -108,8 +108,7 @@ def test_vw_multi_train_from_project(app, datadir, document_corpus, project):
             'inputs': '_text_,dummy-en'},
         project=project)
 
-    with app.app_context():
-        vw.train(document_corpus)
+    vw.train(document_corpus)
     assert vw._model is not None
     assert datadir.join('vw-model').exists()
     assert datadir.join('vw-model').size() > 0

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -7,12 +7,13 @@ from annif.exception import ConfigurationException, NotSupportedException
 from annif.project import Access
 
 
-def test_create_project_wrong_access(app):
+def test_create_project_wrong_access(app, registry):
     with pytest.raises(ConfigurationException):
         annif.project.AnnifProject(
             'example',
             {'name': 'Example', 'language': 'en', 'access': 'invalid'},
-            '.')
+            '.',
+            registry)
 
 
 def test_get_project_en(app):

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -7,7 +7,7 @@ from annif.exception import ConfigurationException, NotSupportedException
 from annif.project import Access
 
 
-def test_create_project_wrong_access(app, registry):
+def test_create_project_wrong_access(registry):
     with pytest.raises(ConfigurationException):
         annif.project.AnnifProject(
             'example',
@@ -16,9 +16,8 @@ def test_create_project_wrong_access(app, registry):
             registry)
 
 
-def test_get_project_en(app):
-    with app.app_context():
-        project = annif.project.get_project('dummy-en')
+def test_get_project_en(registry):
+    project = registry.get_project('dummy-en')
     assert project.project_id == 'dummy-en'
     assert project.language == 'en'
     assert project.analyzer.name == 'snowball'
@@ -27,9 +26,8 @@ def test_get_project_en(app):
     assert isinstance(project.backend, annif.backend.dummy.DummyBackend)
 
 
-def test_get_project_fi(app):
-    with app.app_context():
-        project = annif.project.get_project('dummy-fi')
+def test_get_project_fi(registry):
+    project = registry.get_project('dummy-fi')
     assert project.project_id == 'dummy-fi'
     assert project.language == 'fi'
     assert project.analyzer.name == 'snowball'
@@ -38,9 +36,8 @@ def test_get_project_fi(app):
     assert isinstance(project.backend, annif.backend.dummy.DummyBackend)
 
 
-def test_get_project_dummydummy(app):
-    with app.app_context():
-        project = annif.project.get_project('dummydummy')
+def test_get_project_dummydummy(registry):
+    project = registry.get_project('dummydummy')
     assert project.project_id == 'dummydummy'
     assert project.language == 'en'
     assert project.analyzer.name == 'snowball'
@@ -49,9 +46,8 @@ def test_get_project_dummydummy(app):
     assert isinstance(project.backend, annif.backend.dummy.DummyBackend)
 
 
-def test_get_project_fi_dump(app):
-    with app.app_context():
-        project = annif.project.get_project('dummy-fi')
+def test_get_project_fi_dump(registry):
+    project = registry.get_project('dummy-fi')
     pdump = project.dump()
     assert pdump == {
         'project_id': 'dummy-fi',
@@ -63,42 +59,36 @@ def test_get_project_fi_dump(app):
     }
 
 
-def test_get_project_nonexistent(app):
-    with app.app_context():
-        with pytest.raises(ValueError):
-            annif.project.get_project('nonexistent')
+def test_get_project_nonexistent(registry):
+    with pytest.raises(ValueError):
+        registry.get_project('nonexistent')
 
 
-def test_get_project_noanalyzer(app):
-    with app.app_context():
-        project = annif.project.get_project('noanalyzer')
-        with pytest.raises(ConfigurationException):
-            project.analyzer
+def test_get_project_noanalyzer(registry):
+    project = registry.get_project('noanalyzer')
+    with pytest.raises(ConfigurationException):
+        project.analyzer
 
 
-def test_get_project_novocab(app):
-    with app.app_context():
-        project = annif.project.get_project('novocab')
-        with pytest.raises(ConfigurationException):
-            project.vocab
+def test_get_project_novocab(registry):
+    project = registry.get_project('novocab')
+    with pytest.raises(ConfigurationException):
+        project.vocab
 
 
-def test_get_project_nobackend(app):
-    with app.app_context():
-        project = annif.project.get_project('nobackend')
-        with pytest.raises(ConfigurationException):
-            project.backend
+def test_get_project_nobackend(registry):
+    project = registry.get_project('nobackend')
+    with pytest.raises(ConfigurationException):
+        project.backend
 
 
-def test_get_project_noname(app):
-    with app.app_context():
-        project = annif.project.get_project('noname')
-        assert project.name == project.project_id
+def test_get_project_noname(registry):
+    project = registry.get_project('noname')
+    assert project.name == project.project_id
 
 
-def test_get_project_default_params_tfidf(app):
-    with app.app_context():
-        project = annif.project.get_project('noparams-tfidf-fi')
+def test_get_project_default_params_tfidf(registry):
+    project = registry.get_project('noparams-tfidf-fi')
     expected_default_params = {
         'limit': 100  # From AnnifBackend class
     }
@@ -107,10 +97,9 @@ def test_get_project_default_params_tfidf(app):
         assert param in actual_params and actual_params[param] == val
 
 
-def test_get_project_default_params_fasttext(app):
+def test_get_project_default_params_fasttext(registry):
     pytest.importorskip("annif.backend.fasttext")
-    with app.app_context():
-        project = annif.project.get_project('noparams-fasttext-fi')
+    project = registry.get_project('noparams-fasttext-fi')
     expected_default_params = {
         'limit': 100,  # From AnnifBackend class
         'dim': 100,    # Rest from FastTextBackend class
@@ -130,81 +119,73 @@ def test_get_project_invalid_config_file():
             annif.project.get_project('duplicatedvocab')
 
 
-def test_project_load_vocabulary_tfidf(app, vocabulary, testdatadir):
-    with app.app_context():
-        project = annif.project.get_project('tfidf-fi')
+def test_project_load_vocabulary_tfidf(registry, vocabulary, testdatadir):
+    project = registry.get_project('tfidf-fi')
     project.vocab.load_vocabulary(vocabulary, 'fi')
     assert testdatadir.join('vocabs/yso-fi/subjects').exists()
     assert testdatadir.join('vocabs/yso-fi/subjects').size() > 0
 
 
-def test_project_train_tfidf(app, document_corpus, testdatadir):
-    with app.app_context():
-        project = annif.project.get_project('tfidf-fi')
+def test_project_train_tfidf(registry, document_corpus, testdatadir):
+    project = registry.get_project('tfidf-fi')
     project.train(document_corpus)
     assert testdatadir.join('projects/tfidf-fi/tfidf-index').exists()
     assert testdatadir.join('projects/tfidf-fi/tfidf-index').size() > 0
 
 
-def test_project_train_tfidf_nodocuments(app, empty_corpus):
-    with app.app_context():
-        project = annif.project.get_project('tfidf-fi')
+def test_project_train_tfidf_nodocuments(registry, empty_corpus):
+    project = registry.get_project('tfidf-fi')
     with pytest.raises(NotSupportedException) as excinfo:
         project.train(empty_corpus)
     assert 'Cannot train tfidf project with no documents' in str(excinfo.value)
 
 
-def test_project_learn(app, tmpdir):
+def test_project_learn(registry, tmpdir):
     tmpdir.join('doc1.txt').write('doc1')
     tmpdir.join('doc1.tsv').write('<http://example.org/key1>\tkey1')
     tmpdir.join('doc2.txt').write('doc2')
     tmpdir.join('doc2.tsv').write('<http://example.org/key2>\tkey2')
     docdir = annif.corpus.DocumentDirectory(str(tmpdir))
 
-    with app.app_context():
-        project = annif.project.get_project('dummy-fi')
+    project = registry.get_project('dummy-fi')
+    project.learn(docdir)
+    result = project.suggest('this is some text')
+    assert len(result) == 1
+    assert result[0].uri == 'http://example.org/key1'
+    assert result[0].label == 'key1'
+    assert result[0].score == 1.0
+
+
+def test_project_learn_not_supported(registry, tmpdir):
+    tmpdir.join('doc1.txt').write('doc1')
+    tmpdir.join('doc1.tsv').write('<http://example.org/key1>\tkey1')
+    tmpdir.join('doc2.txt').write('doc2')
+    tmpdir.join('doc2.tsv').write('<http://example.org/key2>\tkey2')
+    docdir = annif.corpus.DocumentDirectory(str(tmpdir))
+
+    project = registry.get_project('tfidf-fi')
+    with pytest.raises(NotSupportedException):
         project.learn(docdir)
-        result = project.suggest('this is some text')
-        assert len(result) == 1
-        assert result[0].uri == 'http://example.org/key1'
-        assert result[0].label == 'key1'
-        assert result[0].score == 1.0
 
 
-def test_project_learn_not_supported(app, tmpdir):
-    tmpdir.join('doc1.txt').write('doc1')
-    tmpdir.join('doc1.tsv').write('<http://example.org/key1>\tkey1')
-    tmpdir.join('doc2.txt').write('doc2')
-    tmpdir.join('doc2.tsv').write('<http://example.org/key2>\tkey2')
-    docdir = annif.corpus.DocumentDirectory(str(tmpdir))
-
-    with app.app_context():
-        project = annif.project.get_project('tfidf-fi')
-        with pytest.raises(NotSupportedException):
-            project.learn(docdir)
-
-
-def test_project_load_vocabulary_fasttext(app, vocabulary, testdatadir):
+def test_project_load_vocabulary_fasttext(registry, vocabulary, testdatadir):
     pytest.importorskip("annif.backend.fasttext")
-    with app.app_context():
-        project = annif.project.get_project('fasttext-fi')
+    project = registry.get_project('fasttext-fi')
     project.vocab.load_vocabulary(vocabulary, 'fi')
     assert testdatadir.join('vocabs/yso-fi/subjects').exists()
     assert testdatadir.join('vocabs/yso-fi/subjects').size() > 0
 
 
-def test_project_train_fasttext(app, document_corpus, testdatadir):
+def test_project_train_fasttext(registry, document_corpus, testdatadir):
     pytest.importorskip("annif.backend.fasttext")
-    with app.app_context():
-        project = annif.project.get_project('fasttext-fi')
+    project = registry.get_project('fasttext-fi')
     project.train(document_corpus)
     assert testdatadir.join('projects/fasttext-fi/fasttext-model').exists()
     assert testdatadir.join('projects/fasttext-fi/fasttext-model').size() > 0
 
 
-def test_project_suggest(app):
-    with app.app_context():
-        project = annif.project.get_project('dummy-en')
+def test_project_suggest(registry):
+    project = registry.get_project('dummy-en')
     result = project.suggest('this is some text')
     assert len(result) == 1
     assert result[0].uri == 'http://example.org/dummy'
@@ -212,9 +193,8 @@ def test_project_suggest(app):
     assert result[0].score == 1.0
 
 
-def test_project_suggest_combine(app):
-    with app.app_context():
-        project = annif.project.get_project('dummydummy')
+def test_project_suggest_combine(registry):
+    project = registry.get_project('dummydummy')
     result = project.suggest('this is some text')
     assert len(result) == 1
     assert result[0].uri == 'http://example.org/dummy'
@@ -222,9 +202,8 @@ def test_project_suggest_combine(app):
     assert result[0].score == 1.0
 
 
-def test_project_not_initialized(app):
-    with app.app_context():
-        project = annif.project.get_project('dummy-en')
+def test_project_not_initialized(registry):
+    project = registry.get_project('dummy-en')
     assert not project.initialized
 
 


### PR DESCRIPTION
The beginnings of implementing #65. At the moment this draft PR only contains commits that separate the Annif project handling from the Flask current_app object. Making a PR to get early feedback from QA tools.