### PR TITLE
Add --version option to CLI

### DIFF
--- a/annif/cli.py
+++ b/annif/cli.py
@@ -23,7 +23,8 @@ from annif.exception import ConfigurationException, NotSupportedException
 logger = annif.logger
 click_log.basic_config(logger)
 
-cli = FlaskGroup(create_app=annif.create_app)
+cli = FlaskGroup(create_app=annif.create_app, add_version_option=False)
+cli = click.version_option(message='%(version)s')(cli)
 
 
 def get_project(project_id):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,6 +5,7 @@ import random
 import re
 import os.path
 import pytest
+import pkg_resources
 from click.testing import CliRunner
 import annif.cli
 
@@ -762,3 +763,12 @@ def test_hyperopt_not_supported(tmpdir):
     assert failed_result.exit_code != 0
 
     assert 'Hyperparameter optimization not supported' in failed_result.output
+
+
+def test_version_option():
+    result = runner.invoke(
+        annif.cli.cli, ['--version'])
+    assert not result.exception
+    assert result.exit_code == 0
+    version = pkg_resources.require('annif')[0].version
+    assert result.output.strip() == version.strip()


### PR DESCRIPTION
Currently the version of Annif needs to be obtained by `pip list` or similar not very convenient way, and `annif --version` confusingly outputs the versions of Python, Flask and Werkzeug.

This PR makes the `--version` option to show only the version of Annif itself, utilizing the [Click decorator](https://click.palletsprojects.com/en/7.x/api/?highlight=version_option#click.version_option):
```
$ annif --version
0.53.0.dev0
```