### PR TITLE
Multiprocessing in eval command

### DIFF
--- a/annif/__init__.py
+++ b/annif/__init__.py
@@ -34,7 +34,7 @@ def create_app(script_info=None, config_name=None):
     CORS(cxapp.app)
 
     if cxapp.app.config['INITIALIZE_PROJECTS']:
-        annif.project.initialize_projects(cxapp.app)
+        annif.registry.initialize_projects(cxapp.app)
 
     # register the views via blueprints
     from annif.views import bp

--- a/annif/backend/dummy.py
+++ b/annif/backend/dummy.py
@@ -25,8 +25,7 @@ class DummyBackend(backend.AnnifLearningBackend):
         return ListSuggestionResult([SubjectSuggestion(uri=self.uri,
                                                        label=self.label,
                                                        notation=notation,
-                                                       score=score)],
-                                    self.project.subjects)
+                                                       score=score)])
 
     def _learn(self, corpus, params):
         # in this dummy backend we "learn" by picking up the URI and label

--- a/annif/backend/ensemble.py
+++ b/annif/backend/ensemble.py
@@ -43,7 +43,9 @@ class EnsembleBackend(backend.AnnifBackend):
             norm_hits = self._normalize_hits(hits, source_project)
             hits_from_sources.append(
                 annif.suggestion.WeightedSuggestion(
-                    hits=norm_hits, weight=weight))
+                    hits=norm_hits,
+                    weight=weight,
+                    subjects=source_project.subjects))
         return hits_from_sources
 
     def _merge_hits_from_sources(self, hits_from_sources, params):

--- a/annif/backend/ensemble.py
+++ b/annif/backend/ensemble.py
@@ -27,6 +27,13 @@ class EnsembleBackend(backend.AnnifBackend):
         return [getattr(self.project.registry.get_project(project_id), attr)
                 for project_id, _ in sources]
 
+    def initialize(self):
+        # initialize all the source projects
+        params = self._get_backend_params(None)
+        for project_id, _ in annif.util.parse_sources(params['sources']):
+            project = self.project.registry.get_project(project_id)
+            project.initialize()
+
     def _normalize_hits(self, hits, source_project):
         """Hook for processing hits from backends. Intended to be overridden
         by subclasses."""

--- a/annif/backend/fasttext.py
+++ b/annif/backend/fasttext.py
@@ -159,4 +159,4 @@ class FastTextBackend(mixins.ChunkingBackend, backend.AnnifBackend):
                 label=subject[1],
                 notation=subject[2],
                 score=score / len(chunktexts)))
-        return ListSuggestionResult(results, self.project.subjects)
+        return ListSuggestionResult(results)

--- a/annif/backend/http.py
+++ b/annif/backend/http.py
@@ -49,13 +49,13 @@ class HTTPBackend(backend.AnnifBackend):
             req.raise_for_status()
         except requests.exceptions.RequestException as err:
             self.warning("HTTP request failed: {}".format(err))
-            return ListSuggestionResult([], self.project.subjects)
+            return ListSuggestionResult([])
 
         try:
             response = req.json()
         except ValueError as err:
             self.warning("JSON decode failed: {}".format(err))
-            return ListSuggestionResult([], self.project.subjects)
+            return ListSuggestionResult([])
 
         if 'results' in response:
             results = response['results']
@@ -71,7 +71,7 @@ class HTTPBackend(backend.AnnifBackend):
                 for hit in results if hit['score'] > 0.0]
         except (TypeError, ValueError) as err:
             self.warning("Problem interpreting JSON data: {}".format(err))
-            return ListSuggestionResult([], self.project.subjects)
+            return ListSuggestionResult([])
 
         return ListSuggestionResult.create_from_index(subject_suggestions,
                                                       self.project.subjects)

--- a/annif/backend/maui.py
+++ b/annif/backend/maui.py
@@ -194,16 +194,16 @@ class MauiBackend(backend.AnnifBackend):
                 for hit in response['topics'] if hit['probability'] > 0.0]
         except (TypeError, ValueError) as err:
             self.warning("Problem interpreting JSON data: {}".format(err))
-            return ListSuggestionResult([], self.project.subjects)
+            return ListSuggestionResult([])
 
         return ListSuggestionResult.create_from_index(subject_suggestions,
                                                       self.project.subjects)
 
     def _suggest(self, text, params):
         if len(text.strip()) == 0:
-            return ListSuggestionResult([], self.project.subjects)
+            return ListSuggestionResult([])
         response = self._suggest_request(text, params)
         if response:
             return self._response_to_result(response)
         else:
-            return ListSuggestionResult([], self.project.subjects)
+            return ListSuggestionResult([])

--- a/annif/backend/mixins.py
+++ b/annif/backend/mixins.py
@@ -36,8 +36,7 @@ class ChunkingBackend(metaclass=abc.ABCMeta):
             chunktexts.append(' '.join(sentences[i:i + chunksize]))
         self.debug('Split sentences into {} chunks'.format(len(chunktexts)))
         if len(chunktexts) == 0:  # no input, empty result
-            return ListSuggestionResult(
-                hits=[], subject_index=self.project.subjects)
+            return ListSuggestionResult([])
         return self._suggest_chunks(chunktexts, params)
 
 

--- a/annif/backend/nn_ensemble.py
+++ b/annif/backend/nn_ensemble.py
@@ -112,6 +112,7 @@ class NNEnsembleBackend(
         return params
 
     def initialize(self):
+        super().initialize()
         if self._model is not None:
             return  # already initialized
         model_filename = os.path.join(self.datadir, self.MODEL_FILE)

--- a/annif/backend/nn_ensemble.py
+++ b/annif/backend/nn_ensemble.py
@@ -129,7 +129,7 @@ class NNEnsembleBackend(
                                 dtype=np.float32)
         results = self._model.predict(
             np.expand_dims(score_vector.transpose(), 0))
-        return VectorSuggestionResult(results[0], self.project.subjects)
+        return VectorSuggestionResult(results[0])
 
     def _create_model(self, sources):
         self.info("creating NN ensemble model")

--- a/annif/backend/nn_ensemble.py
+++ b/annif/backend/nn_ensemble.py
@@ -123,8 +123,9 @@ class NNEnsembleBackend(
         self._model = load_model(model_filename)
 
     def _merge_hits_from_sources(self, hits_from_sources, params):
-        score_vector = np.array([hits.vector * weight
-                                 for hits, weight in hits_from_sources],
+        score_vector = np.array([hits.as_vector(subjects) * weight
+                                 for hits, weight, subjects
+                                 in hits_from_sources],
                                 dtype=np.float32)
         results = self._model.predict(
             np.expand_dims(score_vector.transpose(), 0))
@@ -174,7 +175,8 @@ class NNEnsembleBackend(
             doc_scores = []
             for source_project, weight in sources:
                 hits = source_project.suggest(doc.text)
-                doc_scores.append(hits.vector * weight)
+                doc_scores.append(
+                    hits.as_vector(source_project.subjects) * weight)
             score_vector = np.array(doc_scores,
                                     dtype=np.float32).transpose()
             subjects = annif.corpus.SubjectSet((doc.uris, doc.labels))

--- a/annif/backend/omikuji.py
+++ b/annif/backend/omikuji.py
@@ -117,7 +117,7 @@ class OmikujiBackend(mixins.TfidfVectorizerMixin, backend.AnnifBackend):
             text[:20], len(text)))
         vector = self.vectorizer.transform([text])
         if vector.nnz == 0:  # All zero vector, empty result
-            return ListSuggestionResult([], self.project.subjects)
+            return ListSuggestionResult([])
         feature_values = [(col, vector[row, col])
                           for row, col in zip(*vector.nonzero())]
         results = []
@@ -129,4 +129,4 @@ class OmikujiBackend(mixins.TfidfVectorizerMixin, backend.AnnifBackend):
                 label=subject[1],
                 notation=subject[2],
                 score=score))
-        return ListSuggestionResult(results, self.project.subjects)
+        return ListSuggestionResult(results)

--- a/annif/backend/pav.py
+++ b/annif/backend/pav.py
@@ -35,6 +35,7 @@ class PAVBackend(ensemble.EnsembleBackend):
         return super(ensemble.EnsembleBackend, self).modification_time
 
     def initialize(self):
