### PR TITLE
Fix missing default params in pav and nn ensemble

### DIFF
--- a/annif/backend/nn_ensemble.py
+++ b/annif/backend/nn_ensemble.py
@@ -98,8 +98,7 @@ class NNEnsembleBackend(
     _model = None
 
     def default_params(self):
-        params = {}
-        params.update(super().default_params())
+        params = backend.AnnifBackend.DEFAULT_PARAMETERS.copy()
         params.update(self.DEFAULT_PARAMETERS)
         return params
 

--- a/annif/backend/pav.py
+++ b/annif/backend/pav.py
@@ -12,6 +12,7 @@ import annif.corpus
 import annif.suggestion
 import annif.util
 from annif.exception import NotInitializedException, NotSupportedException
+from . import backend
 from . import ensemble
 
 
@@ -25,6 +26,11 @@ class PAVBackend(ensemble.BaseEnsembleBackend):
     _models = None
 
     DEFAULT_PARAMETERS = {'min-docs': 10}
+
+    def default_params(self):
+        params = backend.AnnifBackend.DEFAULT_PARAMETERS.copy()
+        params.update(self.DEFAULT_PARAMETERS)
+        return params
 
     def initialize(self):
         super().initialize()

--- a/tests/test_backend_nn_ensemble.py
+++ b/tests/test_backend_nn_ensemble.py
@@ -147,7 +147,7 @@ def test_nn_ensemble_initialize(app_project):
     nn_ensemble.initialize()
 
 
-def test_nn_ensemble_default_params(document_corpus, app_project):
+def test_nn_ensemble_default_params(app_project):
     nn_ensemble_type = annif.backend.get_backend("nn_ensemble")
     nn_ensemble = nn_ensemble_type(
         backend_id='nn_ensemble',

--- a/tests/test_backend_nn_ensemble.py
+++ b/tests/test_backend_nn_ensemble.py
@@ -147,6 +147,22 @@ def test_nn_ensemble_initialize(app_project):
     nn_ensemble.initialize()
 
 
+def test_nn_ensemble_default_params(document_corpus, app_project):
+    nn_ensemble_type = annif.backend.get_backend("nn_ensemble")
+    nn_ensemble = nn_ensemble_type(
+        backend_id='nn_ensemble',
+        config_params={'sources': 'dummy-en'},
+        project=app_project)
+
+    expected_default_params = {
+        'optimizer': 'adam',
+        'limit': 100,
+    }
+    actual_params = nn_ensemble.params
+    for param, val in expected_default_params.items():
+        assert param in actual_params and actual_params[param] == val
+
+
 def test_nn_ensemble_suggest(app_project):
     nn_ensemble_type = annif.backend.get_backend("nn_ensemble")
     nn_ensemble = nn_ensemble_type(

--- a/tests/test_backend_pav.py
+++ b/tests/test_backend_pav.py
@@ -18,6 +18,7 @@ def test_pav_default_params(document_corpus, app_project):
 
     expected_default_params = {
         'min-docs': 10,
+        'limit': 100,
     }
     actual_params = pav.params
     for param, val in expected_default_params.items():


### PR DESCRIPTION
As noted in #446 there was a bug concerning the default parameters in PAV and nn_ensemble. 

> > and with nn_ensemble there is similar case.
> 
> I don't see the problem there? The default parameters are combined from the superclass and the current class.

For some reason the default parameters from AnnifBackend were not present in NNEnsembleBackend (for now only the `limit` parameter). Seems like even if the "right method" i.e. `default_params(self)` from AnnifBackend was in use via `super()`, the `self` in this case was the object of NNEnsembleBackend class, which has its own `DEFAULT_PARAMETERS` field.
