### PR TITLE
Raise NotSupportedException for attempt to train YAKE

### DIFF
--- a/annif/backend/yake.py
+++ b/annif/backend/yake.py
@@ -11,8 +11,7 @@ from rdflib.namespace import SKOS
 import annif.util
 from . import backend
 from annif.suggestion import SubjectSuggestion, ListSuggestionResult
-from annif.exception import ConfigurationException
-from annif.exception import NotSupportedException
+from annif.exception import ConfigurationException, NotSupportedException
 
 
 class YakeBackend(backend.AnnifBackend):

--- a/annif/backend/yake.py
+++ b/annif/backend/yake.py
@@ -12,6 +12,7 @@ import annif.util
 from . import backend
 from annif.suggestion import SubjectSuggestion, ListSuggestionResult
 from annif.exception import ConfigurationException
+from annif.exception import NotSupportedException
 
 
 class YakeBackend(backend.AnnifBackend):
@@ -182,3 +183,7 @@ class YakeBackend(backend.AnnifBackend):
         score2 = score2/2 + 0.5
         confl = score1 * score2 / (score1 * score2 + (1-score1) * (1-score2))
         return (confl-0.5) * 2
+
+    def _train(self, corpus, params):
+        raise NotSupportedException(
+            'Training yake backend is not possible.')

--- a/tests/test_backend_yake.py
+++ b/tests/test_backend_yake.py
@@ -3,7 +3,7 @@
 import annif
 import annif.backend
 import pytest
-from annif.exception import ConfigurationException
+from annif.exception import ConfigurationException, NotSupportedException
 
 pytest.importorskip("annif.backend.yake")
 
@@ -131,3 +131,14 @@ def test_combine_scores(project):
     assert yake._combine_scores(1.0, 0.0) == 1.0
     assert yake._combine_scores(0.4, 0.3) == 0.625
     assert yake._combine_scores(0.4, 0.5) == 0.75
+
+
+def test_yake_train(project, document_corpus):
+    yake_type = annif.backend.get_backend('yake')
+    yake = yake_type(
+        backend_id='yake',
+        config_params={'language': 'fi'},
+        project=project)
+
+    with pytest.raises(NotSupportedException):
+        yake.train(document_corpus)


### PR DESCRIPTION
I noticed that a user could try to train a Yake project (which is unnecessary Yake being unsupervised algorithm), but training would seem to succeed, although actually nothing happens.

A more correct behavior is to raise `NotSupportedException` when training a Yake project is attempted, as in the case of the Ensemble backend.