### PR TITLE
Resolve DeprecationWarning by pytest: change warn to warning

### DIFF
--- a/annif/project.py
+++ b/annif/project.py
@@ -172,7 +172,7 @@ class AnnifProject(DatadirMixin):
         list of SubjectSuggestion objects ordered by decreasing score."""
         if not self.is_trained:
             if self.is_trained is None:
-                logger.warn('Could not get train state information.')
+                logger.warning('Could not get train state information.')
             else:
                 raise NotInitializedException('Project is not trained.')
         logger.debug('Suggesting subjects for text "%s..." (len=%d)',


### PR DESCRIPTION
This fixes one `DeprecationWarning` that `pytest` has been giving for a while:
```
tests/test_project.py::test_project_train_state_not_available
  /home/local/jmminkin/git/Annif/annif/project.py:175: DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
    logger.warn('Could not get train state information.')
```
(Two other `DeprecationWarning`s remain, but they are from TensorFlow package.)