### PR TITLE
Address SonarCloud complaint: use strings in __all__ statement

### DIFF
--- a/annif/corpus/__init__.py
+++ b/annif/corpus/__init__.py
@@ -9,6 +9,6 @@ from .skos import SubjectFileSKOS
 from .types import Document
 from .combine import CombinedCorpus
 
-__all__ = [DocumentDirectory, DocumentFile, DocumentList, Subject,
-           SubjectFileTSV, SubjectIndex, SubjectSet, SubjectFileSKOS,
-           Document, CombinedCorpus, TruncatingDocumentCorpus]
+__all__ = ["DocumentDirectory", "DocumentFile", "DocumentList", "Subject",
+           "SubjectFileTSV", "SubjectIndex", "SubjectSet", "SubjectFileSKOS",
+           "Document", "CombinedCorpus", "TruncatingDocumentCorpus"]


### PR DESCRIPTION
This PR addresses a number of similar complaints by SonarCloud: the `__all__` list defined in `__init__.py` [should consists of strings](https://docs.python.org/3/tutorial/modules.html#importing-from-a-package).