### PR TITLE
Pass limit parameter to Maui Server during train

### DIFF
--- a/annif/backend/maui.py
+++ b/annif/backend/maui.py
@@ -79,7 +79,9 @@ class MauiBackend(backend.AnnifBackend):
                    .format(self.tagger(params), resp.status_code))
 
         # create a new tagger
-        data = {'id': self.tagger(params), 'lang': params['language']}
+        data = {'id': self.tagger(params),
+                'lang': params['language'],
+                'max_topics_per_document': int(params['limit'])}
         json = {}
         try:
             resp = requests.post(self.endpoint(params), data=data)

--- a/tests/test_backend_maui.py
+++ b/tests/test_backend_maui.py
@@ -15,7 +15,8 @@ from annif.exception import OperationFailedException
 def maui_params():
     return {'endpoint': 'http://api.example.org/mauiservice/',
             'tagger': 'dummy',
-            'language': 'en'}
+            'language': 'en',
+            'limit': 100}
 
 
 @pytest.fixture


### PR DESCRIPTION
Fixes #459

The `limit` parameter is used to set the `max_topics_per_document` setting for the Maui tagger created during train time. This makes it possible to get more than 10 (the default) results from Maui Server.