### PR TITLE
Limit document number CLI option

### DIFF
--- a/annif/cli.py
+++ b/annif/cli.py
@@ -190,7 +190,7 @@ def run_loadvoc(project_id, subjectfile):
 @click.argument('paths', type=click.Path(exists=True), nargs=-1)
 @click.option('--cached/--no-cached', '-c/-C', default=False,
               help='Reuse preprocessed training data from previous run')
-@click.option('--docs-limit', '-dl', default=None,
+@click.option('--docs-limit', '-d', default=None,
               type=click.IntRange(0, None),
               help='Maximum number of documents to use')
 @backend_param_option
@@ -214,7 +214,7 @@ def run_train(project_id, paths, cached, docs_limit, backend_param):
 @cli.command('learn')
 @click.argument('project_id')
 @click.argument('paths', type=click.Path(exists=True), nargs=-1)
-@click.option('--docs-limit', '-dl', default=None,
+@click.option('--docs-limit', '-d', default=None,
               type=click.IntRange(0, None),
               help='Maximum number of documents to use')
 @backend_param_option
@@ -301,7 +301,7 @@ def run_index(project_id, directory, suffix, force,
 @click.argument('paths', type=click.Path(exists=True), nargs=-1)
 @click.option('--limit', '-l', default=10, help='Maximum number of subjects')
 @click.option('--threshold', '-t', default=0.0, help='Minimum score threshold')
-@click.option('--docs-limit', '-dl', default=None,
+@click.option('--docs-limit', '-d', default=None,
               type=click.IntRange(0, None),
               help='Maximum number of documents to use')
 @click.option(
@@ -372,7 +372,7 @@ def run_eval(
 @cli.command('optimize')
 @click.argument('project_id')
 @click.argument('paths', type=click.Path(exists=True), nargs=-1)
-@click.option('--docs-limit', '-dl', default=None,
+@click.option('--docs-limit', '-d', default=None,
               type=click.IntRange(0, None),
               help='Maximum number of documents to use')
 @backend_param_option
@@ -442,7 +442,7 @@ def run_optimize(project_id, paths, docs_limit, backend_param):
 @cli.command('hyperopt')
 @click.argument('project_id')
 @click.argument('paths', type=click.Path(exists=True), nargs=-1)
-@click.option('--docs-limit', '-dl', default=None,
+@click.option('--docs-limit', '-d', default=None,
               type=click.IntRange(0, None),
               help='Maximum number of documents to use')
 @click.option('--trials', '-T', default=10, help='Number of trials')

--- a/annif/cli.py
+++ b/annif/cli.py
@@ -38,10 +38,11 @@ def get_project(project_id):
         sys.exit(1)
 
 
-def open_documents(paths):
+def open_documents(paths, docs_limit):
     """Helper function to open a document corpus from a list of pathnames,
     each of which is either a TSV file or a directory of TXT files. The
-    corpus will be returned as an instance of DocumentCorpus."""
+    corpus will be returned as an instance of DocumentCorpus or
+    LimitingDocumentCorpus."""
 
     def open_doc_path(path):
         """open a single path and return it as a DocumentCorpus"""
@@ -57,6 +58,8 @@ def open_documents(paths):
     else:
         corpora = [open_doc_path(path) for path in paths]
         docs = annif.corpus.CombinedCorpus(corpora)
+    if docs_limit is not None:
+        docs = annif.corpus.LimitingDocumentCorpus(docs, docs_limit)
     return docs
 
 
@@ -187,9 +190,12 @@ def run_loadvoc(project_id, subjectfile):
 @click.argument('paths', type=click.Path(exists=True), nargs=-1)
 @click.option('--cached/--no-cached', '-c/-C', default=False,
               help='Reuse preprocessed training data from previous run')
+@click.option('--docs-limit', '-dl', default=None,
+              type=click.IntRange(0, None),
+              help='Maximum number of documents to use')
 @backend_param_option
 @common_options
-def run_train(project_id, paths, cached, backend_param):
+def run_train(project_id, paths, cached, docs_limit, backend_param):
     """
     Train a project on a collection of documents.
     """
@@ -201,22 +207,25 @@ def run_train(project_id, paths, cached, backend_param):
                 "Corpus paths cannot be given when using --cached option.")
         documents = 'cached'
     else:
-        documents = open_documents(paths)
+        documents = open_documents(paths, docs_limit)
     proj.train(documents, backend_params)
 
 
 @cli.command('learn')
 @click.argument('project_id')
 @click.argument('paths', type=click.Path(exists=True), nargs=-1)
+@click.option('--docs-limit', '-dl', default=None,
+              type=click.IntRange(0, None),
+              help='Maximum number of documents to use')
 @backend_param_option
 @common_options
-def run_learn(project_id, paths, backend_param):
+def run_learn(project_id, paths, docs_limit, backend_param):
     """
     Further train an existing project on a collection of documents.
     """
     proj = get_project(project_id)
     backend_params = parse_backend_params(backend_param, proj)
-    documents = open_documents(paths)
+    documents = open_documents(paths, docs_limit)
     proj.learn(documents, backend_params)
 
 
@@ -292,6 +301,9 @@ def run_index(project_id, directory, suffix, force,
 @click.argument('paths', type=click.Path(exists=True), nargs=-1)
 @click.option('--limit', '-l', default=10, help='Maximum number of subjects')
 @click.option('--threshold', '-t', default=0.0, help='Minimum score threshold')
+@click.option('--docs-limit', '-dl', default=None,
+              type=click.IntRange(0, None),
+              help='Maximum number of documents to use')
 @click.option(
     '--results-file',
     '-r',
@@ -313,6 +325,7 @@ def run_eval(
         paths,
         limit,
         threshold,
+        docs_limit,
         results_file,
         jobs,
         backend_param):
@@ -337,7 +350,7 @@ def run_eval(
         except Exception as e:
             raise NotSupportedException(
                 "cannot open results-file for writing: " + str(e))
-    docs = open_documents(paths)
+    docs = open_documents(paths, docs_limit)
 
     jobs, pool_class = annif.parallel.get_pool(jobs)
 
@@ -359,9 +372,12 @@ def run_eval(
 @cli.command('optimize')
 @click.argument('project_id')
 @click.argument('paths', type=click.Path(exists=True), nargs=-1)
+@click.option('--docs-limit', '-dl', default=None,
+              type=click.IntRange(0, None),
+              help='Maximum number of documents to use')
 @backend_param_option
 @common_options
-def run_optimize(project_id, paths, backend_param):
+def run_optimize(project_id, paths, docs_limit, backend_param):
     """
     Analyze documents, testing multiple limits and thresholds.
 
@@ -376,7 +392,7 @@ def run_optimize(project_id, paths, backend_param):
     filter_batches = generate_filter_batches(project.subjects)
 
     ndocs = 0
-    docs = open_documents(paths)
+    docs = open_documents(paths, docs_limit)
     for doc in docs.documents:
         hits = project.suggest(doc.text, backend_params)
         gold_subjects = annif.corpus.SubjectSet((doc.uris, doc.labels))
@@ -426,6 +442,9 @@ def run_optimize(project_id, paths, backend_param):
 @cli.command('hyperopt')
 @click.argument('project_id')
 @click.argument('paths', type=click.Path(exists=True), nargs=-1)
+@click.option('--docs-limit', '-dl', default=None,
+              type=click.IntRange(0, None),
+              help='Maximum number of documents to use')
 @click.option('--trials', '-T', default=10, help='Number of trials')
 @click.option('--jobs',
               '-j',
@@ -444,12 +463,13 @@ def run_optimize(project_id, paths, backend_param):
     help="""Specify file path to write trial results as CSV.
     File directory must exist, existing file will be overwritten.""")
 @common_options
-def run_hyperopt(project_id, paths, trials, jobs, metric, results_file):
+def run_hyperopt(project_id, paths, docs_limit, trials, jobs, metric,
+                 results_file):
     """
     Optimize the hyperparameters of a project using a validation corpus.
     """
     proj = get_project(project_id)
-    documents = open_documents(paths)
+    documents = open_documents(paths, docs_limit)
     click.echo(f"Looking for optimal hyperparameters using {trials} trials")
     rec = proj.hyperopt(documents, trials, jobs, metric, results_file)
     click.echo(f"Got best {metric} score {rec.score:.4f} with:")

--- a/annif/corpus/__init__.py
+++ b/annif/corpus/__init__.py
@@ -2,7 +2,7 @@
 
 
 from .document import DocumentDirectory, DocumentFile, DocumentList, \
-    TruncatingDocumentCorpus
+    TruncatingDocumentCorpus, LimitingDocumentCorpus
 from .subject import Subject, SubjectFileTSV
 from .subject import SubjectIndex, SubjectSet
 from .skos import SubjectFileSKOS
@@ -11,4 +11,5 @@ from .combine import CombinedCorpus
 
 __all__ = ["DocumentDirectory", "DocumentFile", "DocumentList", "Subject",
            "SubjectFileTSV", "SubjectIndex", "SubjectSet", "SubjectFileSKOS",
-           "Document", "CombinedCorpus", "TruncatingDocumentCorpus"]
+           "Document", "CombinedCorpus", "TruncatingDocumentCorpus",
+           "LimitingDocumentCorpus"]

--- a/annif/corpus/document.py
+++ b/annif/corpus/document.py
@@ -5,6 +5,7 @@ import os.path
 import re
 import gzip
 import annif.util
+from itertools import islice
 from .types import DocumentCorpus
 from .subject import SubjectSet
 
@@ -101,5 +102,21 @@ class TruncatingDocumentCorpus(DocumentCorpus):
     def documents(self):
         for doc in self._orig_corpus.documents:
             yield self._create_document(text=doc.text[:self._limit],
+                                        uris=doc.uris,
+                                        labels=doc.labels)
+
+
+class LimitingDocumentCorpus(DocumentCorpus):
+    """A document corpus that wraps another document corpus but limits the
+    number of documents to a given limit"""
+
+    def __init__(self, corpus, docs_limit):
+        self._orig_corpus = corpus
+        self.docs_limit = docs_limit
+
+    @property
+    def documents(self):
+        for doc in islice(self._orig_corpus.documents, self.docs_limit):
+            yield self._create_document(text=doc.text,
                                         uris=doc.uris,
                                         labels=doc.labels)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -288,6 +288,21 @@ def test_train_no_path(caplog):
     assert 'Reading empty file' == caplog.records[0].message
 
 
+def test_train_docslimit_zero():
+    docfile = os.path.join(
+        os.path.dirname(__file__),
+        'corpora',
+        'archaeology',
+        'documents.tsv')
+    failed_result = runner.invoke(
+        annif.cli.cli, [
+            'train', 'tfidf-fi', docfile, '--docs-limit', '0'])
+    assert failed_result.exception
+    assert failed_result.exit_code != 0
+    assert "Not supported: Cannot train tfidf project with no documents"  \
+        in failed_result.output
+
+
 def test_learn(testdatadir):
     docfile = os.path.join(
         os.path.dirname(__file__),

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -277,3 +277,20 @@ def test_truncatingcorpus(document_corpus):
     # Ensure docs from TruncatingCorpus are still available after iterating
     assert len(list(truncating_corpus.documents)) \
         == len(list(document_corpus.documents))
+
+
+def test_limitingcorpus(tmpdir):
+    docfile = tmpdir.join('documents_invalid.tsv')
+    docfile.write("""Läntinen\t<http://www.yso.fi/onto/yso/p2557>
+
+        Oulunlinnan\t<http://www.yso.fi/onto/yso/p7346>
+        A line with no tabs
+        Harald Hirmuinen\t<http://www.yso.fi/onto/yso/p6479>""")
+
+    document_corpus = annif.corpus.DocumentFile(str(docfile))
+    limiting_corpus = annif.corpus.LimitingDocumentCorpus(document_corpus, 2)
+
+    assert len(list(limiting_corpus.documents)) == 2
+    for limited_doc, doc in zip(limiting_corpus.documents,
+                                document_corpus.documents):
+        assert limited_doc.text == doc.text


### PR DESCRIPTION
This adds a CLI option `--docs-limit/-dl` to the commands where it is applicable. The option can be used to limit the number of documents to process to create learning-curve data, for example. [Learning curves](https://scikit-learn.org/stable/modules/learning_curve.html#learning-curve) can help to estimate "what is enough training data". 

This CLI option can be used in a shell script with training and evaluation steps, and the complex implementation of #364 can be abandoned.