### PR TITLE
Memory optimization: Avoid double allocation of NumPy arrays in eval operation

### DIFF
--- a/annif/corpus/subject.py
+++ b/annif/corpus/subject.py
@@ -161,23 +161,23 @@ class SubjectSet:
         """returns True if the URIs for all subjects are known"""
         return len(self.subject_uris) >= len(self.subject_labels)
 
-    def as_vector(self, subject_index, target=None):
+    def as_vector(self, subject_index, destination=None):
         """Return the hits as a one-dimensional NumPy array in sklearn
            multilabel indicator format, using a subject index as the source
-           of subjects. Use target array if given (not None), otherwise create
-           and return a new one."""
+           of subjects. Use destination array if given (not None), otherwise
+           create and return a new one."""
 
-        if target is None:
-            target = np.zeros(len(subject_index), dtype=bool)
+        if destination is None:
+            destination = np.zeros(len(subject_index), dtype=bool)
 
         if self.has_uris():
             for uri in self.subject_uris:
                 subject_id = subject_index.by_uri(uri)
                 if subject_id is not None:
-                    target[subject_id] = True
+                    destination[subject_id] = True
         else:
             for label in self.subject_labels:
                 subject_id = subject_index.by_label(label)
                 if subject_id is not None:
-                    target[subject_id] = True
-        return target
+                    destination[subject_id] = True
+        return destination

--- a/annif/corpus/subject.py
+++ b/annif/corpus/subject.py
@@ -161,20 +161,23 @@ class SubjectSet:
         """returns True if the URIs for all subjects are known"""
         return len(self.subject_uris) >= len(self.subject_labels)
 
-    def as_vector(self, subject_index):
+    def as_vector(self, subject_index, target=None):
         """Return the hits as a one-dimensional NumPy array in sklearn
            multilabel indicator format, using a subject index as the source
-           of subjects."""
+           of subjects. Use target array if given (not None), otherwise create
+           and return a new one."""
 
-        vector = np.zeros(len(subject_index), dtype=bool)
+        if target is None:
+            target = np.zeros(len(subject_index), dtype=bool)
+
         if self.has_uris():
             for uri in self.subject_uris:
                 subject_id = subject_index.by_uri(uri)
                 if subject_id is not None:
-                    vector[subject_id] = True
+                    target[subject_id] = True
         else:
             for label in self.subject_labels:
                 subject_id = subject_index.by_label(label)
                 if subject_id is not None:
-                    vector[subject_id] = True
-        return vector
+                    target[subject_id] = True
+        return target

--- a/annif/eval.py
+++ b/annif/eval.py
@@ -202,11 +202,13 @@ class EvaluationBatch:
         if not self._samples:
             raise NotSupportedException("cannot evaluate empty corpus")
 
-        y_true = np.array([gold_subjects.as_vector(self._subject_index)
-                           for hits, gold_subjects in self._samples])
-        y_pred = np.array([hits.as_vector(self._subject_index)
-                           for hits, gold_subjects in self._samples],
-                          dtype=np.float32)
+        shape = (len(self._samples), len(self._subject_index))
+        y_true = np.zeros(shape, dtype=bool)
+        y_pred = np.zeros(shape, dtype=np.float32)
+
+        for idx, (hits, gold_subjects) in enumerate(self._samples):
+            gold_subjects.as_vector(self._subject_index, target=y_true[idx])
+            hits.as_vector(self._subject_index, target=y_pred[idx])
 
         results = self._evaluate_samples(
             y_true, y_pred, metrics)

--- a/annif/eval.py
+++ b/annif/eval.py
@@ -207,11 +207,11 @@ class EvaluationBatch:
         y_pred = np.zeros(shape, dtype=np.float32)
 
         for idx, (hits, gold_subjects) in enumerate(self._samples):
-            gold_subjects.as_vector(self._subject_index, target=y_true[idx])
-            hits.as_vector(self._subject_index, target=y_pred[idx])
+            gold_subjects.as_vector(self._subject_index,
+                                    destination=y_true[idx])
+            hits.as_vector(self._subject_index, destination=y_pred[idx])
 
