### PR TITLE
Warn instead of error in case of multiple subjects per doc in SVC training

### DIFF
--- a/annif/backend/svc.py
+++ b/annif/backend/svc.py
@@ -47,16 +47,15 @@ class SVCBackend(mixins.TfidfVectorizerMixin, backend.AnnifBackend):
         self.initialize_vectorizer()
         self._initialize_model()
 
-    @staticmethod
-    def _corpus_to_texts_and_classes(corpus):
+    def _corpus_to_texts_and_classes(self, corpus):
         texts = []
         classes = []
         for doc in corpus.documents:
             texts.append(doc.text)
             if len(doc.uris) > 1:
-                raise NotSupportedException(
-                    'SVC backend does not support training on documents ' +
-                    'with multiple subjects.')
+                self.warning(
+                    'training on a document with multiple subjects is not ' +
+                    'supported by SVC; selecting one random subject.')
             classes.append(list(doc.uris)[0])
         return texts, classes
 

--- a/annif/backend/svc.py
+++ b/annif/backend/svc.py
@@ -56,7 +56,7 @@ class SVCBackend(mixins.TfidfVectorizerMixin, backend.AnnifBackend):
                 self.warning(
                     'training on a document with multiple subjects is not ' +
                     'supported by SVC; selecting one random subject.')
-            classes.append(list(doc.uris)[0])
+            classes.append(next(iter(doc.uris)))
         return texts, classes
 
     def _train_classifier(self, veccorpus, classes):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -97,17 +97,6 @@ def document_corpus(subject_index):
 
 
 @pytest.fixture(scope='module')
-def document_corpus_single_subject(document_corpus):
-    docs_single_subj = []
-    for doc in document_corpus.documents:
-        uri = list(doc.uris)[0] if len(doc.uris) > 0 else None
-        label = list(doc.labels)[0] if len(doc.labels) > 0 else None
-        docs_single_subj.append(
-            annif.corpus.Document(doc.text, {uri}, {label}))
-    return annif.corpus.DocumentList(docs_single_subj)
-
-
-@pytest.fixture(scope='module')
 def pretrained_vectors():
     return py.path.local(os.path.join(
         os.path.dirname(__file__),

--- a/tests/test_backend_svc.py
+++ b/tests/test_backend_svc.py
@@ -34,28 +34,28 @@ def test_svc_suggest_no_vectorizer(project):
         svc.suggest("example text")
 
 
-def test_svc_train(datadir, document_corpus_single_subject, project, caplog):
+def test_svc_train(datadir, document_corpus, project, caplog):
     svc_type = annif.backend.get_backend('svc')
     svc = svc_type(
         backend_id='svc',
         config_params={},
         project=project)
 
-    svc.train(document_corpus_single_subject)
+    svc.train(document_corpus)
     assert svc._model is not None
     assert datadir.join('svc-model.gz').exists()
     assert 'training on a document with multiple subjects is not ' + \
            'supported by SVC; selecting one random subject.' in caplog.text
 
 
-def test_svc_train_ngram(datadir, document_corpus_single_subject, project):
+def test_svc_train_ngram(datadir, document_corpus, project):
     svc_type = annif.backend.get_backend('svc')
     svc = svc_type(
         backend_id='svc',
         config_params={'ngram': 2},
         project=project)
 
-    svc.train(document_corpus_single_subject)
+    svc.train(document_corpus)
     assert svc._model is not None
     assert datadir.join('svc-model.gz').exists()
 

--- a/tests/test_backend_svc.py
+++ b/tests/test_backend_svc.py
@@ -34,7 +34,7 @@ def test_svc_suggest_no_vectorizer(project):
         svc.suggest("example text")
 
 
-def test_svc_train(datadir, document_corpus_single_subject, project):
+def test_svc_train(datadir, document_corpus_single_subject, project, caplog):
     svc_type = annif.backend.get_backend('svc')
     svc = svc_type(
         backend_id='svc',
@@ -44,6 +44,8 @@ def test_svc_train(datadir, document_corpus_single_subject, project):
     svc.train(document_corpus_single_subject)
     assert svc._model is not None
     assert datadir.join('svc-model.gz').exists()
+    assert 'training on a document with multiple subjects is not ' + \
+           'supported by SVC; selecting one random subject.' in caplog.text
 
 
 def test_svc_train_ngram(datadir, document_corpus_single_subject, project):
@@ -67,17 +69,6 @@ def test_svc_train_cached(datadir, project):
 
     with pytest.raises(NotSupportedException):
         svc.train("cached")
-
-
-def test_svc_train_multiple_subjects(datadir, document_corpus, project):
-    svc_type = annif.backend.get_backend('svc')
-    svc = svc_type(
-        backend_id='svc',
-        config_params={},
-        project=project)
-
-    with pytest.raises(NotSupportedException):
-        svc.train(document_corpus)
 
 
 def test_svc_train_nodocuments(datadir, project, empty_corpus):


### PR DESCRIPTION
PR #501 fixed training SVC on full-text corpus, and also added raising `NotSupportedException` if any training document had multiple uris (as SVC is a multi-class, not multi-label algorithm). However in real-life even in those data-sets meant to have only one subject per doc there can be some docs with many subjects. To allow training SVC on such data sets, this PR changes the error to warning, and lets a random one of the uris to be used as the target uri.