### PR TITLE
Fix training SVC on fulltext corpus

### DIFF
--- a/annif/backend/svc.py
+++ b/annif/backend/svc.py
@@ -53,6 +53,10 @@ class SVCBackend(mixins.TfidfVectorizerMixin, backend.AnnifBackend):
         classes = []
         for doc in corpus.documents:
             texts.append(doc.text)
+            if len(doc.uris) > 1:
+                raise NotSupportedException(
+                    'SVC backend does not support training on documents ' +
+                    'with multiple subjects.')
             classes.append(list(doc.uris)[0])
         return texts, classes
 

--- a/annif/backend/svc.py
+++ b/annif/backend/svc.py
@@ -53,7 +53,7 @@ class SVCBackend(mixins.TfidfVectorizerMixin, backend.AnnifBackend):
         classes = []
         for doc in corpus.documents:
             texts.append(doc.text)
-            classes.append(doc.uris[0])
+            classes.append(list(doc.uris)[0])
         return texts, classes
 
     def _train_classifier(self, veccorpus, classes):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -97,6 +97,17 @@ def document_corpus(subject_index):
 
 
 @pytest.fixture(scope='module')
+def document_corpus_single_subject(document_corpus):
+    docs_single_subj = []
+    for doc in document_corpus.documents:
+        uri = list(doc.uris)[0] if len(doc.uris) > 0 else None
+        label = list(doc.labels)[0] if len(doc.labels) > 0 else None
+        docs_single_subj.append(
+            annif.corpus.Document(doc.text, {uri}, {label}))
+    return annif.corpus.DocumentList(docs_single_subj)
+
+
+@pytest.fixture(scope='module')
 def pretrained_vectors():
     return py.path.local(os.path.join(
         os.path.dirname(__file__),

--- a/tests/test_backend_svc.py
+++ b/tests/test_backend_svc.py
@@ -34,26 +34,26 @@ def test_svc_suggest_no_vectorizer(project):
         svc.suggest("example text")
 
 
-def test_svc_train(datadir, document_corpus, project):
+def test_svc_train(datadir, document_corpus_single_subject, project):
     svc_type = annif.backend.get_backend('svc')
     svc = svc_type(
         backend_id='svc',
         config_params={},
         project=project)
 
-    svc.train(document_corpus)
+    svc.train(document_corpus_single_subject)
     assert svc._model is not None
     assert datadir.join('svc-model.gz').exists()
 
 
-def test_svc_train_ngram(datadir, document_corpus, project):
+def test_svc_train_ngram(datadir, document_corpus_single_subject, project):
     svc_type = annif.backend.get_backend('svc')
     svc = svc_type(
         backend_id='svc',
         config_params={'ngram': 2},
         project=project)
 
-    svc.train(document_corpus)
+    svc.train(document_corpus_single_subject)
     assert svc._model is not None
     assert datadir.join('svc-model.gz').exists()
 

--- a/tests/test_backend_svc.py
+++ b/tests/test_backend_svc.py
@@ -69,6 +69,17 @@ def test_svc_train_cached(datadir, project):
         svc.train("cached")
 
 
+def test_svc_train_multiple_subjects(datadir, document_corpus, project):
+    svc_type = annif.backend.get_backend('svc')
+    svc = svc_type(
+        backend_id='svc',
+        config_params={},
+        project=project)
+
+    with pytest.raises(NotSupportedException):
+        svc.train(document_corpus)
+
+
 def test_svc_train_nodocuments(datadir, project, empty_corpus):
     svc_type = annif.backend.get_backend('svc')
     svc = svc_type(


### PR DESCRIPTION
Claudia [reported in annif-users email list](https://groups.google.com/g/annif-users/c/F8N9x2dBHYM/m/IbMXKwPeDQAJ) that they encountered problems when trying to train the SVC backend on full-text corpus. Their initial problem was not the one that this PR fixes, but their report brought this up.

Training SVC backend on fulltext corpus does not work but fails with `TypeError: 'set' object is not subscriptable`. This is because `DocumentDirectory` [defines uris for documents as a set](https://github.com/NatLibFi/Annif/blob/2b8e3c95e41305532516a9f51be5274788f5579a/annif/corpus/document.py#L46), while in SVC it was assumed that uris are list or other subscriptable (which for `DocumentFile` [is true](https://github.com/NatLibFi/Annif/blob/2b8e3c95e41305532516a9f51be5274788f5579a/annif/corpus/document.py#L71-L72)). 

This PR simply makes sure the uris are a list. If a document has multiple uris a `NotSupportedException` is raised, because a set is not ordered so a random uri from the ones defined for the training document would be taken (if there are many).

To make SVC training unit tests work I made a clumsy fixture `document_corpus_single_subject` that uses the regular `document_corpus` fixture but includes only one subject for each document. This could surely be improved in some way. 

I will also make an issue for the discrepancy of uri container types (set from from DocumentDirectory vs list from DocumentFile).