+        super().initialize()
         if self._models is not None:
             return  # already initialized
         self._models = {}

--- a/annif/backend/pav.py
+++ b/annif/backend/pav.py
@@ -57,7 +57,7 @@ class PAVBackend(ensemble.EnsembleBackend):
     def _normalize_hits(self, hits, source_project):
         reg_models = self._get_model(source_project.project_id)
         pav_result = []
-        for hit in hits.hits:
+        for hit in hits.as_list(source_project.subjects):
             if hit.uri in reg_models:
                 score = reg_models[hit.uri].predict([hit.score])[0]
             else:  # default to raw score

--- a/annif/backend/pav.py
+++ b/annif/backend/pav.py
@@ -69,8 +69,7 @@ class PAVBackend(ensemble.EnsembleBackend):
                     notation=hit.notation,
                     score=score))
         pav_result.sort(key=lambda hit: hit.score, reverse=True)
-        return annif.suggestion.ListSuggestionResult(
-            pav_result, source_project.subjects)
+        return annif.suggestion.ListSuggestionResult(pav_result)
 
     @staticmethod
     def _suggest_train_corpus(source_project, corpus):

--- a/annif/backend/pav.py
+++ b/annif/backend/pav.py
@@ -82,8 +82,9 @@ class PAVBackend(ensemble.EnsembleBackend):
         ndocs = 0
         for docid, doc in enumerate(corpus.documents):
             hits = source_project.suggest(doc.text)
-            for cid in np.flatnonzero(hits.vector):
-                data.append(hits.vector[cid])
+            vector = hits.as_vector(source_project.subjects)
+            for cid in np.flatnonzero(vector):
+                data.append(vector[cid])
                 row.append(docid)
                 col.append(cid)
             subjects = annif.corpus.SubjectSet((doc.uris, doc.labels))

--- a/annif/backend/tfidf.py
+++ b/annif/backend/tfidf.py
@@ -122,6 +122,6 @@ class TFIDFBackend(mixins.TfidfVectorizerMixin, backend.AnnifBackend):
         tokens = self.project.analyzer.tokenize_words(text)
         vectors = self.vectorizer.transform([" ".join(tokens)])
         docsim = self._index[vectors[0]]
-        fullresult = VectorSuggestionResult(docsim, self.project.subjects)
+        fullresult = VectorSuggestionResult(docsim)
         return fullresult.filter(self.project.subjects,
                                  limit=int(params['limit']))

--- a/annif/backend/tfidf.py
+++ b/annif/backend/tfidf.py
@@ -123,4 +123,5 @@ class TFIDFBackend(mixins.TfidfVectorizerMixin, backend.AnnifBackend):
         vectors = self.vectorizer.transform([" ".join(tokens)])
         docsim = self._index[vectors[0]]
         fullresult = VectorSuggestionResult(docsim, self.project.subjects)
-        return fullresult.filter(limit=int(params['limit']))
+        return fullresult.filter(self.project.subjects,
+                                 limit=int(params['limit']))

--- a/annif/backend/vw_multi.py
+++ b/annif/backend/vw_multi.py
@@ -209,11 +209,9 @@ class VWMultiBackend(mixins.ChunkingBackend, backend.AnnifLearningBackend):
             result = self._model.predict(example)
             results.append(self._convert_result(result))
         if not results:  # empty result
-            return ListSuggestionResult(
-                hits=[], subject_index=self.project.subjects)
+            return ListSuggestionResult([])
         return VectorSuggestionResult(
-            np.array(results, dtype=np.float32).mean(axis=0),
-            self.project.subjects)
+            np.array(results, dtype=np.float32).mean(axis=0))
 
     @staticmethod
     def _write_train_file(examples, filename):

--- a/annif/backend/vw_multi.py
+++ b/annif/backend/vw_multi.py
@@ -143,7 +143,7 @@ class VWMultiBackend(mixins.ChunkingBackend, backend.AnnifLearningBackend):
             result = proj.suggest(text)
             features = [
                 '{}:{}'.format(self._cleanup_text(hit.uri), hit.score)
-                for hit in result.hits]
+                for hit in result.as_list(self.project.subjects)]
             return ' '.join(features)
 
     def _inputs_to_exampletext(self, text):

