### PR TITLE
Add support for ngram setting in omikuji backend

### DIFF
--- a/annif/backend/omikuji.py
+++ b/annif/backend/omikuji.py
@@ -23,6 +23,7 @@ class OmikujiBackend(mixins.TfidfVectorizerMixin, backend.AnnifBackend):
 
     DEFAULT_PARAMETERS = {
         'min_df': 1,
+        'ngram': 1,
         'cluster_balanced': True,
         'cluster_k': 2,
         'max_depth': 20,
@@ -105,7 +106,8 @@ class OmikujiBackend(mixins.TfidfVectorizerMixin, backend.AnnifBackend):
                     'Cannot train omikuji project with no documents')
             input = (doc.text for doc in corpus.documents)
             vecparams = {'min_df': int(params['min_df']),
-                         'tokenizer': self.project.analyzer.tokenize_words}
+                         'tokenizer': self.project.analyzer.tokenize_words,
+                         'ngram_range': (1, int(params['ngram']))}
             veccorpus = self.create_vectorizer(input, vecparams)
             self._create_train_file(veccorpus, corpus)
         else:

--- a/tests/test_backend_omikuji.py
+++ b/tests/test_backend_omikuji.py
@@ -77,6 +77,20 @@ def test_omikuji_train(datadir, document_corpus, project):
     assert datadir.join('omikuji-model').listdir()  # non-empty dir
 
 
+def test_omikuji_train_ngram(datadir, document_corpus, project):
+    omikuji_type = annif.backend.get_backend('omikuji')
+    omikuji = omikuji_type(
+        backend_id='omikuji',
+        config_params={'ngram': 2},
+        project=project)
+
+    datadir.join('omikuji-model').remove()
+    omikuji.train(document_corpus)
+    assert omikuji._model is not None
+    assert datadir.join('omikuji-model').exists()
+    assert datadir.join('omikuji-model').listdir()  # non-empty dir
+
+
 def test_omikuji_train_cached(datadir, project):
     assert datadir.join('omikuji-train.txt').exists()
     datadir.join('omikuji-model').remove()


### PR DESCRIPTION
This PR adds a new parameter `ngram` to the omikuji backend. If set to 2 (instead of the default 1), the vectorizer will use 2-grams as well, which may improve the results of the model (but the model will be much larger). It probably makes sense to set `min_df` to something more than 1 when using `ngram`>1, otherwise there may be a huge number of pretty useless features.