### PR TITLE
Fix TruncatingCorpus iterator 

### DIFF
--- a/annif/corpus/document.py
+++ b/annif/corpus/document.py
@@ -94,12 +94,12 @@ class TruncatingDocumentCorpus(DocumentCorpus):
     documents to a given length"""
 
     def __init__(self, corpus, limit):
-        self._documents = corpus.documents
+        self._orig_corpus = corpus
         self._limit = limit
 
     @property
     def documents(self):
-        for doc in self._documents:
+        for doc in self._orig_corpus.documents:
             yield self._create_document(text=doc.text[:self._limit],
                                         uris=doc.uris,
                                         labels=doc.labels)

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -268,12 +268,12 @@ def test_combinedcorpus(tmpdir):
     assert len(list(combined.documents)) == 6
 
 
-def test_truncatedcorpus(document_corpus):
-    truncated_corpus = TruncatingDocumentCorpus(document_corpus, 3)
-    for truncated_doc, doc in zip(truncated_corpus.documents,
+def test_truncatingcorpus(document_corpus):
+    truncating_corpus = TruncatingDocumentCorpus(document_corpus, 3)
+    for truncated_doc, doc in zip(truncating_corpus.documents,
                                   document_corpus.documents):
         assert len(truncated_doc.text) == 3
         assert truncated_doc.text == doc.text[:3]
     # Ensure docs from TruncatingCorpus are still available after iterating
-    assert len(list(truncated_corpus.documents)) \
+    assert len(list(truncating_corpus.documents)) \
         == len(list(document_corpus.documents))

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -274,3 +274,6 @@ def test_truncatedcorpus(document_corpus):
                                   document_corpus.documents):
         assert len(truncated_doc.text) == 3
         assert truncated_doc.text == doc.text[:3]
+    # Ensure docs from TruncatingCorpus are still available after iterating
+    assert len(list(truncated_corpus.documents)) \
+        == len(list(document_corpus.documents))


### PR DESCRIPTION
When trying to train some Omikuji based model with `input-limit` parameter I ran into an error:
```
$ annif train yso-bonsai-fi tests/corpora/archaeology/documents.tsv -b omikuji.input_limit=42
Backend omikuji: creating vectorizer
warning: Unknown subject URI <http://example.org/dummy_subject>
warning: Unknown subject URI <http://example.org/dummy_subject>
Backend omikuji: creating train file
2021-01-22 17:11:09,628 INFO  [omikuji::data] Loading data from data/projects/yso-bonsai-fi/omikuji-train.txt
2021-01-22 17:11:09,628 INFO  [omikuji::data] Parsing data
2021-01-22 17:11:09,629 INFO  [omikuji::data] Loaded 0 examples; it took 0.00s
2021-01-22 17:11:09,629 INFO  [omikuji::model::train] Training model with hyper-parameters HyperParam { n_trees: 3, min_branch_size: 100, max_depth: 3, centroid_threshold: 0.0, collapse_every_n_layers: 0, linear: HyperParam { loss_type: Hinge, eps: 0.1, c: 1.0, weight_threshold: 0.1, max_iter: 20 }, cluster: HyperParam { k: 100, balanced: false, eps: 0.0001, min_size: 2 }, tree_structure_only: false }
2021-01-22 17:11:09,629 INFO  [omikuji::model::train] Initializing tree trainer
thread '<unnamed>' panicked at 'assertion failed: !labels.is_empty()', /tmp/pip-req-build-46t0qwz3/src/model/train.rs:385:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace.
Aborted (core dumped)
```
Then by accident noticed strange behaviour when training a tfidf with `input-limit`:
```
$ annif train tfidf-arch tests/corpora/archaeology/documents.tsv -b tfidf.input_limit=10000000; 
Backend tfidf: transforming subject corpus
Backend tfidf: creating vectorizer
warning: Unknown subject URI <http://example.org/dummy_subject>
warning: Unknown subject URI <http://example.org/dummy_subject>
warning: Unknown subject URI <http://example.org/dummy_subject>
warning: Unknown subject URI <http://example.org/dummy_subject>
Backend tfidf: creating similarity index
$ echo kristillistymisprosessi | annif suggest tfidf-arch
$
```
No suggestions for `kristillistymisprosessi` even though it is contained in the first document of [archaeology corpus](https://github.com/NatLibFi/Annif/blob/master/tests/corpora/archaeology/documents.tsv#L1), but for words in latter documents suggestions are produced as expected. 

It looked like that while training the first line was consumed by the [`is_empty()`](https://github.com/NatLibFi/Annif/blob/master/annif/corpus/types.py#L40) check, and then the training began from the second line. So the same iterator was used all the time, and as Omikuji backend needs to iterate twice over the [documents](https://github.com/NatLibFi/Annif/blob/master/annif/backend/omikuji.py#L106), for the [second time](https://github.com/NatLibFi/Annif/blob/master/annif/backend/omikuji.py#L70) the iterator was already exhausted.

Seems this behavior resulted from storing only the iterator `corpus.documents` of the original corpus when creating the TruncatedCorpus instance. Now, if the whole original corpus is stored, its documents can be iterated over many times.  

~Maybe there should be a proper unit test for this, but now I could not write one (seemed that this problem did not appear in a test with input-limited train followed by suggest).~
The test for TruncatingDocumentCorpus now detects this.