--- a/annif/cli.py
+++ b/annif/cli.py
@@ -344,6 +344,7 @@ def run_eval(
     else:
         pool_class = multiprocessing.Pool
 
+    project.initialize()
     map = annif.project.ProjectSuggestMap(
         project, backend_params, limit, threshold)
 

--- a/annif/cli.py
+++ b/annif/cli.py
@@ -4,6 +4,7 @@ operations and printing the results to console."""
 
 import collections
 import multiprocessing
+import multiprocessing.dummy
 import os.path
 import re
 import sys
@@ -336,10 +337,17 @@ def run_eval(
 
     if jobs < 1:
         jobs = None
+        pool_class = multiprocessing.Pool
+    elif jobs == 1:
+        # use the dummy wrapper around threading to avoid subprocess overhead
+        pool_class = multiprocessing.dummy.Pool
+    else:
+        pool_class = multiprocessing.Pool
+
     map = annif.project.ProjectSuggestMap(
         project, backend_params, limit, threshold)
 
-    with multiprocessing.Pool(jobs) as pool:
+    with pool_class(jobs) as pool:
         for hits, uris, labels in pool.imap_unordered(
                 map.suggest, docs.documents):
             eval_batch.evaluate(hits,

--- a/annif/cli.py
+++ b/annif/cli.py
@@ -84,7 +84,7 @@ def generate_filter_batches(subjects):
     filter_batches = collections.OrderedDict()
     for limit in range(1, 16):
         for threshold in [i * 0.05 for i in range(20)]:
-            hit_filter = SuggestionFilter(limit, threshold)
+            hit_filter = SuggestionFilter(subjects, limit, threshold)
             batch = annif.eval.EvaluationBatch(subjects)
             filter_batches[(limit, threshold)] = (hit_filter, batch)
     return filter_batches
@@ -230,7 +230,7 @@ def run_suggest(project_id, limit, threshold, backend_param):
     project = get_project(project_id)
     text = sys.stdin.read()
     backend_params = parse_backend_params(backend_param, project)
-    hit_filter = SuggestionFilter(limit, threshold)
+    hit_filter = SuggestionFilter(project.subjects, limit, threshold)
     hits = hit_filter(project.suggest(text, backend_params))
     for hit in hits:
         click.echo(
@@ -261,7 +261,7 @@ def run_index(project_id, directory, suffix, force,
     """
     project = get_project(project_id)
     backend_params = parse_backend_params(backend_param, project)
-    hit_filter = SuggestionFilter(limit, threshold)
+    hit_filter = SuggestionFilter(project.subjects, limit, threshold)
 
     for docfilename, dummy_subjectfn in annif.corpus.DocumentDirectory(
             directory, require_subjects=False):
@@ -311,7 +311,7 @@ def run_eval(project_id, paths, limit, threshold, results_file, backend_param):
     project = get_project(project_id)
     backend_params = parse_backend_params(backend_param, project)
 
-    hit_filter = SuggestionFilter(limit=limit, threshold=threshold)
+    hit_filter = SuggestionFilter(project.subjects, limit, threshold)
     eval_batch = annif.eval.EvaluationBatch(project.subjects)
 
     if results_file:

--- a/annif/cli.py
+++ b/annif/cli.py
@@ -232,7 +232,7 @@ def run_suggest(project_id, limit, threshold, backend_param):
     backend_params = parse_backend_params(backend_param, project)
     hit_filter = SuggestionFilter(project.subjects, limit, threshold)
     hits = hit_filter(project.suggest(text, backend_params))
-    for hit in hits:
+    for hit in hits.as_list(project.subjects):
         click.echo(
             "<{}>\t{}\t{}".format(
                 hit.uri,
@@ -275,7 +275,7 @@ def run_index(project_id, directory, suffix, force,
             continue
         with open(subjectfilename, 'w', encoding='utf-8') as subjfile:
             results = project.suggest(text, backend_params)
-            for hit in hit_filter(results):
+            for hit in hit_filter(results).as_list(project.subjects):
                 line = "<{}>\t{}\t{}".format(
                     hit.uri,
                     '\t'.join(filter(None, (hit.label, hit.notation))),

--- a/annif/cli.py
+++ b/annif/cli.py
@@ -300,7 +300,7 @@ def run_index(project_id, directory, suffix, force,
     help="""Specify file in order to write non-aggregated results per subject.
     File directory must exist, existing file will be overwritten.""")
 @click.option('--jobs',
-              default=0,
+              default=1,
               help='Number of parallel jobs (0 means all CPUs)')
 @backend_param_option
 @common_options

--- a/annif/cli.py
+++ b/annif/cli.py
@@ -16,6 +16,7 @@ import annif
 import annif.corpus
 import annif.eval
 import annif.project
+import annif.registry
 from annif.project import Access
 from annif.suggestion import SuggestionFilter
 from annif.exception import ConfigurationException, NotSupportedException
@@ -30,7 +31,7 @@ def get_project(project_id):
     """
     Helper function to get a project by ID and bail out if it doesn't exist"""
     try:
-        return annif.project.get_project(project_id, min_access=Access.hidden)
+        return annif.registry.get_project(project_id, min_access=Access.hidden)
     except ValueError:
         click.echo(
             "No projects found with id \'{0}\'.".format(project_id),
@@ -130,7 +131,8 @@ def run_list_projects():
         "Project ID", "Project Name", "Language", "Trained")
     click.echo(header)
     click.echo("-" * len(header))
-    for proj in annif.project.get_projects(min_access=Access.private).values():
+    for proj in annif.registry.get_projects(
+            min_access=Access.private).values():
         click.echo(template.format(
             proj.project_id, proj.name, proj.language, str(proj.is_trained)))
 

--- a/annif/datadir.py
+++ b/annif/datadir.py
@@ -13,5 +13,9 @@ class DatadirMixin:
     @property
     def datadir(self):
         if not os.path.exists(self._datadir_path):
-            os.makedirs(self._datadir_path)
+            try:
+                os.makedirs(self._datadir_path)
+            except FileExistsError:
+                # apparently the datadir was created by another thread!
+                pass
         return self._datadir_path

--- a/annif/eval.py
+++ b/annif/eval.py
@@ -204,7 +204,7 @@ class EvaluationBatch:
 
         y_true = np.array([gold_subjects.as_vector(self._subject_index)
                            for hits, gold_subjects in self._samples])
-        y_pred = np.array([hits.vector
+        y_pred = np.array([hits.as_vector(self._subject_index)
                            for hits, gold_subjects in self._samples],
                           dtype=np.float32)
 

--- a/annif/project.py
+++ b/annif/project.py
@@ -245,9 +245,12 @@ class AnnifRegistry:
     def __init__(self, projects_file, datadir, init_projects):
         self._rid = id(self)
         self._projects[self._rid] = \
-            self._create_projects(projects_file, datadir, init_projects)
+            self._create_projects(projects_file, datadir)
+        if init_projects:
+            for project in self._projects[self._rid].values():
+                project.initialize()
 
-    def _create_projects(self, projects_file, datadir, init_projects):
+    def _create_projects(self, projects_file, datadir):
         if not os.path.exists(projects_file):
             logger.warning(
                 'Project configuration file "%s" is missing. ' +
@@ -273,8 +276,6 @@ class AnnifRegistry:
                                                 config[project_id],
                                                 datadir,
                                                 self)
-            if init_projects:
-                projects[project_id].initialize()
         return projects
 
     def get_projects(self, min_access=Access.private):

--- a/annif/project.py
+++ b/annif/project.py
@@ -1,17 +1,13 @@
 """Project management functionality for Annif"""
 
-import collections
-import configparser
 import enum
 import os.path
-from flask import current_app
 from shutil import rmtree
 import annif
 import annif.analyzer
 import annif.corpus
 import annif.suggestion
 import annif.backend
-import annif.util
 import annif.vocab
 from annif.datadir import DatadirMixin
 from annif.exception import AnnifException, ConfigurationException, \
@@ -228,100 +224,6 @@ class AnnifProject(DatadirMixin):
         else:
             logger.warning('No model data to remove for project {}.'
                            .format(self.project_id))
-
-
-class AnnifRegistry:
-    """Class that keeps track of the Annif projects"""
-
-    # Note: The individual projects are stored in a shared static variable,
-    # keyed by the "registry ID" which is unique to the registry instance.
-    # This is done to make it possible to serialize AnnifRegistry instances
-    # without including the potentially huge project objects (which contain
-    # backends with large models, vocabularies with lots of concepts etc).
-    # Serialized AnnifRegistry instances can then be passed between
-    # processes when using the multiprocessing module.
-    _projects = {}
-
-    def __init__(self, projects_file, datadir, init_projects):
-        self._rid = id(self)
-        self._projects[self._rid] = \
-            self._create_projects(projects_file, datadir)
-        if init_projects:
-            for project in self._projects[self._rid].values():
-                project.initialize()
-
-    def _create_projects(self, projects_file, datadir):
-        if not os.path.exists(projects_file):
-            logger.warning(
-                'Project configuration file "%s" is missing. ' +
-                'Please provide one. You can set the path to the project ' +
-                'configuration file using the ANNIF_PROJECTS environment ' +
-                'variable or the command-line option "--projects".',
-                projects_file)
-            return {}
-
-        config = configparser.ConfigParser()
-        config.optionxform = annif.util.identity
-        with open(projects_file, encoding='utf-8-sig') as projf:
-            try:
-                config.read_file(projf)
-            except (configparser.DuplicateOptionError,
-                    configparser.DuplicateSectionError) as err:
-                raise ConfigurationException(err)
-
-        # create AnnifProject objects from the configuration file
-        projects = collections.OrderedDict()
-        for project_id in config.sections():
-            projects[project_id] = AnnifProject(project_id,
-                                                config[project_id],
-                                                datadir,
-                                                self)
-        return projects
-
-    def get_projects(self, min_access=Access.private):
-        """Return the available projects as a dict of project_id ->
-        AnnifProject. The min_access parameter may be used to set the minimum
-        access level required for the returned projects."""
-
-        return {project_id: project
-                for project_id, project in self._projects[self._rid].items()
-                if project.access >= min_access}
-
-    def get_project(self, project_id, min_access=Access.private):
-        """return the definition of a single Project by project_id"""
-
-        projects = self.get_projects(min_access)
-        try:
-            return projects[project_id]
-        except KeyError:
-            raise ValueError("No such project {}".format(project_id))
-
-
-def initialize_projects(app):
-    projects_file = app.config['PROJECTS_FILE']
-    datadir = app.config['DATADIR']
-    init_projects = app.config['INITIALIZE_PROJECTS']
-    app.annif_registry = AnnifRegistry(projects_file, datadir, init_projects)
-
-
-def get_projects(min_access=Access.private):
-    """Return the available projects as a dict of project_id ->
-    AnnifProject. The min_access parameter may be used to set the minimum
-    access level required for the returned projects."""
-    if not hasattr(current_app, 'annif_registry'):
-        initialize_projects(current_app)
-
-    return current_app.annif_registry.get_projects(min_access)
-
-
-def get_project(project_id, min_access=Access.private):
-    """return the definition of a single Project by project_id"""
-
-    projects = get_projects(min_access)
-    try:
-        return projects[project_id]
-    except KeyError:
-        raise ValueError("No such project {}".format(project_id))
 
 
 class ProjectSuggestMap:

--- a/annif/project.py
+++ b/annif/project.py
@@ -321,3 +321,23 @@ def get_project(project_id, min_access=Access.private):
         return projects[project_id]
     except KeyError:
         raise ValueError("No such project {}".format(project_id))
+
+
+class ProjectSuggestMap:
+    """A utility class that can be used to wrap a project and provide a
+    mapping method that converts Document objects to suggestions. Intended
+    to be used with the multiprocessing module."""
+
+    def __init__(self, project, backend_params, limit, threshold):
+        self.project_id = project.project_id
+        self.registry = project.registry
+        self.backend_params = backend_params
+        self.limit = limit
+        self.threshold = threshold
+
+    def suggest(self, doc):
+        project = self.registry.get_project(self.project_id)
+        hits = project.suggest(doc.text, self.backend_params)
+        filtered_hits = hits.filter(
+            project.subjects, self.limit, self.threshold)
+        return (filtered_hits, doc.uris, doc.labels)

--- a/annif/registry.py
+++ b/annif/registry.py
@@ -1,0 +1,106 @@
+"""Registry that keeps track of Annif projects"""
+
+import collections
+import configparser
+import os.path
+from flask import current_app
+import annif
+import annif.util
+from annif.exception import ConfigurationException
+from annif.project import Access, AnnifProject
+
+logger = annif.logger
+
+
+class AnnifRegistry:
+    """Class that keeps track of the Annif projects"""
+
+    # Note: The individual projects are stored in a shared static variable,
+    # keyed by the "registry ID" which is unique to the registry instance.
+    # This is done to make it possible to serialize AnnifRegistry instances
+    # without including the potentially huge project objects (which contain
+    # backends with large models, vocabularies with lots of concepts etc).
+    # Serialized AnnifRegistry instances can then be passed between
+    # processes when using the multiprocessing module.
+    _projects = {}
+
+    def __init__(self, projects_file, datadir, init_projects):
+        self._rid = id(self)
+        self._projects[self._rid] = \
+            self._create_projects(projects_file, datadir)
+        if init_projects:
+            for project in self._projects[self._rid].values():
+                project.initialize()
+
+    def _create_projects(self, projects_file, datadir):
+        if not os.path.exists(projects_file):
+            logger.warning(
+                'Project configuration file "%s" is missing. ' +
+                'Please provide one. You can set the path to the project ' +
+                'configuration file using the ANNIF_PROJECTS environment ' +
+                'variable or the command-line option "--projects".',
+                projects_file)
+            return {}
+
+        config = configparser.ConfigParser()
+        config.optionxform = annif.util.identity
+        with open(projects_file, encoding='utf-8-sig') as projf:
+            try:
+                config.read_file(projf)
+            except (configparser.DuplicateOptionError,
+                    configparser.DuplicateSectionError) as err:
+                raise ConfigurationException(err)
+
+        # create AnnifProject objects from the configuration file
+        projects = collections.OrderedDict()
+        for project_id in config.sections():
+            projects[project_id] = AnnifProject(project_id,
+                                                config[project_id],
+                                                datadir,
+                                                self)
+        return projects
+
+    def get_projects(self, min_access=Access.private):
+        """Return the available projects as a dict of project_id ->
+        AnnifProject. The min_access parameter may be used to set the minimum
+        access level required for the returned projects."""
+
+        return {project_id: project
+                for project_id, project in self._projects[self._rid].items()
+                if project.access >= min_access}
+
+    def get_project(self, project_id, min_access=Access.private):
+        """return the definition of a single Project by project_id"""
+
+        projects = self.get_projects(min_access)
+        try:
+            return projects[project_id]
+        except KeyError:
+            raise ValueError("No such project {}".format(project_id))
+
+
+def initialize_projects(app):
+    projects_file = app.config['PROJECTS_FILE']
+    datadir = app.config['DATADIR']
+    init_projects = app.config['INITIALIZE_PROJECTS']
+    app.annif_registry = AnnifRegistry(projects_file, datadir, init_projects)
+
+
+def get_projects(min_access=Access.private):
+    """Return the available projects as a dict of project_id ->
+    AnnifProject. The min_access parameter may be used to set the minimum
+    access level required for the returned projects."""
+    if not hasattr(current_app, 'annif_registry'):
+        initialize_projects(current_app)
+
+    return current_app.annif_registry.get_projects(min_access)
+
+
+def get_project(project_id, min_access=Access.private):
+    """return the definition of a single Project by project_id"""
+
+    projects = get_projects(min_access)
+    try:
+        return projects[project_id]
+    except KeyError:
+        raise ValueError("No such project {}".format(project_id))

--- a/annif/rest.py
+++ b/annif/rest.py
@@ -58,8 +58,8 @@ def suggest(project_id, text, limit, threshold):
     except ValueError:
         return project_not_found_error(project_id)
 
-    hit_filter = SuggestionFilter(limit, threshold)
     try:
+        hit_filter = SuggestionFilter(project.subjects, limit, threshold)
         result = project.suggest(text)
     except AnnifException as err:
         return server_error(err)

--- a/annif/rest.py
+++ b/annif/rest.py
@@ -2,7 +2,7 @@
 methods defined in the Swagger specification."""
 
 import connexion
-import annif.project
+import annif.registry
 from annif.corpus import Document, DocumentList
 from annif.suggestion import SuggestionFilter
 from annif.exception import AnnifException
@@ -33,7 +33,7 @@ def list_projects():
 
     return {
         'projects': [
-            proj.dump() for proj in annif.project.get_projects(
+            proj.dump() for proj in annif.registry.get_projects(
                 min_access=Access.public).values()]}
 
 
@@ -41,7 +41,7 @@ def show_project(project_id):
     """return a single project formatted according to Swagger spec"""
 
     try:
-        project = annif.project.get_project(
+        project = annif.registry.get_project(
             project_id, min_access=Access.hidden)
     except ValueError:
         return project_not_found_error(project_id)
@@ -53,7 +53,7 @@ def suggest(project_id, text, limit, threshold):
     formatted according to Swagger spec"""
 
     try:
-        project = annif.project.get_project(
+        project = annif.registry.get_project(
             project_id, min_access=Access.hidden)
     except ValueError:
         return project_not_found_error(project_id)
@@ -80,7 +80,7 @@ def learn(project_id, documents):
     """learn from documents and return an empty 204 response if succesful"""
 
     try:
-        project = annif.project.get_project(
+        project = annif.registry.get_project(
             project_id, min_access=Access.hidden)
     except ValueError:
         return project_not_found_error(project_id)

--- a/annif/rest.py
+++ b/annif/rest.py
@@ -63,7 +63,7 @@ def suggest(project_id, text, limit, threshold):
         result = project.suggest(text)
     except AnnifException as err:
         return server_error(err)
-    hits = hit_filter(result)
+    hits = hit_filter(result).as_list(project.subjects)
     return {'results': [hit._asdict() for hit in hits]}
 
 

--- a/annif/suggestion.py
+++ b/annif/suggestion.py
@@ -89,9 +89,8 @@ class LazySuggestionResult(SuggestionResult):
 class VectorSuggestionResult(SuggestionResult):
     """SuggestionResult implementation based primarily on NumPy vectors."""
 
-    def __init__(self, vector, subject_index):
+    def __init__(self, vector):
         self._vector = vector.astype(np.float32)
-        self._subject_index = subject_index
         self._subject_order = None
         self._list = None
 
@@ -108,8 +107,7 @@ class VectorSuggestionResult(SuggestionResult):
                     label=subject[1],
                     notation=subject[2],
                     score=float(score)))
-        return ListSuggestionResult(hits,
-                                    subject_index).as_list(subject_index)
+        return ListSuggestionResult(hits).as_list(subject_index)
 
     @property
     def subject_order(self):
@@ -138,7 +136,7 @@ class VectorSuggestionResult(SuggestionResult):
             deprecated_mask = np.ones_like(self._vector, dtype=np.bool)
             deprecated_mask[deprecated_ids] = False
             mask = mask & deprecated_mask
-        return VectorSuggestionResult(self._vector * mask, subject_index)
+        return VectorSuggestionResult(self._vector * mask)
 
     def __len__(self):
         return (self._vector > 0.0).sum()
@@ -147,9 +145,8 @@ class VectorSuggestionResult(SuggestionResult):
 class ListSuggestionResult(SuggestionResult):
     """SuggestionResult implementation based primarily on lists of hits."""
 
-    def __init__(self, hits, subject_index):
+    def __init__(self, hits):
         self._list = [hit for hit in hits if hit.score > 0.0]
-        self._subject_index = subject_index
         self._vector = None
 
     @classmethod
@@ -165,7 +162,7 @@ class ListSuggestionResult(SuggestionResult):
                                   label=subject[1],
                                   notation=subject[2],
                                   score=hit.score))
-        return ListSuggestionResult(subject_suggestions, subject_index)
+        return ListSuggestionResult(subject_suggestions)
 
     def _list_to_vector(self, subject_index):
         vector = np.zeros(len(subject_index), dtype=np.float32)
@@ -190,7 +187,7 @@ class ListSuggestionResult(SuggestionResult):
                          hit.label is not None]
         if limit is not None:
             filtered_hits = filtered_hits[:limit]
-        return ListSuggestionResult(filtered_hits, subject_index)
+        return ListSuggestionResult(filtered_hits)
 
     def __len__(self):
         return len(self._list)

--- a/annif/suggestion.py
+++ b/annif/suggestion.py
@@ -92,9 +92,9 @@ class VectorSuggestionResult(SuggestionResult):
     def __init__(self, vector):
         self._vector = vector.astype(np.float32)
         self._subject_order = None
-        self._list = None
+        self._lsr = None
 
-    def _vector_to_list(self, subject_index):
+    def _vector_to_list_suggestion(self, subject_index):
         hits = []
         for subject_id in self.subject_order:
             score = self._vector[subject_id]
@@ -107,7 +107,7 @@ class VectorSuggestionResult(SuggestionResult):
                     label=subject[1],
                     notation=subject[2],
                     score=float(score)))
-        return ListSuggestionResult(hits).as_list(subject_index)
+        return ListSuggestionResult(hits)
 
     @property
     def subject_order(self):
@@ -116,9 +116,9 @@ class VectorSuggestionResult(SuggestionResult):
         return self._subject_order
 
     def as_list(self, subject_index):
-        if self._list is None:
-            self._list = self._vector_to_list(subject_index)
-        return self._list
+        if self._lsr is None:
+            self._lsr = self._vector_to_list_suggestion(subject_index)
+        return self._lsr.as_list(subject_index)
 
     def as_vector(self, subject_index):
         return self._vector
@@ -136,7 +136,8 @@ class VectorSuggestionResult(SuggestionResult):
             deprecated_mask = np.ones_like(self._vector, dtype=np.bool)
             deprecated_mask[deprecated_ids] = False
             mask = mask & deprecated_mask
-        return VectorSuggestionResult(self._vector * mask)
+        vsr = VectorSuggestionResult(self._vector * mask)
+        return ListSuggestionResult(vsr.as_list(subject_index))
 
     def __len__(self):
         return (self._vector > 0.0).sum()

--- a/annif/util.py
+++ b/annif/util.py
@@ -45,7 +45,7 @@ def merge_hits(weighted_hits, subject_index):
     weights = [whit.weight for whit in weighted_hits]
     scores = [whit.hits.as_vector(subject_index) for whit in weighted_hits]
     result = np.average(scores, axis=0, weights=weights)
-    return VectorSuggestionResult(result, subject_index)
+    return VectorSuggestionResult(result)
 
 
 def parse_sources(sourcedef):

--- a/annif/util.py
+++ b/annif/util.py
@@ -43,7 +43,7 @@ def merge_hits(weighted_hits, subject_index):
     Returns an SuggestionResult object."""
 
     weights = [whit.weight for whit in weighted_hits]
-    scores = [whit.hits.vector for whit in weighted_hits]
+    scores = [whit.hits.as_vector(subject_index) for whit in weighted_hits]
     result = np.average(scores, axis=0, weights=weights)
     return VectorSuggestionResult(result, subject_index)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,7 @@ import annif
 import annif.analyzer
 import annif.corpus
 import annif.project
+import annif.registry
 
 
 @pytest.fixture(scope='module')
@@ -21,7 +22,7 @@ def app():
     vocab = annif.corpus.SubjectFileTSV(subjfile)
     app = annif.create_app(config_name='annif.default_config.TestingConfig')
     with app.app_context():
-        project = annif.project.get_project('dummy-en')
+        project = annif.registry.get_project('dummy-en')
         project.vocab.load_vocabulary(vocab, 'en')
     return app
 
@@ -106,7 +107,7 @@ def app_project(app):
     with app.app_context():
         dir = py.path.local(app.config['DATADIR'])
         shutil.rmtree(os.path.join(str(dir), 'projects'), ignore_errors=True)
-        return annif.project.get_project('dummy-en')
+        return annif.registry.get_project('dummy-en')
 
 
 @pytest.fixture(scope='function')

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -18,9 +18,10 @@ def test_get_backend_dummy(project):
                        project=project)
     result = dummy.suggest(text='this is some text')
     assert len(result) == 1
-    assert result[0].uri == 'http://example.org/dummy'
-    assert result[0].label == 'dummy'
-    assert result[0].score == 1.0
+    hits = result.as_list(project.subjects)
+    assert hits[0].uri == 'http://example.org/dummy'
+    assert hits[0].label == 'dummy'
+    assert hits[0].score == 1.0
 
 
 def test_learn_dummy(project, tmpdir):
@@ -38,9 +39,10 @@ def test_learn_dummy(project, tmpdir):
 
     result = dummy.suggest(text='this is some text')
     assert len(result) == 1
-    assert result[0].uri == 'http://example.org/key1'
-    assert result[0].label == 'key1'
-    assert result[0].score == 1.0
+    hits = result.as_list(project.subjects)
+    assert hits[0].uri == 'http://example.org/key1'
+    assert hits[0].label == 'key1'
+    assert hits[0].score == 1.0
 
 
 def test_fill_params_with_defaults(project):

--- a/tests/test_backend_fasttext.py
+++ b/tests/test_backend_fasttext.py
@@ -200,6 +200,7 @@ def test_fasttext_suggest(project):
         pohjaan.""")
 
     assert len(results) > 0
+    hits = results.as_list(project.subjects)
     assert 'http://www.yso.fi/onto/yso/p1265' in [
-        result.uri for result in results]
-    assert 'arkeologia' in [result.label for result in results]
+        result.uri for result in hits]
+    assert 'arkeologia' in [result.label for result in hits]

