### PR TITLE
New SVC (support vector classification) backend using scikit-learn

### DIFF
--- a/annif/backend/__init__.py
+++ b/annif/backend/__init__.py
@@ -8,6 +8,7 @@ from . import pav
 from . import maui
 from . import stwfsa
 from . import mllm
+from . import svc
 import annif
 
 
@@ -33,6 +34,7 @@ register_backend(pav.PAVBackend)
 register_backend(maui.MauiBackend)
 register_backend(stwfsa.StwfsaBackend)
 register_backend(mllm.MLLMBackend)
+register_backend(svc.SVCBackend)
 
 # Optional backends
 try:

--- a/annif/backend/svc.py
+++ b/annif/backend/svc.py
@@ -63,6 +63,7 @@ class SVCBackend(mixins.TfidfVectorizerMixin, backend.AnnifBackend):
                      'tokenizer': self.project.analyzer.tokenize_words,
                      'ngram_range': (1, int(params['ngram']))}
         veccorpus = self.create_vectorizer(input, vecparams)
+        self.info('creating classifier')
         self._model = LinearSVC()
         self._model.fit(veccorpus, classes)
         annif.util.atomic_save(self._model,

--- a/annif/backend/svc.py
+++ b/annif/backend/svc.py
@@ -47,6 +47,15 @@ class SVCBackend(mixins.TfidfVectorizerMixin, backend.AnnifBackend):
         self.initialize_vectorizer()
         self._initialize_model()
 
+    @staticmethod
+    def _corpus_to_texts_and_classes(corpus):
+        texts = []
+        classes = []
+        for doc in corpus.documents:
+            texts.append(doc.text)
+            classes.append(doc.uris[0])
+        return texts, classes
+
     def _train_classifier(self, veccorpus, classes):
         self.info('creating classifier')
         self._model = LinearSVC()
@@ -63,11 +72,7 @@ class SVCBackend(mixins.TfidfVectorizerMixin, backend.AnnifBackend):
         if corpus.is_empty():
             raise NotSupportedException(
                 'Cannot train SVC project with no documents')
-        texts = []
-        classes = []
-        for doc in corpus.documents:
-            texts.append(doc.text)
-            classes.append(doc.uris[0])
+        texts, classes = self._corpus_to_texts_and_classes(corpus)
         vecparams = {'min_df': int(params['min_df']),
                      'tokenizer': self.project.analyzer.tokenize_words,
                      'ngram_range': (1, int(params['ngram']))}

--- a/annif/backend/svc.py
+++ b/annif/backend/svc.py
@@ -54,15 +54,15 @@ class SVCBackend(mixins.TfidfVectorizerMixin, backend.AnnifBackend):
         if corpus.is_empty():
             raise NotSupportedException(
                 'Cannot train SVC project with no documents')
-        input = []
+        texts = []
         classes = []
         for doc in corpus.documents:
-            input.append(doc.text)
+            texts.append(doc.text)
             classes.append(doc.uris[0])
         vecparams = {'min_df': int(params['min_df']),
                      'tokenizer': self.project.analyzer.tokenize_words,
                      'ngram_range': (1, int(params['ngram']))}
-        veccorpus = self.create_vectorizer(input, vecparams)
+        veccorpus = self.create_vectorizer(texts, vecparams)
         self.info('creating classifier')
         self._model = LinearSVC()
         self._model.fit(veccorpus, classes)

--- a/annif/backend/svc.py
+++ b/annif/backend/svc.py
@@ -24,6 +24,7 @@ class SVCBackend(mixins.TfidfVectorizerMixin, backend.AnnifBackend):
 
     DEFAULT_PARAMETERS = {
         'min_df': 1,
+        'ngram': 1
     }
 
     def default_params(self):
@@ -59,7 +60,8 @@ class SVCBackend(mixins.TfidfVectorizerMixin, backend.AnnifBackend):
             input.append(doc.text)
             classes.append(doc.uris[0])
         vecparams = {'min_df': int(params['min_df']),
-                     'tokenizer': self.project.analyzer.tokenize_words}
+                     'tokenizer': self.project.analyzer.tokenize_words,
+                     'ngram_range': (1, int(params['ngram']))}
         veccorpus = self.create_vectorizer(input, vecparams)
         self._model = LinearSVC()
         self._model.fit(veccorpus, classes)

