### PR TITLE
upgrade LMDB dependency from 0.98 to 1.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN apt-get update \
 	&& pip install --no-cache-dir \
 		vowpalwabbit==8.7.* \
         ## LMDB
-        && pip install --no-cache-dir lmdb==0.98
+        && pip install --no-cache-dir lmdb==1.0.0
 
 
 

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
         'fasttext': ['fasttext==0.9.2'],
         'voikko': ['voikko'],
         'vw': ['vowpalwabbit==8.7.*'],
-        'nn': ['tensorflow-cpu==2.3.0', 'lmdb==0.98'],
+        'nn': ['tensorflow-cpu==2.3.0', 'lmdb==1.0.0'],
         'omikuji': ['omikuji==0.3.*'],
         'dev': [
             'codecov',


### PR DESCRIPTION
While working on #444 I noticed that there was a new release of LMDB, with a new (semantic) version number scheme.
This PR upgrades the LMDB dependency from 0.98 to 1.0.0. The actual changes should be very minor.