--- a/tests/test_backend_http.py
+++ b/tests/test_backend_http.py
@@ -26,10 +26,11 @@ def test_http_suggest(app_project):
             project=app_project)
         result = http.suggest('this is some text')
         assert len(result) == 1
-        assert result[0].uri == 'http://example.org/dummy'
-        assert result[0].label == 'dummy'
-        assert result[0].score == 1.0
-        assert result[0].notation is None
+        hits = result.as_list(app_project.subjects)
+        assert hits[0].uri == 'http://example.org/dummy'
+        assert hits[0].label == 'dummy'
+        assert hits[0].score == 1.0
+        assert hits[0].notation is None
 
 
 def test_http_suggest_with_results(app_project):
@@ -54,10 +55,11 @@ def test_http_suggest_with_results(app_project):
 
         result = http.suggest('this is some text')
         assert len(result) == 1
-        assert result[0].uri == 'http://example.org/dummy-with-notation'
-        assert result[0].label == 'dummy'
-        assert result[0].score == 1.0
-        assert result[0].notation == '42.42'
+        hits = result.as_list(app_project.subjects)
+        assert hits[0].uri == 'http://example.org/dummy-with-notation'
+        assert hits[0].label == 'dummy'
+        assert hits[0].score == 1.0
+        assert hits[0].notation == '42.42'
 
 
 def test_http_suggest_zero_score(project):

