### PR TITLE
Apply the input_limit backend parameter to texts in train & learn 

### DIFF
--- a/annif/backend/backend.py
+++ b/annif/backend/backend.py
@@ -5,6 +5,7 @@ import os.path
 from datetime import datetime, timezone
 from glob import glob
 from annif import logger
+from annif.corpus import TruncatingDocumentCorpus
 
 
 class AnnifBackend(metaclass=abc.ABCMeta):
@@ -63,6 +64,9 @@ class AnnifBackend(metaclass=abc.ABCMeta):
     def train(self, corpus, params=None):
         """Train the model on the given document or subject corpus."""
         beparams = self._get_backend_params(params)
+        if int(beparams['input_limit']) != 0:
+            corpus = TruncatingDocumentCorpus(corpus,
+                                              int(beparams['input_limit']))
         return self._train(corpus, params=beparams)
 
     def initialize(self):
@@ -110,4 +114,7 @@ class AnnifLearningBackend(AnnifBackend):
     def learn(self, corpus, params=None):
         """Further train the model on the given document or subject corpus."""
         beparams = self._get_backend_params(params)
+        if int(beparams['input_limit']) != 0:
+            corpus = TruncatingDocumentCorpus(corpus,
+                                              int(beparams['input_limit']))
         return self._learn(corpus, params=beparams)

--- a/annif/backend/backend.py
+++ b/annif/backend/backend.py
@@ -63,6 +63,8 @@ class AnnifBackend(metaclass=abc.ABCMeta):
     def train(self, corpus, params=None):
         """Train the model on the given document or subject corpus."""
         beparams = self._get_backend_params(params)
+        if int(beparams['input_limit']) != 0:
+            corpus.text_limit = int(beparams['input_limit'])
         return self._train(corpus, params=beparams)
 
     def initialize(self):
@@ -110,4 +112,6 @@ class AnnifLearningBackend(AnnifBackend):
     def learn(self, corpus, params=None):
         """Further train the model on the given document or subject corpus."""
         beparams = self._get_backend_params(params)
+        if int(beparams['input_limit']) != 0:
+            corpus.text_limit = int(beparams['input_limit'])
         return self._learn(corpus, params=beparams)

--- a/annif/backend/backend.py
+++ b/annif/backend/backend.py
@@ -63,8 +63,6 @@ class AnnifBackend(metaclass=abc.ABCMeta):
     def train(self, corpus, params=None):
         """Train the model on the given document or subject corpus."""
         beparams = self._get_backend_params(params)
-        if int(beparams['input_limit']) != 0:
-            corpus.text_limit = int(beparams['input_limit'])
         return self._train(corpus, params=beparams)
 
     def initialize(self):
@@ -112,6 +110,4 @@ class AnnifLearningBackend(AnnifBackend):
     def learn(self, corpus, params=None):
         """Further train the model on the given document or subject corpus."""
         beparams = self._get_backend_params(params)
-        if int(beparams['input_limit']) != 0:
-            corpus.text_limit = int(beparams['input_limit'])
         return self._learn(corpus, params=beparams)

--- a/annif/corpus/__init__.py
+++ b/annif/corpus/__init__.py
@@ -1,7 +1,8 @@
 """Annif corpus operations"""
 
 
-from .document import DocumentDirectory, DocumentFile, DocumentList
+from .document import DocumentDirectory, DocumentFile, DocumentList, \
+    TruncatingDocumentCorpus
 from .subject import Subject, SubjectFileTSV
 from .subject import SubjectIndex, SubjectSet
 from .skos import SubjectFileSKOS
@@ -10,4 +11,4 @@ from .combine import CombinedCorpus
 
 __all__ = [DocumentDirectory, DocumentFile, DocumentList, Subject,
            SubjectFileTSV, SubjectIndex, SubjectSet, SubjectFileSKOS,
-           Document, CombinedCorpus]
+           Document, CombinedCorpus, TruncatingDocumentCorpus]

