### PR TITLE
Upgrade TensorFlow to version 2.3.0 (from 2.2.0)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ RUN apt-get update \
 	&& pip install --no-cache-dir \
 		voikko \
 		vowpalwabbit==8.7.* \
-		tensorflow-cpu==2.2.0 \
+		tensorflow-cpu==2.3.0 \
 		omikuji==0.3.* \
 	# For Docker healthcheck:
 	&& apt-get install -y --no-install-recommends curl \

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
         'fasttext': ['fasttext==0.9.2'],
         'voikko': ['voikko'],
         'vw': ['vowpalwabbit==8.7.*'],
-        'nn': ['tensorflow-cpu==2.2.0', 'lmdb==0.98'],
+        'nn': ['tensorflow-cpu==2.3.0', 'lmdb==0.98'],
         'omikuji': ['omikuji==0.3.*'],
         'dev': [
             'codecov',


### PR DESCRIPTION
TensorFlow 2.3.0 was just released. This PR updates Annif to use it. None of the changes in the 2.3.0 release seem relevant for Annif, so this is just for keeping up to date.