--- a/tests/test_backend_maui.py
+++ b/tests/test_backend_maui.py
@@ -179,7 +179,7 @@ def test_maui_train(maui, document_corpus, app_project):
 
 
 @responses.activate
-def test_maui_suggest(maui):
+def test_maui_suggest(maui, subject_index):
     responses.add(responses.POST,
                   'http://api.example.org/mauiservice/dummy/suggest',
                   json={'title': '1 recommendation from dummy',
@@ -189,10 +189,11 @@ def test_maui_suggest(maui):
 
     result = maui.suggest('this is some text')
     assert len(result) == 1
-    assert result[0].uri == 'http://example.org/dummy'
-    assert result[0].label == 'dummy'
-    assert result[0].notation is None
-    assert result[0].score == 1.0
+    hits = result.as_list(subject_index)
+    assert hits[0].uri == 'http://example.org/dummy'
+    assert hits[0].label == 'dummy'
+    assert hits[0].notation is None
+    assert hits[0].score == 1.0
     assert len(responses.calls) == 1
 
 
@@ -211,7 +212,7 @@ def test_maui_suggest_no_input(maui):
 
 
 @responses.activate
-def test_maui_suggest_with_notation(maui):
+def test_maui_suggest_with_notation(maui, subject_index):
     responses.add(responses.POST,
                   'http://api.example.org/mauiservice/dummy/suggest',
                   json={'title': '1 recommendation from dummy',
@@ -224,10 +225,11 @@ def test_maui_suggest_with_notation(maui):
         'http://example.org/dummy-with-notation', 'dummy', '42.42')
     result = maui.suggest('this is some text')
     assert len(result) == 1
-    assert result[0].uri == 'http://example.org/dummy-with-notation'
-    assert result[0].label == 'dummy'
-    assert result[0].notation == '42.42'
-    assert result[0].score == 1.0
+    hits = result.as_list(subject_index)
+    assert hits[0].uri == 'http://example.org/dummy-with-notation'
+    assert hits[0].label == 'dummy'
+    assert hits[0].notation == '42.42'
+    assert hits[0].score == 1.0
     assert len(responses.calls) == 1
 
 

--- a/tests/test_backend_omikuji.py
+++ b/tests/test_backend_omikuji.py
@@ -138,9 +138,10 @@ def test_omikuji_suggest(project):
 
     assert len(results) > 0
     assert len(results) <= 8
+    hits = results.as_list(project.subjects)
     assert 'http://www.yso.fi/onto/yso/p1265' in [
-        result.uri for result in results]
-    assert 'arkeologia' in [result.label for result in results]
+        result.uri for result in hits]
+    assert 'arkeologia' in [result.label for result in hits]
 
 
 def test_omikuji_suggest_no_input(project):

--- a/tests/test_backend_pav.py
+++ b/tests/test_backend_pav.py
@@ -130,19 +130,19 @@ def test_pav_train_params(tmpdir, app_project, caplog):
     assert parameters_spec in caplog.text
 
 
-def test_pav_is_trained(project):
+def test_pav_is_trained(app_project):
     pav_type = annif.backend.get_backend("pav")
     pav = pav_type(
         backend_id='pav',
         config_params={'limit': 50, 'min-docs': 2, 'sources': 'dummy-fi'},
-        project=project)
+        project=app_project)
     assert pav.is_trained
 
 
-def test_pav_modification_time(project):
+def test_pav_modification_time(app_project):
     pav_type = annif.backend.get_backend("pav")
     pav = pav_type(
         backend_id='pav',
         config_params={'limit': 50, 'min-docs': 2, 'sources': 'dummy-fi'},
-        project=project)
+        project=app_project)
     assert datetime.now() - pav.modification_time < timedelta(1)

