### PR TITLE
MLLM fix: don't include use_hidden_labels in hyperopt, it won't have any effect

### DIFF
--- a/annif/backend/mllm.py
+++ b/annif/backend/mllm.py
@@ -32,8 +32,6 @@ class MLLMOptimizer(hyperopt.HyperparameterOptimizer):
             'min_samples_leaf': trial.suggest_int('min_samples_leaf', 5, 30),
             'max_leaf_nodes': trial.suggest_int('max_leaf_nodes', 100, 2000),
             'max_samples': trial.suggest_float('max_samples', 0.5, 1.0),
-            'use_hidden_labels':
-                trial.suggest_categorical('use_hidden_labels', [True, False]),
             'limit': 100
         }
         model = self._backend._model._create_classifier(params)
@@ -59,8 +57,7 @@ class MLLMOptimizer(hyperopt.HyperparameterOptimizer):
         lines = [
             f"min_samples_leaf={bp['min_samples_leaf']}",
             f"max_leaf_nodes={bp['max_leaf_nodes']}",
-            f"max_samples={bp['max_samples']:.4f}",
-            f"use_hidden_labels={bp['use_hidden_labels']}"
+            f"max_samples={bp['max_samples']:.4f}"
         ]
         return hyperopt.HPRecommendation(lines=lines, score=study.best_value)
 


### PR DESCRIPTION
This PR removes the `use_hidden_labels` parameter from the hyperparameter search in the MLLM backend. The reason is that `use_hidden_labels` affects the construction of the term index and this is done before hyperparameter optimization, so varying it won't affect the results of the hyperparameter search.