### PR TITLE
Allow configuration of nn ensemble learning rate

### DIFF
--- a/annif/backend/nn_ensemble.py
+++ b/annif/backend/nn_ensemble.py
@@ -148,6 +148,9 @@ class NNEnsembleBackend(
         self._model.compile(optimizer=self.params['optimizer'],
                             loss='binary_crossentropy',
                             metrics=['top_k_categorical_accuracy'])
+        if 'lr' in self.params:
+            self._model.optimizer.learning_rate.assign(
+                float(self.params['lr']))
 
         summary = []
         self._model.summary(print_fn=summary.append)

--- a/tests/test_backend_nn_ensemble.py
+++ b/tests/test_backend_nn_ensemble.py
@@ -36,6 +36,17 @@ def test_nn_ensemble_is_not_trained(app_project):
     assert not nn_ensemble.is_trained
 
 
+def test_nn_ensemble_can_set_lr(registry):
+    project = registry.get_project('dummy-en')
+    nn_ensemble_type = annif.backend.get_backend("nn_ensemble")
+    nn_ensemble = nn_ensemble_type(
+        backend_id='nn_ensemble',
+        config_params={'epochs': 1, 'lr': 0.002},
+        project=project)
+    nn_ensemble._create_model(['dummy-en'])
+    assert nn_ensemble._model.optimizer.learning_rate.value() == 0.002
+
+
 def test_nn_ensemble_train_and_learn(registry, tmpdir):
     project = registry.get_project('dummy-en')
     nn_ensemble_type = annif.backend.get_backend("nn_ensemble")
@@ -51,6 +62,9 @@ def test_nn_ensemble_train_and_learn(registry, tmpdir):
     document_corpus = annif.corpus.DocumentFile(str(tmpfile))
 
     nn_ensemble.train(document_corpus)
+
+    # check adam default learning_rate:
+    assert nn_ensemble._model.optimizer.learning_rate.value() == 0.001
 
     datadir = py.path.local(project.datadir)
     assert datadir.join('nn-model.h5').exists()


### PR DESCRIPTION
When training nn-ensemble with optimizers that do not automatically adjust the learning rate it is helpful to configure it manually. Even with automatically adjusting optimizers, it may sometimes be beneficial to change the learning rate.
This pr allow to set the learning rate in the nn-ensemble project definition.
As different optimizers have different default learning rates, it is not possible to just add a default parameter. Instead the presence of a `lr` key in the config map is checked.