--- a/tests/test_backend_pav.py
+++ b/tests/test_backend_pav.py
@@ -1,6 +1,7 @@
 """Unit tests for the PAV backend in Annif"""
 
 import logging
+import py.path
 import pytest
 from datetime import datetime, timedelta
 import annif.backend
@@ -8,12 +9,12 @@ import annif.corpus
 from annif.exception import NotSupportedException
 
 
-def test_pav_default_params(document_corpus, project):
+def test_pav_default_params(document_corpus, app_project):
     pav_type = annif.backend.get_backend("pav")
     pav = pav_type(
         backend_id='pav',
         config_params={},
-        project=project)
+        project=app_project)
 
     expected_default_params = {
         'min-docs': 10,
@@ -23,21 +24,21 @@ def test_pav_default_params(document_corpus, project):
         assert param in actual_params and actual_params[param] == val
 
 
-def test_pav_is_not_trained(project):
+def test_pav_is_not_trained(app_project):
     pav_type = annif.backend.get_backend("pav")
     pav = pav_type(
         backend_id='pav',
         config_params={'limit': 50, 'min-docs': 2, 'sources': 'dummy-fi'},
-        project=project)
+        project=app_project)
     assert not pav.is_trained
 
 
-def test_pav_train(datadir, tmpdir, project):
+def test_pav_train(datadir, tmpdir, app_project):
     pav_type = annif.backend.get_backend("pav")
     pav = pav_type(
         backend_id='pav',
         config_params={'limit': 50, 'min-docs': 2, 'sources': 'dummy-fi'},
-        project=project)
+        project=app_project)
 
     tmpfile = tmpdir.join('document.tsv')
     tmpfile.write("dummy\thttp://example.org/dummy\n" +
@@ -46,39 +47,40 @@ def test_pav_train(datadir, tmpdir, project):
     document_corpus = annif.corpus.DocumentFile(str(tmpfile))
 
     pav.train(document_corpus)
+    datadir = py.path.local(app_project.datadir)
     assert datadir.join('pav-model-dummy-fi').exists()
     assert datadir.join('pav-model-dummy-fi').size() > 0
 
 
-def test_pav_train_cached(project):
+def test_pav_train_cached(app_project):
     pav_type = annif.backend.get_backend("pav")
     pav = pav_type(
         backend_id='pav',
         config_params={'limit': 50, 'min-docs': 2, 'sources': 'dummy-fi'},
-        project=project)
+        project=app_project)
 
     with pytest.raises(NotSupportedException):
         pav.train("cached")
 
 
-def test_pav_train_nodocuments(project, empty_corpus):
+def test_pav_train_nodocuments(app_project, empty_corpus):
     pav_type = annif.backend.get_backend("pav")
     pav = pav_type(
         backend_id='pav',
         config_params={'limit': 50, 'min-docs': 2, 'sources': 'dummy-fi'},
-        project=project)
+        project=app_project)
 
     with pytest.raises(NotSupportedException) as excinfo:
         pav.train(empty_corpus)
     assert 'training backend pav with no documents' in str(excinfo.value)
 
 
-def test_pav_initialize(project):
+def test_pav_initialize(app_project):
     pav_type = annif.backend.get_backend("pav")
     pav = pav_type(
         backend_id='pav',
         config_params={'limit': 50, 'min-docs': 2, 'sources': 'dummy-fi'},
-        project=project)
+        project=app_project)
 
     assert pav._models is None
     pav.initialize()
@@ -87,12 +89,12 @@ def test_pav_initialize(project):
     pav.initialize()
 
 
-def test_pav_suggest(project):
+def test_pav_suggest(app_project):
     pav_type = annif.backend.get_backend("pav")
     pav = pav_type(
         backend_id='pav',
         config_params={'limit': 50, 'min-docs': 2, 'sources': 'dummy-fi'},
-        project=project)
+        project=app_project)
 
     results = pav.suggest("""Arkeologiaa sanotaan joskus myös
         muinaistutkimukseksi tai muinaistieteeksi. Se on humanistinen tiede
@@ -105,7 +107,7 @@ def test_pav_suggest(project):
     assert len(results) > 0
 
 
-def test_pav_train_params(tmpdir, project, caplog):
+def test_pav_train_params(tmpdir, app_project, caplog):
     logger = annif.logger
     logger.propagate = True
 
@@ -113,7 +115,7 @@ def test_pav_train_params(tmpdir, project, caplog):
     pav = pav_type(
         backend_id='pav',
         config_params={'limit': 50, 'min-docs': 2, 'sources': 'dummy-fi'},
-        project=project)
+        project=app_project)
 
     tmpfile = tmpdir.join('document.tsv')
     tmpfile.write("dummy\thttp://example.org/dummy\n" +

--- a/tests/test_backend_pav.py
+++ b/tests/test_backend_pav.py
@@ -33,7 +33,7 @@ def test_pav_is_not_trained(app_project):
     assert not pav.is_trained
 
 
-def test_pav_train(datadir, tmpdir, app_project):
+def test_pav_train(tmpdir, app_project):
     pav_type = annif.backend.get_backend("pav")
     pav = pav_type(
         backend_id='pav',

--- a/tests/test_backend_tfidf.py
+++ b/tests/test_backend_tfidf.py
@@ -51,9 +51,10 @@ def test_tfidf_suggest(project):
         pohjaan.""")
 
     assert len(results) == 10
