### PR TITLE
Assign first retrieved project to selected variable.

### DIFF
--- a/annif/templates/home.html
+++ b/annif/templates/home.html
@@ -170,6 +170,9 @@ new Vue({
         method: 'GET',
         success: function(data) {
           this_.projects = data.projects;
+          if(data.projects && data.projects.length > 0){
+            this_.project = data.projects[0].project_id
+          }
         },
         error: function(data) {
           if (data.responseJSON == null) {


### PR DESCRIPTION
My last PR selected the first project only visually. When trying to analyze text in the web UI, before selecting another project than the first, the user was asked to select a project. The only way to select the first project was to select another project and then again select the first project from the drop down menu. Sorry for the mess.