### PR TITLE
Add Codecov Action to GH workflow for uploading reports

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,4 +1,2 @@
-codecov:
-  token: 60207e06-1f46-4a09-90db-024d39a6954a
 ignore:
   - "setup.py"

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -52,6 +52,8 @@ jobs:
     - name: Test with pytest
       run: |
         pytest --cov=./
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v1
 
   publish:
     needs: test


### PR DESCRIPTION
When Annif's CI service was switched from Travis to GitHub Actions (#474) the uploading of unit-test coverage reports was not included in the GH Actions workflow, so the coverage report at [codecov.io](https://app.codecov.io/gh/NatLibFi/Annif/) has not been up to date.

This PR adds the [Codecov Action](https://github.com/codecov/codecov-action) to upload the coverage report. For public repositories this Action does not require the codecov token, which is removed from the `.codecov.yml`.