-        results = self._evaluate_samples(
-            y_true, y_pred, metrics)
+        results = self._evaluate_samples(y_true, y_pred, metrics)
         results['Documents evaluated'] = y_true.shape[0]
 
         if results_file:

--- a/annif/suggestion.py
+++ b/annif/suggestion.py
@@ -37,9 +37,11 @@ class SuggestionResult(metaclass=abc.ABCMeta):
         pass  # pragma: no cover
 
     @abc.abstractmethod
-    def as_vector(self, subject_index):
+    def as_vector(self, subject_index, target=None):
         """Return the hits as a one-dimensional score vector
-        where the indexes match the given subject index."""
+        where the indexes match the given subject index. If target array
+        is given (not None) it will be used, otherwise a new array will
+        be created."""
         pass  # pragma: no cover
 
     @abc.abstractmethod
@@ -73,9 +75,9 @@ class LazySuggestionResult(SuggestionResult):
         self._initialize()
         return self._object.as_list(subject_index)
 
-    def as_vector(self, subject_index):
+    def as_vector(self, subject_index, target=None):
         self._initialize()
-        return self._object.as_vector(subject_index)
+        return self._object.as_vector(subject_index, target)
 
     def filter(self, subject_index, limit=None, threshold=0.0):
         self._initialize()
@@ -120,7 +122,10 @@ class VectorSuggestionResult(SuggestionResult):
             self._lsr = self._vector_to_list_suggestion(subject_index)
         return self._lsr.as_list(subject_index)
 
-    def as_vector(self, subject_index):
+    def as_vector(self, subject_index, target=None):
+        if target is not None:
+            np.copyto(target, self._vector)
+            return target
         return self._vector
 
     def filter(self, subject_index, limit=None, threshold=0.0):
@@ -165,20 +170,22 @@ class ListSuggestionResult(SuggestionResult):
                                   score=hit.score))
         return ListSuggestionResult(subject_suggestions)
 
-    def _list_to_vector(self, subject_index):
-        vector = np.zeros(len(subject_index), dtype=np.float32)
+    def _list_to_vector(self, subject_index, target):
+        if target is None:
+            target = np.zeros(len(subject_index), dtype=np.float32)
+
         for hit in self._list:
             subject_id = subject_index.by_uri(hit.uri)
             if subject_id is not None:
-                vector[subject_id] = hit.score
-        return vector
+                target[subject_id] = hit.score
+        return target
 
     def as_list(self, subject_index):
         return self._list
 
-    def as_vector(self, subject_index):
+    def as_vector(self, subject_index, target=None):
         if self._vector is None:
-            self._vector = self._list_to_vector(subject_index)
+            self._vector = self._list_to_vector(subject_index, target)
         return self._vector
 
     def filter(self, subject_index, limit=None, threshold=0.0):

--- a/annif/suggestion.py
+++ b/annif/suggestion.py
@@ -37,9 +37,9 @@ class SuggestionResult(metaclass=abc.ABCMeta):
         pass  # pragma: no cover
 
     @abc.abstractmethod
-    def as_vector(self, subject_index, target=None):
+    def as_vector(self, subject_index, destination=None):
         """Return the hits as a one-dimensional score vector