+    hits = results.as_list(project.subjects)
     assert 'http://www.yso.fi/onto/yso/p1265' in [
-        result.uri for result in results]
-    assert 'arkeologia' in [result.label for result in results]
+        result.uri for result in hits]
+    assert 'arkeologia' in [result.label for result in hits]
 
 
 def test_suggest_params(project):

--- a/tests/test_backend_vw_multi.py
+++ b/tests/test_backend_vw_multi.py
@@ -216,9 +216,10 @@ def test_vw_multi_suggest(project):
         pohjaan.""")
 
     assert len(results) > 0
+    hits = results.as_list(project.subjects)
     assert 'http://www.yso.fi/onto/yso/p1265' in [
-        result.uri for result in results]
-    assert 'arkeologia' in [result.label for result in results]
+        result.uri for result in hits]
+    assert 'arkeologia' in [result.label for result in hits]
 
 
 def test_vw_multi_suggest_empty(project):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -616,6 +616,32 @@ def test_eval_nonexistent_path():
            "Path 'nonexistent_path' does not exist." in failed_result.output
 
 
+def test_eval_single_process(tmpdir):
+    tmpdir.join('doc1.txt').write('doc1')
+    tmpdir.join('doc1.key').write('dummy')
+    tmpdir.join('doc2.txt').write('doc2')
+    tmpdir.join('doc2.key').write('none')
+    tmpdir.join('doc3.txt').write('doc3')
+
+    result = runner.invoke(
+        annif.cli.cli, ['eval', '--jobs', '1', 'dummy-en', str(tmpdir)])
+    assert not result.exception
+    assert result.exit_code == 0
+
+
+def test_eval_two_jobs(tmpdir):
+    tmpdir.join('doc1.txt').write('doc1')
+    tmpdir.join('doc1.key').write('dummy')
+    tmpdir.join('doc2.txt').write('doc2')
+    tmpdir.join('doc2.key').write('none')
+    tmpdir.join('doc3.txt').write('doc3')
+
+    result = runner.invoke(
+        annif.cli.cli, ['eval', '--jobs', '2', 'dummy-en', str(tmpdir)])
+    assert not result.exception
+    assert result.exit_code == 0
+
+
 def test_optimize_dir(tmpdir):
     tmpdir.join('doc1.txt').write('doc1')
     tmpdir.join('doc1.key').write('dummy')

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -103,14 +103,14 @@ def test_evaluation_batch(subject_index):
             uri='http://www.yso.fi/onto/yso/p10849',
             label='arkeologit',
             notation=None,
-            score=1.0)], subject_index)
+            score=1.0)])
     batch.evaluate(hits1, gold_set)
     hits2 = annif.suggestion.ListSuggestionResult([
         annif.suggestion.SubjectSuggestion(
             uri='http://www.yso.fi/onto/yso/p1747',
             label='egyptologit',
             notation=None,
-            score=1.0)], subject_index)
+            score=1.0)])
     batch.evaluate(hits2, gold_set)
     results = batch.results()
     assert results['Precision (doc avg)'] == 0.5

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -170,9 +170,10 @@ def test_project_learn(registry, tmpdir):
     project.learn(docdir)
     result = project.suggest('this is some text')
     assert len(result) == 1
-    assert result[0].uri == 'http://example.org/key1'
-    assert result[0].label == 'key1'
-    assert result[0].score == 1.0
+    hits = result.as_list(project.subjects)
+    assert hits[0].uri == 'http://example.org/key1'
+    assert hits[0].label == 'key1'
+    assert hits[0].score == 1.0
 
 
 def test_project_learn_not_supported(registry, tmpdir):
@@ -207,18 +208,20 @@ def test_project_suggest(registry):
     project = registry.get_project('dummy-en')
     result = project.suggest('this is some text')
     assert len(result) == 1
-    assert result[0].uri == 'http://example.org/dummy'
-    assert result[0].label == 'dummy'
-    assert result[0].score == 1.0
+    hits = result.as_list(project.subjects)
+    assert hits[0].uri == 'http://example.org/dummy'
+    assert hits[0].label == 'dummy'
+    assert hits[0].score == 1.0
 
 
 def test_project_suggest_combine(registry):
     project = registry.get_project('dummydummy')
     result = project.suggest('this is some text')
     assert len(result) == 1
-    assert result[0].uri == 'http://example.org/dummy'
-    assert result[0].label == 'dummy'
-    assert result[0].score == 1.0
+    hits = result.as_list(project.subjects)
+    assert hits[0].uri == 'http://example.org/dummy'
+    assert hits[0].label == 'dummy'
+    assert hits[0].score == 1.0
 
 
 def test_project_train_state_not_available(registry, caplog):

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -231,9 +231,10 @@ def test_project_train_state_not_available(registry, caplog):
         result = project.suggest('this is some text')
     assert project.is_trained is None
     assert len(result) == 1
-    assert result[0].uri == 'http://example.org/dummy'
-    assert result[0].label == 'dummy'
-    assert result[0].score == 1.0
+    hits = result.as_list(project.subjects)
+    assert hits[0].uri == 'http://example.org/dummy'
+    assert hits[0].label == 'dummy'
+    assert hits[0].score == 1.0
     assert 'Could not get train state information' in caplog.text
 
 

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -120,7 +120,7 @@ def test_get_project_invalid_config_file():
         config_name='annif.default_config.TestingInvalidProjectsConfig')
     with app.app_context():
         with pytest.raises(ConfigurationException):
-            annif.project.get_project('duplicatedvocab')
+            annif.registry.get_project('duplicatedvocab')
 
 
 def test_project_load_vocabulary_tfidf(registry, vocabulary, testdatadir):
@@ -245,7 +245,7 @@ def test_project_not_initialized(registry):
 
 def test_project_initialized(app_with_initialize):
     with app_with_initialize.app_context():
-        project = annif.project.get_project('dummy-en')
+        project = annif.registry.get_project('dummy-en')
     assert project.initialized
     assert project.backend.initialized
 
@@ -255,4 +255,4 @@ def test_project_file_not_found():
         config_name='annif.default_config.TestingNoProjectsConfig')
     with app.app_context():
         with pytest.raises(ValueError):
-            annif.project.get_project('dummy-en')
+            annif.registry.get_project('dummy-en')

--- a/tests/test_suggestion.py
+++ b/tests/test_suggestion.py
@@ -96,7 +96,7 @@ def test_lazy_suggestion_result(subject_index):
     assert lsr._object is None
     assert len(lsr) == 10
     assert len(lsr.as_list(subject_index)) == 10
-    assert lsr.vector is not None
+    assert lsr.as_vector(subject_index) is not None
     assert lsr.as_list(subject_index)[0] is not None
     filtered = lsr.filter(subject_index, limit=5, threshold=0.0)
     assert len(filtered) == 5
@@ -117,10 +117,11 @@ def test_list_suggestions_vector(document_corpus, subject_index):
                 notation=None,
                 score=0.5)],
         subject_index)
-    assert isinstance(suggestions.vector, np.ndarray)
-    assert len(suggestions.vector) == len(subject_index)
-    assert suggestions.vector.sum() == 1.5
-    for subject_id, score in enumerate(suggestions.vector):
+    vector = suggestions.as_vector(subject_index)
+    assert isinstance(vector, np.ndarray)
+    assert len(vector) == len(subject_index)
+    assert vector.sum() == 1.5
+    for subject_id, score in enumerate(vector):
         if subject_index[subject_id][1] == 'sinetit':
             assert score == 1.0
         elif subject_index[subject_id][1] == 'viikingit':
@@ -138,4 +139,4 @@ def test_list_suggestions_vector_notfound(document_corpus, subject_index):
                 notation=None,
                 score=1.0)],
         subject_index)
-    assert suggestions.vector.sum() == 0
+    assert suggestions.as_vector(subject_index).sum() == 0

--- a/tests/test_suggestion.py
+++ b/tests/test_suggestion.py
@@ -19,14 +19,15 @@ def generate_suggestions(n, subject_index):
 
 def test_hitfilter_limit(subject_index):
     origsuggestions = generate_suggestions(10, subject_index)
-    suggestions = SuggestionFilter(limit=5)(origsuggestions)
+    suggestions = SuggestionFilter(subject_index, limit=5)(origsuggestions)
     assert isinstance(suggestions, SuggestionResult)
     assert len(suggestions) == 5
 
 
 def test_hitfilter_threshold(subject_index):
     origsuggestions = generate_suggestions(10, subject_index)
-    suggestions = SuggestionFilter(threshold=0.5)(origsuggestions)
+    suggestions = SuggestionFilter(subject_index,
+                                   threshold=0.5)(origsuggestions)
     assert isinstance(suggestions, SuggestionResult)
     assert len(suggestions) == 2
 
@@ -36,7 +37,7 @@ def test_hitfilter_zero_score(subject_index):
         [SubjectSuggestion(uri='uri', label='label', notation=None,
                            score=0.0)],
         subject_index)
-    suggestions = SuggestionFilter()(origsuggestions)
+    suggestions = SuggestionFilter(subject_index)(origsuggestions)
     assert isinstance(suggestions, SuggestionResult)
     assert len(suggestions) == 0
 
@@ -62,7 +63,7 @@ def test_hitfilter_list_suggestion_results_with_deprecated_subjects(
                 notation=None,
                 score=0.5)],
         subject_index)
-    filtered_suggestions = SuggestionFilter()(suggestions)
+    filtered_suggestions = SuggestionFilter(subject_index)(suggestions)
     assert isinstance(filtered_suggestions, SuggestionResult)
     assert len(filtered_suggestions) == 2
     assert filtered_suggestions[0] == suggestions[0]
@@ -74,7 +75,7 @@ def test_hitfilter_vector_suggestion_results_with_deprecated_subjects(
     subject_index.append('http://example.org/deprecated', None, None)
     vector = np.ones(len(subject_index))
     suggestions = VectorSuggestionResult(vector, subject_index)
-    filtered_suggestions = SuggestionFilter()(suggestions)
+    filtered_suggestions = SuggestionFilter(subject_index)(suggestions)
 
     assert len(suggestions) == len(filtered_suggestions) \
         + len(subject_index.deprecated_ids())
@@ -95,7 +96,7 @@ def test_lazy_suggestion_result(subject_index):
     assert len(lar.hits) == 10
     assert lar.vector is not None
     assert lar[0] is not None
-    filtered = lar.filter(limit=5, threshold=0.0)
+    filtered = lar.filter(subject_index, limit=5, threshold=0.0)
     assert len(filtered) == 5
     assert lar._object is not None
 

--- a/tests/test_suggestion.py
+++ b/tests/test_suggestion.py
@@ -66,8 +66,10 @@ def test_hitfilter_list_suggestion_results_with_deprecated_subjects(
     filtered_suggestions = SuggestionFilter(subject_index)(suggestions)
     assert isinstance(filtered_suggestions, SuggestionResult)
     assert len(filtered_suggestions) == 2
-    assert filtered_suggestions[0] == suggestions[0]
-    assert filtered_suggestions[1] == suggestions[1]
+    assert filtered_suggestions.as_list(
+        subject_index)[0] == suggestions.as_list(subject_index)[0]
+    assert filtered_suggestions.as_list(
+        subject_index)[1] == suggestions.as_list(subject_index)[1]
 
 
 def test_hitfilter_vector_suggestion_results_with_deprecated_subjects(
@@ -85,20 +87,20 @@ def test_hitfilter_vector_suggestion_results_with_deprecated_subjects(
         label=None,
         notation=None,
         score=1.0)
-    assert deprecated in list(suggestions.hits)
-    assert deprecated not in list(filtered_suggestions.hits)
+    assert deprecated in suggestions.as_list(subject_index)
+    assert deprecated not in filtered_suggestions.as_list(subject_index)
 
 
 def test_lazy_suggestion_result(subject_index):
-    lar = LazySuggestionResult(lambda: generate_suggestions(10, subject_index))
-    assert lar._object is None
-    assert len(lar) == 10
-    assert len(lar.hits) == 10
-    assert lar.vector is not None
-    assert lar[0] is not None
-    filtered = lar.filter(subject_index, limit=5, threshold=0.0)
+    lsr = LazySuggestionResult(lambda: generate_suggestions(10, subject_index))
+    assert lsr._object is None
+    assert len(lsr) == 10
+    assert len(lsr.as_list(subject_index)) == 10
+    assert lsr.vector is not None
+    assert lsr.as_list(subject_index)[0] is not None
+    filtered = lsr.filter(subject_index, limit=5, threshold=0.0)
     assert len(filtered) == 5
-    assert lar._object is not None
+    assert lsr._object is not None
 
 
 def test_list_suggestions_vector(document_corpus, subject_index):

--- a/tests/test_suggestion.py
+++ b/tests/test_suggestion.py
@@ -14,7 +14,7 @@ def generate_suggestions(n, subject_index):
                                              label='hit {}'.format(i),
                                              notation=None,
                                              score=1.0 / (i + 1)))
-    return ListSuggestionResult(suggestions, subject_index)
+    return ListSuggestionResult(suggestions)
 
 
 def test_hitfilter_limit(subject_index):
@@ -35,8 +35,7 @@ def test_hitfilter_threshold(subject_index):
 def test_hitfilter_zero_score(subject_index):
     origsuggestions = ListSuggestionResult(
         [SubjectSuggestion(uri='uri', label='label', notation=None,
-                           score=0.0)],
-        subject_index)
+                           score=0.0)])
     suggestions = SuggestionFilter(subject_index)(origsuggestions)
     assert isinstance(suggestions, SuggestionResult)
     assert len(suggestions) == 0
@@ -61,8 +60,7 @@ def test_hitfilter_list_suggestion_results_with_deprecated_subjects(
                 uri='http://example.org/deprecated',
                 label=None,
                 notation=None,
-                score=0.5)],
-        subject_index)
+                score=0.5)])
     filtered_suggestions = SuggestionFilter(subject_index)(suggestions)
     assert isinstance(filtered_suggestions, SuggestionResult)
     assert len(filtered_suggestions) == 2
@@ -76,7 +74,7 @@ def test_hitfilter_vector_suggestion_results_with_deprecated_subjects(
         subject_index):
     subject_index.append('http://example.org/deprecated', None, None)
     vector = np.ones(len(subject_index))
-    suggestions = VectorSuggestionResult(vector, subject_index)
+    suggestions = VectorSuggestionResult(vector)
     filtered_suggestions = SuggestionFilter(subject_index)(suggestions)
 
     assert len(suggestions) == len(filtered_suggestions) \
@@ -115,8 +113,7 @@ def test_list_suggestions_vector(document_corpus, subject_index):
                 uri='http://www.yso.fi/onto/yso/p6479',
                 label='viikingit',
                 notation=None,
-                score=0.5)],
-        subject_index)
+                score=0.5)])
     vector = suggestions.as_vector(subject_index)
     assert isinstance(vector, np.ndarray)
     assert len(vector) == len(subject_index)
@@ -137,6 +134,5 @@ def test_list_suggestions_vector_notfound(document_corpus, subject_index):
                 uri='http://example.com/notfound',
                 label='not found',
                 notation=None,
-                score=1.0)],
-        subject_index)
+                score=1.0)])
     assert suggestions.as_vector(subject_index).sum() == 0


### PR DESCRIPTION
This PR makes it possible to use multiprocessing to speed up the `eval` command.

The majority of the changes are actually refactorings to decouple the subject index from the SuggestionResult classes. After the changes, SuggestionResult instances no longer keep a reference to SubjectIndex. Instead a SubjectIndex is passed as a parameter to individual SuggestionResult methods as necessary. Since properties cannot take parameters, the `hits` property has been changed to the `as_list` method and the `vector` property has been changed to the `as_vector` method.

The actual multiprocessing implementation is still very rough and further changes are needed:

- [x] make it possible to select the number of parallel jobs (e.g. using a `--jobs` CLI argument)
- [x] don't use multiprocessing module if jobs=1
- [x] (try to) optimize VectorSuggestionResult.filter() so it won't return large vectors which cause serialization/deserialization overhead
- [x] test with different backends to make sure that they perform well (measure CPU time, wall time, peak memory) and don't have race conditions or other similar issues

Fixes #65