### PR TITLE
Fix NN ensemble training and learning on one-document corpus

### DIFF
--- a/annif/backend/nn_ensemble.py
+++ b/annif/backend/nn_ensemble.py
@@ -15,7 +15,7 @@ from tensorflow.keras.utils import Sequence
 import tensorflow.keras.backend as K
 import annif.corpus
 import annif.util
-from annif.exception import NotInitializedException
+from annif.exception import NotInitializedException, NotSupportedException
 from annif.suggestion import VectorSuggestionResult
 from . import backend
 from . import ensemble
@@ -189,6 +189,9 @@ class NNEnsembleBackend(
     def _fit_model(self, corpus, epochs):
         env = self._open_lmdb(corpus == 'cached')
         if corpus != 'cached':
+            if corpus.is_empty():
+                raise NotSupportedException(
+                    'Cannot train nn_ensemble project with no documents')
             with env.begin(write=True, buffers=True) as txn:
                 seq = LMDBSequence(txn, batch_size=32)
                 self._corpus_to_vectors(corpus, seq)

--- a/annif/backend/nn_ensemble.py
+++ b/annif/backend/nn_ensemble.py
@@ -38,7 +38,8 @@ class LMDBSequence(Sequence):
         self._txn = txn
         cursor = txn.cursor()
         if cursor.last():
-            self._counter = key_to_idx(cursor.key())
+            # Counter holds the number of samples in the database
+            self._counter = key_to_idx(cursor.key()) + 1
         else:  # empty database
             self._counter = 0
         self._batch_size = batch_size
@@ -193,7 +194,6 @@ class NNEnsembleBackend(
                 self._corpus_to_vectors(corpus, seq)
         else:
             self.info("Reusing cached training data from previous run.")
-
         # fit the model using a read-only view of the LMDB
         with env.begin(buffers=True) as txn:
             seq = LMDBSequence(txn, batch_size=32)

--- a/tests/test_backend_nn_ensemble.py
+++ b/tests/test_backend_nn_ensemble.py
@@ -78,7 +78,10 @@ def test_nn_ensemble_train_and_learn(registry, tmpdir):
 
     time.sleep(0.1)  # make sure the timestamp has a chance to increase
 
-    nn_ensemble.learn(document_corpus)
+    # Learning is typically performed on one document at a time
+    document_corpus_single_doc = annif.corpus.LimitingDocumentCorpus(
+        document_corpus, 1)
+    nn_ensemble.learn(document_corpus_single_doc)
 
     assert modelfile.size() != old_size or modelfile.mtime() != old_mtime
 

--- a/tests/test_backend_nn_ensemble.py
+++ b/tests/test_backend_nn_ensemble.py
@@ -6,7 +6,7 @@ import py.path
 from datetime import datetime, timedelta, timezone
 import annif.backend
 import annif.corpus
-from annif.exception import NotInitializedException
+from annif.exception import NotInitializedException, NotSupportedException
 
 pytest.importorskip("annif.backend.nn_ensemble")
 
@@ -178,6 +178,16 @@ def test_nn_ensemble_default_params(app_project):
     actual_params = nn_ensemble.params
     for param, val in expected_default_params.items():
         assert param in actual_params and actual_params[param] == val
+
+
+def test_nn_ensemble_train_nodocuments(project, empty_corpus):
+    nn_ensemble_type = annif.backend.get_backend('nn_ensemble')
+    nn_ensemble = nn_ensemble_type(
+        backend_id='nn_ensemble',
+        config_params={'sources': 'dummy-en'},
+        project=project)
+    with pytest.raises(NotSupportedException):
+        nn_ensemble.train(empty_corpus)
 
 
 def test_nn_ensemble_suggest(app_project):


### PR DESCRIPTION
Training or learning NN ensemble projects on a corpus consisting of only one document has been failing due to `UnboundLocalError` from Keras. 

On Annif side the reason for this was an error for calculating [the number of batches in `LMDBSequence`](https://github.com/NatLibFi/Annif/blob/a1348aa42236446dc315ef9c3ed2ea4de00a2ceb/annif/backend/nn_ensemble.py#L72-74), which was based on a wrong `self._counter` value: when loading the LMDB the counter value [was obtained as the index of the last element](https://github.com/NatLibFi/Annif/blob/a1348aa42236446dc315ef9c3ed2ea4de00a2ceb/annif/backend/nn_ensemble.py#L41), which resulted in the counter value to be too small by one (for a corpus of one document `self._counter = 0`, and thus `len(seq) = 0`). So, Keras did not find any batches to iterate over, but raised the (spurious) error.

This PR fixes the off-by-one error enabling training and - more importantly - learning nn_ensemble projects on one document only (learn is typically called on one doc at a time). 

Also raises `NotSupportedException` for attempts of training or learning with empty corpora. 

Closes #504 and #505.