### PR TITLE
Make sure suggestion scores are in the range 0.0-1.0

### DIFF
--- a/annif/suggestion.py
+++ b/annif/suggestion.py
@@ -161,9 +161,7 @@ class ListSuggestionResult(SuggestionResult):
 
     @staticmethod
     def _enforce_score_range(hit):
-        if hit.score < 0.0:
-            return hit._replace(score=0.0)
-        elif hit.score > 1.0:
+        if hit.score > 1.0:
             return hit._replace(score=1.0)
         return hit
 

--- a/annif/suggestion.py
+++ b/annif/suggestion.py
@@ -92,7 +92,9 @@ class VectorSuggestionResult(SuggestionResult):
     """SuggestionResult implementation based primarily on NumPy vectors."""
 
     def __init__(self, vector):
-        self._vector = vector.astype(np.float32)
+        vector_f32 = vector.astype(np.float32)
+        # limit scores to the range 0.0 .. 1.0
+        self._vector = np.minimum(np.maximum(vector_f32, 0.0), 1.0)
         self._subject_order = None
         self._lsr = None
 
@@ -152,8 +154,18 @@ class ListSuggestionResult(SuggestionResult):
     """SuggestionResult implementation based primarily on lists of hits."""
 
     def __init__(self, hits):
-        self._list = [hit for hit in hits if hit.score > 0.0]
+        self._list = [self._enforce_score_range(hit)
+                      for hit in hits
+                      if hit.score > 0.0]
         self._vector = None
+
+    @staticmethod
+    def _enforce_score_range(hit):
+        if hit.score < 0.0:
+            return hit._replace(score=0.0)
+        elif hit.score > 1.0:
+            return hit._replace(score=1.0)
+        return hit
 
     @classmethod
     def create_from_index(cls, hits, subject_index):

--- a/tests/test_suggestion.py
+++ b/tests/test_suggestion.py
@@ -127,6 +127,45 @@ def test_list_suggestions_vector(document_corpus, subject_index):
             assert score == 0.0
 
 
+def test_list_suggestions_vector_enforce_score_range(subject_index):
+    suggestions = ListSuggestionResult(
+        [
+            SubjectSuggestion(
+                uri='http://www.yso.fi/onto/yso/p7141',
+                label='sinetit',
+                notation=None,
+                score=1.5),
+            SubjectSuggestion(
+                uri='http://www.yso.fi/onto/yso/p6479',
+                label='viikingit',
+                notation=None,
+                score=1.0),
+            SubjectSuggestion(
+                uri='http://www.yso.fi/onto/yso/p14173',
+                label='kaivaukset',
+                notation=None,
+                score=0.5),
+            SubjectSuggestion(
+                uri='http://www.yso.fi/onto/yso/p14588',
+                label='riimukivet',
+                notation=None,
+                score=0.0),
+            SubjectSuggestion(
+                uri='http://www.yso.fi/onto/yso/p12738',
+                label='viikinkiaika',
+                notation=None,
+                score=-0.5)])
+    vector = suggestions.as_vector(subject_index)
+    assert vector.sum() == 2.5
+    for subject_id, score in enumerate(vector):
+        if subject_index[subject_id][1] == 'sinetit':
+            assert score == 1.0
+        elif subject_index[subject_id][1] == 'viikinkiaika':
+            assert score == 0.0
+        else:
+            assert score in (1.0, 0.5, 0.0)
+
+
 def test_list_suggestions_vector_destination(document_corpus, subject_index):
     suggestions = ListSuggestionResult(
         [
@@ -161,6 +200,14 @@ def test_vector_suggestions_as_vector(subject_index):
     suggestions = VectorSuggestionResult(orig_vector)
     vector = suggestions.as_vector(subject_index)
     assert (vector == orig_vector).all()
+
+
+def test_vector_suggestions_enforce_score_range(subject_index):
+    orig_vector = np.array([-0.1, 0.0, 0.5, 1.0, 1.5], dtype=np.float32)
+    suggestions = VectorSuggestionResult(orig_vector)
+    vector = suggestions.as_vector(subject_index)
+    expected = np.array([0.0, 0.0, 0.5, 1.0, 1.0], dtype=np.float32)
+    assert (vector == expected).all()
 
 
 def test_vector_suggestions_as_vector_destination(subject_index):


### PR DESCRIPTION
Fixes #470

This is a really simple fix to ensure that the NN ensemble can never return a score below 0.0 or above 1.0.

I don't see any obvious downsides except it loses the distinction between, say, 1.0 (very sure this is correct) and 1.1 (extra sure this is correct!). An alternative would be to use some sort of activation function such as [sigmoid](https://en.wikipedia.org/wiki/Sigmoid_function) that squeezes any kind of score values into the range 0.0-1.0 but I think this would be overkill and the resulting typical score range would then probably not make a lot of sense.

Any opinions about this @juhoinkinen ? Would it be fine to merge this as is or should we do something else here?

I couldn't figure out a way to test this since it's pretty rare and it requires a heavily biased model to trigger this.