### PR TITLE
Improved handling of source weights in NN ensemble

### DIFF
--- a/annif/backend/nn_ensemble.py
+++ b/annif/backend/nn_ensemble.py
@@ -115,7 +115,7 @@ class NNEnsembleBackend(
         self._model = load_model(model_filename)
 
     def _merge_hits_from_sources(self, hits_from_sources, params):
-        score_vector = np.array([hits.as_vector(subjects) * weight
+        score_vector = np.array([hits.as_vector(subjects) * weight * len(hits_from_sources)
                                  for hits, weight, subjects
                                  in hits_from_sources],
                                 dtype=np.float32)
@@ -168,7 +168,7 @@ class NNEnsembleBackend(
             for source_project, weight in sources:
                 hits = source_project.suggest(doc.text)
                 doc_scores.append(
-                    hits.as_vector(source_project.subjects) * weight)
+                    hits.as_vector(source_project.subjects) * weight * len(sources))
             score_vector = np.array(doc_scores,
                                     dtype=np.float32).transpose()
             subjects = annif.corpus.SubjectSet((doc.uris, doc.labels))

--- a/annif/backend/nn_ensemble.py
+++ b/annif/backend/nn_ensemble.py
@@ -115,7 +115,8 @@ class NNEnsembleBackend(
         self._model = load_model(model_filename)
 
     def _merge_hits_from_sources(self, hits_from_sources, params):
-        score_vector = np.array([hits.as_vector(subjects) * weight * len(hits_from_sources)
+        score_vector = np.array([np.sqrt(hits.as_vector(subjects))
+                                 * weight * len(hits_from_sources)
                                  for hits, weight, subjects
                                  in hits_from_sources],
                                 dtype=np.float32)
@@ -167,8 +168,8 @@ class NNEnsembleBackend(
             doc_scores = []
             for source_project, weight in sources:
                 hits = source_project.suggest(doc.text)
-                doc_scores.append(
-                    hits.as_vector(source_project.subjects) * weight * len(sources))
+                vector = hits.as_vector(source_project.subjects)
+                doc_scores.append(np.sqrt(vector) * weight * len(sources))
             score_vector = np.array(doc_scores,
                                     dtype=np.float32).transpose()
             subjects = annif.corpus.SubjectSet((doc.uris, doc.labels))

--- a/annif/util.py
+++ b/annif/util.py
@@ -53,6 +53,7 @@ def parse_sources(sourcedef):
     tuples (src_id, weight)"""
 
     sources = []
+    totalweight = 0.0
     for srcdef in sourcedef.strip().split(','):
         srcval = srcdef.strip().split(':')
         src_id = srcval[0]
@@ -61,7 +62,8 @@ def parse_sources(sourcedef):
         else:
             weight = 1.0
         sources.append((src_id, weight))
-    return sources
+        totalweight += weight
+    return [(srcid, weight / totalweight) for srcid, weight in sources]
 
 
 def boolean(val):


### PR DESCRIPTION
This PR contains fixes aiming at improving the way the NN ensemble handles sources that have been assigned non-default weights.

1. The weights assigned to source backends are now always normalized so that they add up to 1 (L1 normalization).
2. The NN ensemble multiplies incoming score vectors by the assigned weights. Since the normalized weights are now generally smaller than they used to be (e.g. not 1:1:1 but 0.33:0.33:0.33), they are multiplied - outside the neural network - by the number of sources to compensate for this change.
3. While researching this, I discovered that the NN ensemble performs better when the incoming weights are slightly larger numerically. Taking the square root of the scores (which increases the scores, since sqrt(x) > x when 0<x<1) before feeding them to the neural network seems to improve F1@5 scores by an additional 1-2 percentage points!

Fixes #457