--- a/annif/corpus/document.py
+++ b/annif/corpus/document.py
@@ -91,7 +91,8 @@ class DocumentList(DocumentCorpus):
 
 class TruncatingDocumentCorpus(DocumentCorpus):
     """A document corpus that wraps another document corpus but truncates the
-    documents to a given length"""
+    documents retaining a given number of characters. When the limit value is
+    negative it sets the number of characters that are dropped."""
 
     def __init__(self, corpus, limit):
         self._documents = corpus.documents

--- a/annif/corpus/document.py
+++ b/annif/corpus/document.py
@@ -87,3 +87,19 @@ class DocumentList(DocumentCorpus):
     @property
     def documents(self):
         yield from self._documents
+
+
+class TruncatingDocumentCorpus(DocumentCorpus):
+    """A document corpus that wraps another document corpus but truncates the
+    documents to a given length"""
+
+    def __init__(self, corpus, limit):
+        self._documents = corpus.documents
+        self._limit = limit
+
+    @property
+    def documents(self):
+        for doc in self._documents:
+            yield self._create_document(text=doc.text[:self._limit],
+                                        uris=doc.uris,
+                                        labels=doc.labels)

--- a/annif/corpus/document.py
+++ b/annif/corpus/document.py
@@ -17,7 +17,6 @@ class DocumentDirectory(DocumentCorpus):
     def __init__(self, path, require_subjects=False):
         self.path = path
         self.require_subjects = require_subjects
-        self.text_limit = None
 
     def __iter__(self):
         """Iterate through the directory, yielding tuples of (docfile,
@@ -41,7 +40,7 @@ class DocumentDirectory(DocumentCorpus):
         for docfilename, keyfilename in self:
             with open(docfilename, errors='replace',
                       encoding='utf-8-sig') as docfile:
-                text = docfile.read()[:self.text_limit]
+                text = docfile.read()
             with open(keyfilename, encoding='utf-8-sig') as keyfile:
                 subjects = SubjectSet.from_string(keyfile.read())
             yield self._create_document(text=text,
@@ -54,7 +53,6 @@ class DocumentFile(DocumentCorpus):
 
     def __init__(self, path):
         self.path = path
-        self.text_limit = None
 
     @property
     def documents(self):
@@ -69,7 +67,6 @@ class DocumentFile(DocumentCorpus):
     def _parse_tsv_line(self, line):
         if '\t' in line:
             text, uris = line.split('\t', maxsplit=1)
-            text = text[:self.text_limit]
             subjects = [annif.util.cleanup_uri(uri)
                         for uri in uris.split()]
             yield self._create_document(text=text,

--- a/annif/corpus/document.py
+++ b/annif/corpus/document.py
@@ -17,6 +17,7 @@ class DocumentDirectory(DocumentCorpus):
     def __init__(self, path, require_subjects=False):
         self.path = path
         self.require_subjects = require_subjects
+        self.text_limit = None
 
     def __iter__(self):
         """Iterate through the directory, yielding tuples of (docfile,
@@ -40,7 +41,7 @@ class DocumentDirectory(DocumentCorpus):
         for docfilename, keyfilename in self:
             with open(docfilename, errors='replace',
                       encoding='utf-8-sig') as docfile:
-                text = docfile.read()
+                text = docfile.read()[:self.text_limit]
             with open(keyfilename, encoding='utf-8-sig') as keyfile:
                 subjects = SubjectSet.from_string(keyfile.read())
             yield self._create_document(text=text,
@@ -53,6 +54,7 @@ class DocumentFile(DocumentCorpus):
 
     def __init__(self, path):
         self.path = path
+        self.text_limit = None
 
     @property
     def documents(self):
@@ -67,6 +69,7 @@ class DocumentFile(DocumentCorpus):
     def _parse_tsv_line(self, line):
         if '\t' in line:
             text, uris = line.split('\t', maxsplit=1)
+            text = text[:self.text_limit]
             subjects = [annif.util.cleanup_uri(uri)
                         for uri in uris.split()]
             yield self._create_document(text=text,

--- a/annif/corpus/document.py
+++ b/annif/corpus/document.py
@@ -91,8 +91,7 @@ class DocumentList(DocumentCorpus):
 
 class TruncatingDocumentCorpus(DocumentCorpus):
     """A document corpus that wraps another document corpus but truncates the
-    documents retaining a given number of characters. When the limit value is
-    negative it sets the number of characters that are dropped."""
+    documents to a given length"""
 
     def __init__(self, corpus, limit):
         self._documents = corpus.documents

--- a/tests/test_backend_tfidf.py
+++ b/tests/test_backend_tfidf.py
@@ -35,7 +35,7 @@ def test_tfidf_train(datadir, document_corpus, project):
     assert datadir.join('tfidf-index').size() > 0
 
 
-def test_tfidf_train_input_limited(datadir, document_corpus, project):
+def test_tfidf_train_input_limited(document_corpus, project):
     tfidf_type = annif.backend.get_backend("tfidf")
     tfidf = tfidf_type(
         backend_id='tfidf',
@@ -48,7 +48,7 @@ def test_tfidf_train_input_limited(datadir, document_corpus, project):
         in str(excinfo)
 
 
-def test_tfidf_train_negative_input_limit(datadir, document_corpus, project):
+def test_tfidf_train_negative_input_limit(document_corpus, project):
     tfidf_type = annif.backend.get_backend("tfidf")
     tfidf = tfidf_type(
         backend_id='tfidf',

--- a/tests/test_backend_tfidf.py
+++ b/tests/test_backend_tfidf.py
@@ -1,5 +1,6 @@
 """Unit tests for the TF-IDF backend in Annif"""
 
+import pytest
 import annif
 import annif.backend
 import annif.corpus
@@ -31,6 +32,19 @@ def test_tfidf_train(datadir, document_corpus, project):
     assert len(tfidf._index) > 0
     assert datadir.join('tfidf-index').exists()
     assert datadir.join('tfidf-index').size() > 0
+
+
+def test_tfidf_train_input_limited(datadir, document_corpus, project):
+    tfidf_type = annif.backend.get_backend("tfidf")
+    tfidf = tfidf_type(
+        backend_id='tfidf',
+        config_params={'limit': 10, 'input_limit': 1},
+        project=project)
+
+    with pytest.raises(ValueError) as excinfo:
+        tfidf.train(document_corpus)
+    assert 'empty vocabulary; perhaps the documents only contain stop words' \
+        in str(excinfo)
 
 
 def test_tfidf_suggest(project):

--- a/tests/test_backend_tfidf.py
+++ b/tests/test_backend_tfidf.py
@@ -4,6 +4,7 @@ import pytest
 import annif
 import annif.backend
 import annif.corpus
+from annif.exception import ConfigurationException
 
 
 def test_tfidf_default_params(project):
@@ -45,6 +46,16 @@ def test_tfidf_train_input_limited(datadir, document_corpus, project):
         tfidf.train(document_corpus)
     assert 'empty vocabulary; perhaps the documents only contain stop words' \
         in str(excinfo)
+
+
+def test_tfidf_train_negative_input_limit(datadir, document_corpus, project):
+    tfidf_type = annif.backend.get_backend("tfidf")
+    tfidf = tfidf_type(
+        backend_id='tfidf',
+        config_params={'limit': 10, 'input_limit': -1},
+        project=project)
+    with pytest.raises(ConfigurationException):
+        tfidf.train(document_corpus)
 
 
 def test_tfidf_suggest(project):

--- a/tests/test_backend_tfidf.py
+++ b/tests/test_backend_tfidf.py
@@ -40,7 +40,7 @@ def test_tfidf_train_input_limited(datadir, document_corpus, project):
         backend_id='tfidf',
         config_params={'limit': 10, 'input_limit': 1},
         project=project)
-
+    # Training on documents truncated to only one character fails
     with pytest.raises(ValueError) as excinfo:
         tfidf.train(document_corpus)
     assert 'empty vocabulary; perhaps the documents only contain stop words' \

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -3,6 +3,7 @@
 import gzip
 import numpy as np
 import annif.corpus
+from annif.corpus import TruncatingDocumentCorpus
 
 
 def test_subjectset_uris():
@@ -265,3 +266,9 @@ def test_combinedcorpus(tmpdir):
     combined = annif.corpus.CombinedCorpus([corpus1, corpus2])
 
     assert len(list(combined.documents)) == 6
+
+
+def test_truncatedcorpus(document_corpus):
+    truncated_corpus = TruncatingDocumentCorpus(document_corpus, 3)
+    for doc in truncated_corpus.documents:
+        assert len(doc.text) == 3

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -270,5 +270,7 @@ def test_combinedcorpus(tmpdir):
 
 def test_truncatedcorpus(document_corpus):
     truncated_corpus = TruncatingDocumentCorpus(document_corpus, 3)
-    for doc in truncated_corpus.documents:
-        assert len(doc.text) == 3
+    for truncated_doc, doc in zip(truncated_corpus.documents,
+                                  document_corpus.documents):
+        assert len(truncated_doc.text) == 3
+        assert truncated_doc.text == doc.text[:3]


### PR DESCRIPTION
…learn

Would this approach be suitable? Another way would be to apply the limit when each backend uses the document texts.

Now I see the limit would need to be applied also in [`DocumentList` class](https://github.com/NatLibFi/Annif/blob/input-limit-for-corpus-document-texts/annif/corpus/document.py#L91) as it is used by REST learn method.