### PR TITLE
Fix RTD build error due to package conflict

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,3 @@
 sphinx
 sphinx-rtd-theme
 sphinxcontrib-apidoc==0.3.0
-flask
-PyYAML>=5.1
-Werkzeug==0.16.1


### PR DESCRIPTION
In the past in the documentation builds in [ReadTheDocs](https://annif.readthedocs.io/en/latest/) some dependencies have been needed, but lately (since v0.52) in installing them there has been a version conflict and the builds have been failing. This PR removes installing now unnecessary packages in docs building, and up-to-date documentation will be available again.