-        where the indexes match the given subject index. If target array
+        where the indexes match the given subject index. If destination array
         is given (not None) it will be used, otherwise a new array will
         be created."""
         pass  # pragma: no cover
@@ -75,9 +75,9 @@ class LazySuggestionResult(SuggestionResult):
         self._initialize()
         return self._object.as_list(subject_index)
 
-    def as_vector(self, subject_index, target=None):
+    def as_vector(self, subject_index, destination=None):
         self._initialize()
-        return self._object.as_vector(subject_index, target)
+        return self._object.as_vector(subject_index, destination)
 
     def filter(self, subject_index, limit=None, threshold=0.0):
         self._initialize()
@@ -122,10 +122,10 @@ class VectorSuggestionResult(SuggestionResult):
             self._lsr = self._vector_to_list_suggestion(subject_index)
         return self._lsr.as_list(subject_index)
 
-    def as_vector(self, subject_index, target=None):
-        if target is not None:
-            np.copyto(target, self._vector)
-            return target
+    def as_vector(self, subject_index, destination=None):
+        if destination is not None:
+            np.copyto(destination, self._vector)
+            return destination
         return self._vector
 
     def filter(self, subject_index, limit=None, threshold=0.0):
@@ -170,22 +170,22 @@ class ListSuggestionResult(SuggestionResult):
                                   score=hit.score))
         return ListSuggestionResult(subject_suggestions)
 
-    def _list_to_vector(self, subject_index, target):
-        if target is None:
-            target = np.zeros(len(subject_index), dtype=np.float32)
+    def _list_to_vector(self, subject_index, destination):
+        if destination is None:
+            destination = np.zeros(len(subject_index), dtype=np.float32)
 
         for hit in self._list:
             subject_id = subject_index.by_uri(hit.uri)
             if subject_id is not None:
-                target[subject_id] = hit.score
-        return target
+                destination[subject_id] = hit.score
+        return destination
 
     def as_list(self, subject_index):
         return self._list
 
-    def as_vector(self, subject_index, target=None):
+    def as_vector(self, subject_index, destination=None):
         if self._vector is None:
-            self._vector = self._list_to_vector(subject_index, target)
+            self._vector = self._list_to_vector(subject_index, destination)
         return self._vector
 
     def filter(self, subject_index, limit=None, threshold=0.0):

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -48,14 +48,14 @@ def test_subjectset_as_vector(subject_index):
     assert vector.sum() == 1  # only one known subject
 
 
-def test_subjectset_as_vector_target(subject_index):
+def test_subjectset_as_vector_destination(subject_index):
     uris = ['http://www.yso.fi/onto/yso/p10849', 'http://example.org/unknown']
     labels = ['arkeologit', 'unknown-subject']
     sset = annif.corpus.SubjectSet((uris, labels))
-    target = np.zeros(len(subject_index), dtype=np.float32)
-    vector = sset.as_vector(subject_index, target=target)
+    destination = np.zeros(len(subject_index), dtype=np.float32)
+    vector = sset.as_vector(subject_index, destination=destination)
     assert vector.sum() == 1  # only one known subject
-    assert vector is target
+    assert vector is destination
 
 
 def test_docdir_key(tmpdir):

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -1,6 +1,7 @@
 """Unit tests for corpus functionality in Annif"""
 
 import gzip
+import numpy as np
 import annif.corpus
 
 
@@ -45,6 +46,16 @@ def test_subjectset_as_vector(subject_index):
     sset = annif.corpus.SubjectSet((uris, labels))
     vector = sset.as_vector(subject_index)
     assert vector.sum() == 1  # only one known subject
+
+
+def test_subjectset_as_vector_target(subject_index):
+    uris = ['http://www.yso.fi/onto/yso/p10849', 'http://example.org/unknown']
+    labels = ['arkeologit', 'unknown-subject']
+    sset = annif.corpus.SubjectSet((uris, labels))
+    target = np.zeros(len(subject_index), dtype=np.float32)
+    vector = sset.as_vector(subject_index, target=target)
+    assert vector.sum() == 1  # only one known subject
+    assert vector is target
 
 
 def test_docdir_key(tmpdir):

--- a/tests/test_suggestion.py
+++ b/tests/test_suggestion.py
@@ -127,7 +127,7 @@ def test_list_suggestions_vector(document_corpus, subject_index):
             assert score == 0.0
 
 
-def test_list_suggestions_vector_target(document_corpus, subject_index):
+def test_list_suggestions_vector_destination(document_corpus, subject_index):
     suggestions = ListSuggestionResult(
         [
             SubjectSuggestion(
@@ -140,9 +140,9 @@ def test_list_suggestions_vector_target(document_corpus, subject_index):
                 label='viikingit',
                 notation=None,
                 score=0.5)])
-    target = np.zeros(len(subject_index), dtype=np.float32)
-    vector = suggestions.as_vector(subject_index, target=target)
-    assert vector is target
+    destination = np.zeros(len(subject_index), dtype=np.float32)
+    vector = suggestions.as_vector(subject_index, destination=destination)
+    assert vector is destination
 
 
 def test_list_suggestions_vector_notfound(document_corpus, subject_index):
@@ -163,12 +163,12 @@ def test_vector_suggestions_as_vector(subject_index):
     assert (vector == orig_vector).all()
 
 
-def test_vector_suggestions_as_vector_target(subject_index):
+def test_vector_suggestions_as_vector_destination(subject_index):
     orig_vector = np.ones(len(subject_index), dtype=np.float32)
     suggestions = VectorSuggestionResult(orig_vector)
-    target = np.zeros(len(subject_index), dtype=np.float32)
-    assert not (target == orig_vector).all()  # target is all zeros
+    destination = np.zeros(len(subject_index), dtype=np.float32)
+    assert not (destination == orig_vector).all()  # destination is all zeros
 
-    vector = suggestions.as_vector(subject_index, target=target)
-    assert vector is target
-    assert (target == orig_vector).all()      # target is now all ones
+    vector = suggestions.as_vector(subject_index, destination=destination)
+    assert vector is destination
+    assert (destination == orig_vector).all()      # destination now all ones

--- a/tests/test_suggestion.py
+++ b/tests/test_suggestion.py
@@ -127,6 +127,24 @@ def test_list_suggestions_vector(document_corpus, subject_index):
             assert score == 0.0
 
 
+def test_list_suggestions_vector_target(document_corpus, subject_index):
+    suggestions = ListSuggestionResult(
+        [
+            SubjectSuggestion(
+                uri='http://www.yso.fi/onto/yso/p7141',
+                label='sinetit',
+                notation=None,
+                score=1.0),
+            SubjectSuggestion(
+                uri='http://www.yso.fi/onto/yso/p6479',
+                label='viikingit',
+                notation=None,
+                score=0.5)])
+    target = np.zeros(len(subject_index), dtype=np.float32)
+    vector = suggestions.as_vector(subject_index, target=target)
+    assert vector is target
+
+
 def test_list_suggestions_vector_notfound(document_corpus, subject_index):
     suggestions = ListSuggestionResult(
         [
@@ -136,3 +154,21 @@ def test_list_suggestions_vector_notfound(document_corpus, subject_index):
                 notation=None,
                 score=1.0)])
     assert suggestions.as_vector(subject_index).sum() == 0
+
+
+def test_vector_suggestions_as_vector(subject_index):
+    orig_vector = np.ones(len(subject_index), dtype=np.float32)
+    suggestions = VectorSuggestionResult(orig_vector)
+    vector = suggestions.as_vector(subject_index)
+    assert (vector == orig_vector).all()
+
+
+def test_vector_suggestions_as_vector_target(subject_index):
+    orig_vector = np.ones(len(subject_index), dtype=np.float32)
+    suggestions = VectorSuggestionResult(orig_vector)
+    target = np.zeros(len(subject_index), dtype=np.float32)
+    assert not (target == orig_vector).all()  # target is all zeros
+
+    vector = suggestions.as_vector(subject_index, target=target)
+    assert vector is target
+    assert (target == orig_vector).all()      # target is now all ones


### PR DESCRIPTION
This PR changes the way NumPy arrays are allocated during evaluation operations. Instead of allocating N one-dimensional vectors (where N is the number of documents) and then combining them into a single 2D vector, the 2D vector is allocated up front. This reduces the memory usage a bit. I was hoping to see a speedup as well, but so far it seems there is no measurable difference. I will run a few more benchmarks to verify before merging.

TODO:

- [x] benchmark a few different types of backends (currently just Omikuji has been tested)
- [ ] check and address QA tool complaints