### PR TITLE
Pin SciPy to 1.4.1 as required by TensorFlow 2.2.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
         'nltk',
         'gensim==3.8.*',
         'scikit-learn==0.22.*',
+        'scipy==1.4.1',
         'rdflib',
         'gunicorn',
         'numpy==1.17.*',


### PR DESCRIPTION
SciPy 1.5.0 was just released, but TensorFlow 2.2.0 complains that it needs 1.4.1.