### PR TITLE
Upgrade scikit-learn to 0.24.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
         'joblib==0.17.0',
         'nltk',
         'gensim==3.8.*',
-        'scikit-learn==0.23.2',
+        'scikit-learn==0.24.*',
         'scipy==1.5.3',
         'rdflib>=4.2,<6.0',
         'gunicorn',

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
         'joblib==0.17.0',
         'nltk',
         'gensim==3.8.*',
-        'scikit-learn==0.24.*',
+        'scikit-learn==0.24.2',
         'scipy==1.5.3',
         'rdflib>=4.2,<6.0',
         'gunicorn',


### PR DESCRIPTION
This PR upgrades the scikit-learn dependency from 0.23.2 to 0.24.*

This seems to work without any problems. stwfsapy has declared its dependency as `scikit-learn>=0.22.*` which is compatible as well.

This upgrade is required to get access to some new features in CalibratedClassifierCV, which is used in the SVC backend (PR #486)