### PR TITLE
Support jobs parameter in train command

### DIFF
--- a/annif/backend/backend.py
+++ b/annif/backend/backend.py
@@ -54,15 +54,15 @@ class AnnifBackend(metaclass=abc.ABCMeta):
             backend_params.update(params)
         return backend_params
 
-    def _train(self, corpus, params):
+    def _train(self, corpus, params, jobs=0):
         """This method can be overridden by backends. It implements
         the train functionality, with pre-processed parameters."""
         pass  # default is to do nothing, subclasses may override
 
-    def train(self, corpus, params=None):
+    def train(self, corpus, params=None, jobs=0):
         """Train the model on the given document or subject corpus."""
         beparams = self._get_backend_params(params)
-        return self._train(corpus, params=beparams)
+        return self._train(corpus, params=beparams, jobs=jobs)
 
     def initialize(self):
         """This method can be overridden by backends. It should cause the

--- a/annif/backend/ensemble.py
+++ b/annif/backend/ensemble.py
@@ -142,6 +142,6 @@ class EnsembleBackend(BaseEnsembleBackend, hyperopt.AnnifHyperoptBackend):
     def get_hp_optimizer(self, corpus, metric):
         return EnsembleOptimizer(self, corpus, metric)
 
-    def _train(self, corpus, params):
+    def _train(self, corpus, params, jobs=0):
         raise NotSupportedException(
             'Training ensemble backend is not possible.')

--- a/annif/backend/fasttext.py
+++ b/annif/backend/fasttext.py
@@ -112,13 +112,15 @@ class FastTextBackend(mixins.ChunkingBackend, backend.AnnifBackend):
                                self.TRAIN_FILE,
                                method=self._write_train_file)
 
-    def _create_model(self, params):
+    def _create_model(self, params, jobs):
         self.info('creating fastText model')
         trainpath = os.path.join(self.datadir, self.TRAIN_FILE)
         modelpath = os.path.join(self.datadir, self.MODEL_FILE)
         params = {param: self.FASTTEXT_PARAMS[param](val)
                   for param, val in params.items()
                   if param in self.FASTTEXT_PARAMS}
+        if jobs != 0:  # jobs set by user to non-default value
+            params['thread'] = jobs
         self.debug('Model parameters: {}'.format(params))
         self._model = fasttext.train_supervised(trainpath, **params)
         self._model.save_model(modelpath)
@@ -132,7 +134,7 @@ class FastTextBackend(mixins.ChunkingBackend, backend.AnnifBackend):
             self._create_train_file(corpus)
         else:
             self.info("Reusing cached training data from previous run.")
-        self._create_model(params)
+        self._create_model(params, jobs)
 
     def _predict_chunks(self, chunktexts, limit):
         return self._model.predict(list(

--- a/annif/backend/fasttext.py
+++ b/annif/backend/fasttext.py
@@ -123,7 +123,7 @@ class FastTextBackend(mixins.ChunkingBackend, backend.AnnifBackend):
         self._model = fasttext.train_supervised(trainpath, **params)
         self._model.save_model(modelpath)
 
-    def _train(self, corpus, params):
+    def _train(self, corpus, params, jobs=0):
         if corpus != 'cached':
             if corpus.is_empty():
                 raise NotSupportedException(

--- a/annif/backend/maui.py
+++ b/annif/backend/maui.py
@@ -154,7 +154,7 @@ class MauiBackend(backend.AnnifBackend):
                 return
             time.sleep(1)
 
-    def _train(self, corpus, params):
+    def _train(self, corpus, params, jobs=0):
         if corpus == 'cached':
             raise NotSupportedException(
                 'Training maui project from cached data not supported.')

--- a/annif/backend/mllm.py
+++ b/annif/backend/mllm.py
@@ -112,7 +112,7 @@ class MLLMBackend(hyperopt.AnnifHyperoptBackend):
         if self._model is None:
             self._model = self._load_model()
 
-    def _train(self, corpus, params):
+    def _train(self, corpus, params, jobs=0):
         self.info('starting train')
         if corpus != 'cached':
             if corpus.is_empty():

--- a/annif/backend/nn_ensemble.py
+++ b/annif/backend/nn_ensemble.py
@@ -164,7 +164,7 @@ class NNEnsembleBackend(
         self._model.summary(print_fn=summary.append)
         self.debug("Created model: \n" + "\n".join(summary))
 
-    def _train(self, corpus, params):
+    def _train(self, corpus, params, jobs=0):
         sources = annif.util.parse_sources(self.params['sources'])
         self._create_model(sources)
         self._fit_model(corpus, epochs=int(params['epochs']))

--- a/annif/backend/omikuji.py
+++ b/annif/backend/omikuji.py
@@ -82,7 +82,7 @@ class OmikujiBackend(mixins.TfidfVectorizerMixin, backend.AnnifBackend):
             trainfile.seek(0)
             print('{:08d}'.format(n_samples), end='', file=trainfile)
 
-    def _create_model(self, params):
+    def _create_model(self, params, jobs):
         train_path = os.path.join(self.datadir, self.TRAIN_FILE)
         model_path = os.path.join(self.datadir, self.MODEL_FILE)
         hyper_param = omikuji.Model.default_hyper_param()
@@ -94,7 +94,8 @@ class OmikujiBackend(mixins.TfidfVectorizerMixin, backend.AnnifBackend):
         hyper_param.collapse_every_n_layers = int(
             params['collapse_every_n_layers'])
 
-        self._model = omikuji.Model.train_on_data(train_path, hyper_param)
+        self._model = omikuji.Model.train_on_data(
+            train_path, hyper_param, jobs or None)
         if os.path.exists(model_path):
             shutil.rmtree(model_path)
         self._model.save(os.path.join(self.datadir, self.MODEL_FILE))
@@ -112,7 +113,7 @@ class OmikujiBackend(mixins.TfidfVectorizerMixin, backend.AnnifBackend):
             self._create_train_file(veccorpus, corpus)
         else:
             self.info("Reusing cached training data from previous run.")
-        self._create_model(params)
+        self._create_model(params, jobs)
 
     def _suggest(self, text, params):
         self.debug('Suggesting subjects for text "{}..." (len={})'.format(

--- a/annif/backend/omikuji.py
+++ b/annif/backend/omikuji.py
@@ -99,7 +99,7 @@ class OmikujiBackend(mixins.TfidfVectorizerMixin, backend.AnnifBackend):
             shutil.rmtree(model_path)
         self._model.save(os.path.join(self.datadir, self.MODEL_FILE))
 
-    def _train(self, corpus, params):
+    def _train(self, corpus, params, jobs=0):
         if corpus != 'cached':
             if corpus.is_empty():
                 raise NotSupportedException(

--- a/annif/backend/pav.py
+++ b/annif/backend/pav.py
@@ -124,7 +124,7 @@ class PAVBackend(ensemble.BaseEnsembleBackend):
             model_filename,
             method=joblib.dump)
 
-    def _train(self, corpus, params):
+    def _train(self, corpus, params, jobs=0):
         if corpus == 'cached':
             raise NotSupportedException(
                 'Training pav project from cached data not supported.')

--- a/annif/backend/stwfsa.py
+++ b/annif/backend/stwfsa.py
@@ -90,7 +90,7 @@ class StwfsaBackend(backend.AnnifBackend):
             y.append(doc.uris)
         return X, y
 
-    def _train(self, corpus, params):
+    def _train(self, corpus, params, jobs=0):
         X, y = self._load_data(corpus)
         new_params = {
                 key: self.STWFSA_PARAMETERS[key](val)

--- a/annif/backend/svc.py
+++ b/annif/backend/svc.py
@@ -68,7 +68,7 @@ class SVCBackend(mixins.TfidfVectorizerMixin, backend.AnnifBackend):
                                self.MODEL_FILE,
                                method=joblib.dump)
 
-    def _train(self, corpus, params):
+    def _train(self, corpus, params, jobs=0):
         if corpus == 'cached':
             raise NotSupportedException(
                 'SVC backend does not support reuse of cached training data.')

--- a/annif/backend/tfidf.py
+++ b/annif/backend/tfidf.py
@@ -109,7 +109,7 @@ class TFIDFBackend(mixins.TfidfVectorizerMixin, backend.AnnifBackend):
             self.datadir,
             self.INDEX_FILE)
 
-    def _train(self, corpus, params):
+    def _train(self, corpus, params, jobs=0):
         if corpus == 'cached':
             raise NotSupportedException(
                 'Training tfidf project from cached data not supported.')

--- a/annif/backend/vw_multi.py
+++ b/annif/backend/vw_multi.py
@@ -227,7 +227,7 @@ class VWMultiBackend(mixins.ChunkingBackend, backend.AnnifLearningBackend):
                                self.TRAIN_FILE,
                                method=self._write_train_file)
 
-    def _train(self, corpus, params):
+    def _train(self, corpus, params, jobs=0):
         if corpus != 'cached':
             self._create_train_file(corpus)
         else:

--- a/annif/backend/yake.py
+++ b/annif/backend/yake.py
@@ -183,6 +183,6 @@ class YakeBackend(backend.AnnifBackend):
         confl = score1 * score2 / (score1 * score2 + (1-score1) * (1-score2))
         return (confl-0.5) * 2
 
-    def _train(self, corpus, params):
+    def _train(self, corpus, params, jobs=0):
         raise NotSupportedException(
             'Training yake backend is not possible.')

--- a/annif/cli.py
+++ b/annif/cli.py
@@ -197,9 +197,13 @@ def run_loadvoc(project_id, subjectfile):
 @click.option('--docs-limit', '-d', default=None,
               type=click.IntRange(0, None),
               help='Maximum number of documents to use')
+@click.option('--jobs',
+              '-j',
+              default=0,
+              help='Number of parallel jobs (0 means choose automatically)')
 @backend_param_option
 @common_options
-def run_train(project_id, paths, cached, docs_limit, backend_param):
+def run_train(project_id, paths, cached, docs_limit, jobs, backend_param):
     """
     Train a project on a collection of documents.
     """
@@ -212,7 +216,7 @@ def run_train(project_id, paths, cached, docs_limit, backend_param):
         documents = 'cached'
     else:
         documents = open_documents(paths, docs_limit)
-    proj.train(documents, backend_params)
+    proj.train(documents, backend_params, jobs)
 
 
 @cli.command('learn')

--- a/annif/project.py
+++ b/annif/project.py
@@ -193,7 +193,7 @@ class AnnifProject(DatadirMixin):
         logger.debug('%d hits from backend', len(hits))
         return hits
 
-    def train(self, corpus, backend_params=None):
+    def train(self, corpus, backend_params=None, jobs=0):
         """train the project using documents from a metadata source"""
         if corpus != 'cached':
             corpus.set_subject_index(self.subjects)
@@ -201,7 +201,7 @@ class AnnifProject(DatadirMixin):
         if backend_params is None:
             backend_params = {}
         beparams = backend_params.get(self.backend.backend_id, {})
-        self.backend.train(corpus, beparams)
+        self.backend.train(corpus, beparams, jobs)
 
     def learn(self, corpus, backend_params=None):
         """further train the project using documents from a metadata source"""

--- a/tests/test_backend_fasttext.py
+++ b/tests/test_backend_fasttext.py
@@ -47,7 +47,7 @@ def test_fasttext_train(document_corpus, project, datadir):
     assert datadir.join('fasttext-model').size() > 0
 
 
-def test_fasttext_train_cached(project, datadir):
+def test_fasttext_train_cached_jobs(project, datadir):
     assert datadir.join('fasttext-train.txt').exists()
     datadir.join('fasttext-model').remove()
     fasttext_type = annif.backend.get_backend("fasttext")
@@ -61,7 +61,7 @@ def test_fasttext_train_cached(project, datadir):
             'loss': 'hs'},
         project=project)
 
-    fasttext.train("cached")
+    fasttext.train("cached", jobs=2)
     assert fasttext._model is not None
     assert datadir.join('fasttext-model').exists()
     assert datadir.join('fasttext-model').size() > 0


### PR DESCRIPTION
This PR adds a new `jobs` parameter for the `annif train` command, similar to the one already implemented in `eval` and `hyperopt` commands. The intent is to make it easier to control the amount of threads/CPUs used for training, for those backends that can make use of parallel processing during training.

The PR adds this support to the fasttext and Omikuji backends, for which this was simple to implement.

Adding as draft PR for now, since this needs more testing and QA tool checks.

This is a sideshoot of PR #511 which will benefit from this, but I thought it was cleaner to implement it as a separate PR.