--- a/annif/backend/svc.py
+++ b/annif/backend/svc.py
@@ -62,7 +62,7 @@ class SVCBackend(mixins.TfidfVectorizerMixin, backend.AnnifBackend):
                      'tokenizer': self.project.analyzer.tokenize_words}
         veccorpus = self.create_vectorizer(input, vecparams)
         svc = LinearSVC()
-        self._model = CalibratedClassifierCV(svc)
+        self._model = CalibratedClassifierCV(svc, n_jobs=-1)
         self._model.fit(veccorpus, classes)
         annif.util.atomic_save(self._model,
                                self.datadir,

--- a/annif/backend/svc.py
+++ b/annif/backend/svc.py
@@ -47,6 +47,15 @@ class SVCBackend(mixins.TfidfVectorizerMixin, backend.AnnifBackend):
         self.initialize_vectorizer()
         self._initialize_model()
 
+    def _train_classifier(self, veccorpus, classes):
+        self.info('creating classifier')
+        self._model = LinearSVC()
+        self._model.fit(veccorpus, classes)
+        annif.util.atomic_save(self._model,
+                               self.datadir,
+                               self.MODEL_FILE,
+                               method=joblib.dump)
+
     def _train(self, corpus, params):
         if corpus == 'cached':
             raise NotSupportedException(
@@ -63,13 +72,7 @@ class SVCBackend(mixins.TfidfVectorizerMixin, backend.AnnifBackend):
                      'tokenizer': self.project.analyzer.tokenize_words,
                      'ngram_range': (1, int(params['ngram']))}
         veccorpus = self.create_vectorizer(texts, vecparams)
-        self.info('creating classifier')
-        self._model = LinearSVC()
-        self._model.fit(veccorpus, classes)
-        annif.util.atomic_save(self._model,
-                               self.datadir,
-                               self.MODEL_FILE,
-                               method=joblib.dump)
+        self._train_classifier(veccorpus, classes)
 
     def _suggest(self, text, params):
         self.debug('Suggesting subjects for text "{}..." (len={})'.format(

--- a/annif/backend/svc.py
+++ b/annif/backend/svc.py
@@ -1,0 +1,91 @@
+"""Annif backend using a SVM classifier"""
+
+import os.path
+import joblib
+import numpy as np
+from sklearn.svm import LinearSVC
+from sklearn.calibration import CalibratedClassifierCV
+import annif.util
+from annif.suggestion import SubjectSuggestion, ListSuggestionResult
+from annif.exception import NotInitializedException, NotSupportedException
+from . import backend
+from . import mixins
+
+
+class SVCBackend(mixins.TfidfVectorizerMixin, backend.AnnifBackend):
+    """Support vector classifier backend for Annif"""
+    name = "svc"
+    needs_subject_index = True
+
+    # defaults for uninitialized instances
+    _model = None
+
+    MODEL_FILE = 'svc-model.gz'
+
+    DEFAULT_PARAMETERS = {
+        'min_df': 1,
+    }
+
+    def default_params(self):
+        params = backend.AnnifBackend.DEFAULT_PARAMETERS.copy()
+        params.update(self.DEFAULT_PARAMETERS)
+        return params
+
+    def _initialize_model(self):
+        if self._model is None:
+            path = os.path.join(self.datadir, self.MODEL_FILE)
+            self.debug('loading model from {}'.format(path))
+            if os.path.exists(path):
+                self._model = joblib.load(path)
+            else:
+                raise NotInitializedException(
+                    'model {} not found'.format(path),
+                    backend_id=self.backend_id)
+
+    def initialize(self):
+        self.initialize_vectorizer()
+        self._initialize_model()
+
+    def _train(self, corpus, params):
+        if corpus == 'cached':
+            raise NotSupportedException(
+                'SVC backend does not support reuse of cached training data.')
+        if corpus.is_empty():
+            raise NotSupportedException(
+                'Cannot train SVC project with no documents')
+        input = []
+        classes = []
+        for doc in corpus.documents:
+            input.append(doc.text)
+            classes.append(doc.uris[0])
+        vecparams = {'min_df': int(params['min_df']),
+                     'tokenizer': self.project.analyzer.tokenize_words}
+        veccorpus = self.create_vectorizer(input, vecparams)
+        svc = LinearSVC()
+        self._model = CalibratedClassifierCV(svc)
+        self._model.fit(veccorpus, classes)
+        annif.util.atomic_save(self._model,
+                               self.datadir,
+                               self.MODEL_FILE,
+                               method=joblib.dump)
+
+    def _suggest(self, text, params):
+        self.debug('Suggesting subjects for text "{}..." (len={})'.format(
+            text[:20], len(text)))
+        vector = self.vectorizer.transform([text])
+        if vector.nnz == 0:  # All zero vector, empty result
+            return ListSuggestionResult([])
+        predictions = self._model.predict_proba(vector)[0]
+        results = []
+        limit = int(params['limit'])
+        for class_id in np.argsort(predictions)[::-1][:limit]:
+            class_uri = self._model.classes_[class_id]
+            subject_id = self.project.subjects.by_uri(class_uri)
+            if subject_id is not None:
+                uri, label, notation = self.project.subjects[subject_id]
+                results.append(SubjectSuggestion(
+                    uri=uri,
+                    label=label,
+                    notation=notation,
+                    score=predictions[class_id]))
+        return ListSuggestionResult(results)

--- a/tests/test_backend_svc.py
+++ b/tests/test_backend_svc.py
@@ -85,9 +85,9 @@ def test_svc_suggest(project):
     assert len(results) > 0
     assert len(results) <= 8
     hits = results.as_list(project.subjects)
-    assert 'http://www.yso.fi/onto/yso/p1265' in [
+    assert 'http://www.yso.fi/onto/yso/p10849' in [
         result.uri for result in hits]
-    assert 'arkeologia' in [result.label for result in hits]
+    assert 'arkeologit' in [result.label for result in hits]
 
 
 def test_svc_suggest_no_input(project):

--- a/tests/test_backend_svc.py
+++ b/tests/test_backend_svc.py
@@ -46,6 +46,18 @@ def test_svc_train(datadir, document_corpus, project):
     assert datadir.join('svc-model.gz').exists()
 
 
+def test_svc_train_ngram(datadir, document_corpus, project):
+    svc_type = annif.backend.get_backend('svc')
+    svc = svc_type(
+        backend_id='svc',
+        config_params={'ngram': 2},
+        project=project)
+
+    svc.train(document_corpus)
+    assert svc._model is not None
+    assert datadir.join('svc-model.gz').exists()
+
+
 def test_svc_train_cached(datadir, project):
     svc_type = annif.backend.get_backend('svc')
     svc = svc_type(

--- a/tests/test_backend_svc.py
+++ b/tests/test_backend_svc.py
@@ -1,0 +1,113 @@
+"""Unit tests for the SVC backend in Annif"""
+
+import pytest
+import annif.backend
+import annif.corpus
+from annif.exception import NotInitializedException
+from annif.exception import NotSupportedException
+
+
+def test_svc_default_params(project):
+    svc_type = annif.backend.get_backend("svc")
+    svc = svc_type(
+        backend_id='svc',
+        config_params={},
+        project=project)
+
+    expected_default_params = {
+        'limit': 100,
+        'min_df': 1,
+    }
+    actual_params = svc.params
+    for param, val in expected_default_params.items():
+        assert param in actual_params and actual_params[param] == val
+
+
+def test_svc_suggest_no_vectorizer(project):
+    svc_type = annif.backend.get_backend('svc')
+    svc = svc_type(
+        backend_id='svc',
+        config_params={},
+        project=project)
+
+    with pytest.raises(NotInitializedException):
+        svc.suggest("example text")
+
+
+def test_svc_train(datadir, document_corpus, project):
+    svc_type = annif.backend.get_backend('svc')
+    svc = svc_type(
+        backend_id='svc',
+        config_params={},
+        project=project)
+
+    svc.train(document_corpus)
+    assert svc._model is not None
+    assert datadir.join('svc-model.gz').exists()
+
+
+def test_svc_train_cached(datadir, project):
+    svc_type = annif.backend.get_backend('svc')
+    svc = svc_type(
+        backend_id='svc',
+        config_params={},
+        project=project)
+
+    with pytest.raises(NotSupportedException):
+        svc.train("cached")
+
+
+def test_svc_train_nodocuments(datadir, project, empty_corpus):
+    svc_type = annif.backend.get_backend('svc')
+    svc = svc_type(
+        backend_id='svc',
+        config_params={},
+        project=project)
+
+    with pytest.raises(NotSupportedException):
+        svc.train(empty_corpus)
+
+
+def test_svc_suggest(project):
+    svc_type = annif.backend.get_backend('svc')
+    svc = svc_type(
+        backend_id='svc',
+        config_params={'limit': 8},
+        project=project)
+
+    results = svc.suggest("""Arkeologiaa sanotaan joskus myös
+        muinaistutkimukseksi tai muinaistieteeksi. Se on humanistinen tiede
+        tai oikeammin joukko tieteitä, jotka tutkivat ihmisen menneisyyttä.
+        Tutkimusta tehdään analysoimalla muinaisjäännöksiä eli niitä jälkiä,
+        joita ihmisten toiminta on jättänyt maaperään tai vesistöjen
+        pohjaan.""")
+
+    assert len(results) > 0
+    assert len(results) <= 8
+    hits = results.as_list(project.subjects)
+    assert 'http://www.yso.fi/onto/yso/p1265' in [
+        result.uri for result in hits]
+    assert 'arkeologia' in [result.label for result in hits]
+
+
+def test_svc_suggest_no_input(project):
+    svc_type = annif.backend.get_backend('svc')
+    svc = svc_type(
+        backend_id='svc',
+        config_params={'limit': 8},
+        project=project)
+
+    results = svc.suggest("j")
+    assert len(results) == 0
+
+
+def test_svc_suggest_no_model(datadir, project):
+    svc_type = annif.backend.get_backend('svc')
+    svc = svc_type(
+        backend_id='svc',
+        config_params={},
+        project=project)
+
+    datadir.join('svc-model.gz').remove()
+    with pytest.raises(NotInitializedException):
+        svc.suggest("example text")


### PR DESCRIPTION
This (draft) PR adds a new backend `svc` that implements Linear Support Vector Classification. It is based on LinearSVC in scikit-learn, which in turn is based on liblinear. This kind of algorithm is well suited for multiclass (but not multilabel) classification, for example classifying documents with the Dewey Decimal Classification. It requires relatively little training data.

TODO (at least):

- [ ] ~~make the `ensemble` setting of CalibratedClassifierCV a project parameter (needs upgrade to scikit-learn 0.24)~~
- [ ] ~~make use of the `n_jobs` parameter of CalibratedClassifierCV (needs upgrade to scikit-learn 0.24)~~
- [ ] ~~address the warning message `The least populated class in y has only 1 members`... given by CalibratedClassifierCV~~
- [x] add a project parameter for using word n-grams
- [x] add a wiki page for the backend
- [x] address QA tool complaints