### PR TITLE
Optimize check for deprecated subject IDs using a set

### DIFF
--- a/annif/suggestion.py
+++ b/annif/suggestion.py
@@ -135,8 +135,9 @@ class VectorSuggestionResult(SuggestionResult):
         deprecated_ids = subject_index.deprecated_ids()
         if limit is not None:
             limit_mask = np.zeros_like(self._vector, dtype=np.bool)
+            deprecated_set = set(deprecated_ids)
             top_k_subjects = [subj for subj in self.subject_order
-                              if subj not in deprecated_ids][:limit]
+                              if subj not in deprecated_set][:limit]
             limit_mask[top_k_subjects] = True
             mask = mask & limit_mask
         else:


### PR DESCRIPTION
This PR implements a small optimization for situations where the subject vocabulary contains deprecated IDs.

Due to a small configuration mistake during testing, I messed up my subject vocabulary so that I had almost 4000 deprecated subject IDs. This caused most normal operations (suggest, eval, etc.) to slow down to a crawl. The problem was that subject IDs were being checked for memberhip in `deprecated_ids`, which is a list; this is an O(n) operation, where n is the number of deprecated IDs. Changing it to a `set` object makes this O(1) instead, avoiding the slowdown. It's probably rare to have a large number of deprecated IDs, but the fix is easy and doesn't hurt.