### PR TITLE
Make modification timestamps timezone-aware

### DIFF
--- a/annif/backend/backend.py
+++ b/annif/backend/backend.py
@@ -2,7 +2,7 @@
 
 import abc
 import os.path
-from datetime import datetime
+from datetime import datetime, timezone
 from glob import glob
 from annif import logger
 
@@ -41,9 +41,12 @@ class AnnifBackend(metaclass=abc.ABCMeta):
 
     @property
     def modification_time(self):
-        mtimes = [datetime.fromtimestamp(os.path.getmtime(p))
+        mtimes = [datetime.utcfromtimestamp(os.path.getmtime(p))
                   for p in glob(os.path.join(self.datadir, '*'))]
-        return max(mtimes, default=None)
+        most_recent = max(mtimes, default=None)
+        if most_recent is None:
+            return None
+        return most_recent.replace(tzinfo=timezone.utc)
 
     def _get_backend_params(self, params):
         backend_params = dict(self.params)

--- a/annif/backend/http.py
+++ b/annif/backend/http.py
@@ -2,6 +2,7 @@
 and returns the results"""
 
 
+import dateutil.parser
 import requests
 import requests.exceptions
 from annif.suggestion import SubjectSuggestion, ListSuggestionResult
@@ -18,7 +19,10 @@ class HTTPBackend(backend.AnnifBackend):
 
     @property
     def modification_time(self):
-        return self._get_project_info('modification_time')
+        mtime = self._get_project_info('modification_time')
+        if mtime is None:
+            return None
+        return dateutil.parser.parse(mtime)
 
     def _get_project_info(self, key):
         params = self._get_backend_params(None)

--- a/annif/backend/maui.py
+++ b/annif/backend/maui.py
@@ -4,9 +4,9 @@
 import time
 import os.path
 import json
+import dateutil.parser
 import requests
 import requests.exceptions
-from datetime import datetime
 from annif.exception import ConfigurationException
 from annif.exception import NotSupportedException
 from annif.exception import OperationFailedException
@@ -26,8 +26,9 @@ class MauiBackend(backend.AnnifBackend):
     @property
     def modification_time(self):
         mtime = self._get_project_info('end_time')
-        if mtime is not None:
-            return datetime.strptime(mtime, '%Y-%m-%dT%H:%M:%S.%fZ')
+        if mtime is None:
+            return None
+        return dateutil.parser.parse(mtime)
 
     def _get_project_info(self, key):
         params = self._get_backend_params(None)

--- a/tests/test_backend_http.py
+++ b/tests/test_backend_http.py
@@ -1,5 +1,6 @@
 """Unit tests for the HTTP backend in Annif"""
 
+from datetime import datetime, timezone
 import pytest
 import requests.exceptions
 import unittest.mock
@@ -160,7 +161,7 @@ def test_http_modification_time(project):
         # define here
         mock_response = unittest.mock.Mock()
         mock_response.json.return_value = {'modification_time':
-                                           '1970-1-1 00:00:00'}
+                                           '1970-01-01T00:00:00.000Z'}
         mock_request.return_value = mock_response
 
         http_type = annif.backend.get_backend("http")
@@ -170,7 +171,8 @@ def test_http_modification_time(project):
                 'endpoint': 'http://api.example.org/analyze',
                 'project': 'dummy'},
             project=project)
-        assert http.modification_time == '1970-1-1 00:00:00'
+        assert http.modification_time == datetime(
+            1970, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
 
 
 def test_http_get_project_info_http_error(project):

--- a/tests/test_backend_http.py
+++ b/tests/test_backend_http.py
@@ -175,6 +175,24 @@ def test_http_modification_time(project):
             1970, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
 
 
+def test_http_modification_time_none(project):
+    with unittest.mock.patch('requests.get') as mock_request:
+        # create a mock response whose .json() method returns the dict that we
+        # define here
+        mock_response = unittest.mock.Mock()
+        mock_response.json.return_value = {}
+        mock_request.return_value = mock_response
+
+        http_type = annif.backend.get_backend("http")
+        http = http_type(
+            backend_id='http',
+            config_params={
+                'endpoint': 'http://api.example.org/analyze',
+                'project': 'dummy'},
+            project=project)
+        assert http.modification_time is None
+
+
 def test_http_get_project_info_http_error(project):
     with unittest.mock.patch('requests.get') as mock_request:
         mock_request.side_effect = requests.exceptions.RequestException(

--- a/tests/test_backend_maui.py
+++ b/tests/test_backend_maui.py
@@ -318,6 +318,14 @@ def test_maui_modification_time_offset(maui, project):
         1970, 1, 1, 21, 0, 0, tzinfo=timezone.utc)
 
 
+@responses.activate
+def test_maui_modification_time_none(maui, project):
+    responses.add(responses.GET,
+                  'http://api.example.org/mauiservice/dummy/train',
+                  json={})
+    assert maui.modification_time is None
+
+
 def test_maui_get_project_info_http_error(maui, project):
     with unittest.mock.patch('requests.get') as mock_request:
         mock_request.side_effect = requests.exceptions.RequestException(

--- a/tests/test_backend_maui.py
+++ b/tests/test_backend_maui.py
@@ -4,7 +4,7 @@ import requests.exceptions
 import responses
 import unittest.mock
 import pytest
-from datetime import datetime
+from datetime import datetime, timezone
 import annif.backend.maui
 from annif.exception import ConfigurationException
 from annif.exception import NotSupportedException
@@ -301,11 +301,21 @@ def test_maui_is_trained(maui, project):
 
 
 @responses.activate
-def test_maui_modification_time(maui, project):
+def test_maui_modification_time_utc(maui, project):
     responses.add(responses.GET,
                   'http://api.example.org/mauiservice/dummy/train',
                   json={"end_time": '1970-01-01T00:00:00.000Z'})
-    assert maui.modification_time == datetime(1970, 1, 1, 0, 0, 0)
+    assert maui.modification_time == datetime(
+        1970, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+
+
+@responses.activate
+def test_maui_modification_time_offset(maui, project):
+    responses.add(responses.GET,
+                  'http://api.example.org/mauiservice/dummy/train',
+                  json={"end_time": '1970-01-02T00:00:00.000+03:00'})
+    assert maui.modification_time == datetime(
+        1970, 1, 1, 21, 0, 0, tzinfo=timezone.utc)
 
 
 def test_maui_get_project_info_http_error(maui, project):

--- a/tests/test_backend_nn_ensemble.py
+++ b/tests/test_backend_nn_ensemble.py
@@ -3,7 +3,7 @@
 import time
 import pytest
 import py.path
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 import annif.backend
 import annif.corpus
 from annif.exception import NotInitializedException
@@ -129,7 +129,8 @@ def test_nn_ensemble_modification_time(app_project):
         backend_id='nn_ensemble',
         config_params={'sources': 'dummy-en'},
         project=app_project)
-    assert datetime.now() - nn_ensemble.modification_time < timedelta(1)
+    assert datetime.now(timezone.utc) - \
+        nn_ensemble.modification_time < timedelta(1)
 
 
 def test_nn_ensemble_initialize(app_project):

--- a/tests/test_backend_pav.py
+++ b/tests/test_backend_pav.py
@@ -3,7 +3,7 @@
 import logging
 import py.path
 import pytest
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 import annif.backend
 import annif.corpus
 from annif.exception import NotSupportedException
@@ -145,4 +145,4 @@ def test_pav_modification_time(app_project):
         backend_id='pav',
         config_params={'limit': 50, 'min-docs': 2, 'sources': 'dummy-fi'},
         project=app_project)
-    assert datetime.now() - pav.modification_time < timedelta(1)
+    assert datetime.now(timezone.utc) - pav.modification_time < timedelta(1)

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -2,7 +2,7 @@
 
 import logging
 import pytest
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 import annif.project
 import annif.backend.dummy
 from annif.exception import ConfigurationException, NotSupportedException
@@ -149,7 +149,8 @@ def test_project_tfidf_is_trained(registry):
 
 def test_project_tfidf_modification_time(registry):
     project = registry.get_project('tfidf-fi')
-    assert datetime.now() - project.modification_time < timedelta(1)
+    assert datetime.now(timezone.utc) - \
+        project.modification_time < timedelta(1)
 
 
 def test_project_train_tfidf_nodocuments(registry, empty_corpus):


### PR DESCRIPTION
The handling of timezones in modification timestamps was inconsistent. One symptom of this was the problem handling Maui Server timestamps (#431) but there were other issues as well, such as not being able to parse all RFC3339 compliant formats, problems with fractions of seconds etc.

This PR fixes many related issues. The basic principles are:
* modification times are now represented internally as timezone-aware datetime objects, always with timezone set to UTC
* use `dateutil.parser.parse` to parse incoming date strings (from Maui Server or HTTP endpoint), since it can handle many format variations

Fixes #431