### PR TITLE
Backwards compatibility fix for the token_min_length setting

### DIFF
--- a/annif/analyzer/analyzer.py
+++ b/annif/analyzer/analyzer.py
@@ -14,9 +14,11 @@ class Analyzer(metaclass=abc.ABCMeta):
     be overridden when necessary."""
 
     name = None
+    token_min_length = 3  # default value, can be overridden in instances
 
     def __init__(self, **kwargs):
-        self.token_min_length = int(kwargs.get(_KEY_TOKEN_MIN_LENGTH, 3))
+        if _KEY_TOKEN_MIN_LENGTH in kwargs:
+            self.token_min_length = int(kwargs[_KEY_TOKEN_MIN_LENGTH])
 
     def tokenize_sentences(self, text):
         """Tokenize a piece of text (e.g. a document) into sentences."""


### PR DESCRIPTION
After PR #468 that introduced the `token_min_length` setting, old Omikuji models no longer work. They fail with this error:

```
  File "/home/ozone/git/Annif/annif/analyzer/analyzer.py", line 28, in is_valid_token
    if len(word) < self.token_min_length:
AttributeError: 'SnowballAnalyzer' object has no attribute 'token_min_length'
```

The problem is that the new code expects that the `token_min_length` field is always present. It was set by the new constructor, but old Analyzer objects (serialized alongside the model) don't have it.

This PR changes the implementation so that the field with a default value is defined for the class, but can be overridden in instances. This way old models will keep working, they will just rely on the default value.

Ping @mo-fu 