### PR TITLE
WEB-UI: Remove empty entry from list of projects.

### DIFF
--- a/annif/templates/home.html
+++ b/annif/templates/home.html
@@ -114,7 +114,6 @@ Vue.component('annif-projects', {
   <div class="form-group">\
     <label for="project">Project (vocabulary and language):</label>\
     <select class="form-control" id="project" @input="handleProjectSelected">\
-      <option></option>\
       <option v-for="project in projects" v-bind:value="project.project_id"><% project.name %></option>\
     </select>\
   </div>\


### PR DESCRIPTION
Remove an empty entry in the Vue.js UI. With the change, the first element of project list is selected by default. Therefore the user does not need to select a project manually.