### PR TITLE
Keep serialized dump of SKOS graph to save parsing time

### DIFF
--- a/annif/corpus/skos.py
+++ b/annif/corpus/skos.py
@@ -1,5 +1,6 @@
 """Support for subjects loaded from a SKOS/RDF file"""
 
+import os.path
 import shutil
 import joblib
 import rdflib
@@ -80,7 +81,8 @@ class SubjectFileSKOS(SubjectCorpus):
 
         if self.path.endswith('.ttl'):
             # input is already in Turtle syntax, no need to reserialize
-            if self.path != path:
+            if not os.path.exists(path) or \
+               not os.path.samefile(self.path, path):
                 shutil.copyfile(self.path, path)
         else:
             # need to serialize into Turtle

--- a/annif/corpus/skos.py
+++ b/annif/corpus/skos.py
@@ -1,6 +1,7 @@
 """Support for subjects loaded from a SKOS/RDF file"""
 
 import shutil
+import joblib
 import rdflib
 import rdflib.util
 from rdflib.namespace import SKOS, RDF, OWL
@@ -22,6 +23,8 @@ def serialize_subjects_to_skos(subjects, language, path):
                    SKOS.notation,
                    rdflib.Literal(subject.notation)))
     graph.serialize(destination=path, format='turtle')
+    # also dump the graph in joblib format which is faster to load
+    joblib.dump(graph, path.replace('.ttl', '.joblib'))
 
 
 class SubjectFileSKOS(SubjectCorpus):
@@ -30,8 +33,12 @@ class SubjectFileSKOS(SubjectCorpus):
     def __init__(self, path, language):
         self.path = path
         self.language = language
-        self.graph = rdflib.Graph()
-        self.graph.load(self.path, format=rdflib.util.guess_format(self.path))
+        if path.endswith('.joblib'):
+            self.graph = joblib.load(path)
+        else:
+            self.graph = rdflib.Graph()
+            self.graph.load(self.path,
+                            format=rdflib.util.guess_format(self.path))
 
     @property
     def subjects(self):
@@ -73,7 +80,10 @@ class SubjectFileSKOS(SubjectCorpus):
 
         if self.path.endswith('.ttl'):
             # input is already in Turtle syntax, no need to reserialize
-            shutil.copyfile(self.path, path)
+            if self.path != path:
+                shutil.copyfile(self.path, path)
         else:
             # need to serialize into Turtle
             self.graph.serialize(destination=path, format='turtle')
+        # also dump the graph in joblib format which is faster to load
+        joblib.dump(self.graph, path.replace('.ttl', '.joblib'))

--- a/annif/corpus/skos.py
+++ b/annif/corpus/skos.py
@@ -24,7 +24,7 @@ def serialize_subjects_to_skos(subjects, language, path):
                    rdflib.Literal(subject.notation)))
     graph.serialize(destination=path, format='turtle')
     # also dump the graph in joblib format which is faster to load
-    joblib.dump(graph, path.replace('.ttl', '.joblib'))
+    joblib.dump(graph, path.replace('.ttl', '.joblib.gz'))
 
 
 class SubjectFileSKOS(SubjectCorpus):
@@ -33,7 +33,7 @@ class SubjectFileSKOS(SubjectCorpus):
     def __init__(self, path, language):
         self.path = path
         self.language = language
-        if path.endswith('.joblib'):
+        if path.endswith('.joblib.gz'):
             self.graph = joblib.load(path)
         else:
             self.graph = rdflib.Graph()
@@ -86,4 +86,4 @@ class SubjectFileSKOS(SubjectCorpus):
             # need to serialize into Turtle
             self.graph.serialize(destination=path, format='turtle')
         # also dump the graph in joblib format which is faster to load
-        joblib.dump(self.graph, path.replace('.ttl', '.joblib'))
+        joblib.dump(self.graph, path.replace('.ttl', '.joblib.gz'))

--- a/annif/vocab.py
+++ b/annif/vocab.py
@@ -60,7 +60,7 @@ class AnnifVocabulary(DatadirMixin):
     def skos(self):
         """return the subject vocabulary from SKOS file"""
         if self._skos_vocab is None:
-            dumppath = os.path.join(self.datadir, 'subjects.joblib')
+            dumppath = os.path.join(self.datadir, 'subjects.joblib.gz')
             if os.path.exists(dumppath):
                 logger.debug(f'loading graph dump from {dumppath}')
                 self._skos_vocab = annif.corpus.SubjectFileSKOS(dumppath,

--- a/annif/vocab.py
+++ b/annif/vocab.py
@@ -60,11 +60,18 @@ class AnnifVocabulary(DatadirMixin):
     def skos(self):
         """return the subject vocabulary from SKOS file"""
         if self._skos_vocab is None:
+            dumppath = os.path.join(self.datadir, 'subjects.joblib')
+            if os.path.exists(dumppath):
+                logger.debug(f'loading graph dump from {dumppath}')
+                self._skos_vocab = annif.corpus.SubjectFileSKOS(dumppath,
+                                                                self.language)
+        if self._skos_vocab is None:
             path = os.path.join(self.datadir, 'subjects.ttl')
             if os.path.exists(path):
                 logger.debug(f'loading graph from {path}')
                 self._skos_vocab = annif.corpus.SubjectFileSKOS(path,
                                                                 self.language)
+                self._skos_vocab.save_skos(path, self.language)
             else:
                 raise NotInitializedException(f'graph file {path} not found')
         return self._skos_vocab

--- a/annif/vocab.py
+++ b/annif/vocab.py
@@ -59,26 +59,28 @@ class AnnifVocabulary(DatadirMixin):
     @property
     def skos(self):
         """return the subject vocabulary from SKOS file"""
-        if self._skos_vocab is None:
-            dumppath = os.path.join(self.datadir, 'subjects.joblib.gz')
-            if os.path.exists(dumppath):
-                logger.debug(f'loading graph dump from {dumppath}')
-                self._skos_vocab = annif.corpus.SubjectFileSKOS(dumppath,
-                                                                self.language)
-                return self._skos_vocab
+        if self._skos_vocab is not None:
+            return self._skos_vocab
 
-            # graph dump file not found - parse ttl file instead
-            path = os.path.join(self.datadir, 'subjects.ttl')
-            if os.path.exists(path):
-                logger.debug(f'loading graph from {path}')
-                self._skos_vocab = annif.corpus.SubjectFileSKOS(path,
-                                                                self.language)
-                # store the dump file so we can use it next time
-                self._skos_vocab.save_skos(path, self.language)
-                return self._skos_vocab
-            else:
-                raise NotInitializedException(f'graph file {path} not found')
-        return self._skos_vocab
+        # attempt to load graph from dump file
+        dumppath = os.path.join(self.datadir, 'subjects.joblib.gz')
+        if os.path.exists(dumppath):
+            logger.debug(f'loading graph dump from {dumppath}')
+            self._skos_vocab = annif.corpus.SubjectFileSKOS(dumppath,
+                                                            self.language)
+            return self._skos_vocab
+
+        # graph dump file not found - parse ttl file instead
+        path = os.path.join(self.datadir, 'subjects.ttl')
+        if os.path.exists(path):
+            logger.debug(f'loading graph from {path}')
+            self._skos_vocab = annif.corpus.SubjectFileSKOS(path,
+                                                            self.language)
+            # store the dump file so we can use it next time
+            self._skos_vocab.save_skos(path, self.language)
+            return self._skos_vocab
+
+        raise NotInitializedException(f'graph file {path} not found')
 
     def load_vocabulary(self, subject_corpus, language):
         """load subjects from a subject corpus and save them into a

--- a/annif/vocab.py
+++ b/annif/vocab.py
@@ -65,13 +65,17 @@ class AnnifVocabulary(DatadirMixin):
                 logger.debug(f'loading graph dump from {dumppath}')
                 self._skos_vocab = annif.corpus.SubjectFileSKOS(dumppath,
                                                                 self.language)
-        if self._skos_vocab is None:
+                return self._skos_vocab
+
+            # graph dump file not found - parse ttl file instead
             path = os.path.join(self.datadir, 'subjects.ttl')
             if os.path.exists(path):
                 logger.debug(f'loading graph from {path}')
                 self._skos_vocab = annif.corpus.SubjectFileSKOS(path,
                                                                 self.language)
+                # store the dump file so we can use it next time
                 self._skos_vocab.save_skos(path, self.language)
+                return self._skos_vocab
             else:
                 raise NotInitializedException(f'graph file {path} not found')
         return self._skos_vocab

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -129,6 +129,8 @@ def test_loadvoc_tsv(testdatadir):
     assert testdatadir.join('vocabs/yso-fi/subjects').size() > 0
     assert testdatadir.join('vocabs/yso-fi/subjects.ttl').exists()
     assert testdatadir.join('vocabs/yso-fi/subjects.ttl').size() > 0
+    assert testdatadir.join('vocabs/yso-fi/subjects.joblib.gz').exists()
+    assert testdatadir.join('vocabs/yso-fi/subjects.joblib.gz').size() > 0
 
 
 def test_loadvoc_tsv_with_bom(testdatadir):
@@ -148,6 +150,8 @@ def test_loadvoc_tsv_with_bom(testdatadir):
     assert testdatadir.join('vocabs/yso-fi/subjects').size() > 0
     assert testdatadir.join('vocabs/yso-fi/subjects.ttl').exists()
     assert testdatadir.join('vocabs/yso-fi/subjects.ttl').size() > 0
+    assert testdatadir.join('vocabs/yso-fi/subjects.joblib.gz').exists()
+    assert testdatadir.join('vocabs/yso-fi/subjects.joblib.gz').size() > 0
 
 
 def test_loadvoc_rdf(testdatadir):
@@ -167,6 +171,8 @@ def test_loadvoc_rdf(testdatadir):
     assert testdatadir.join('vocabs/yso-fi/subjects').size() > 0
     assert testdatadir.join('vocabs/yso-fi/subjects.ttl').exists()
     assert testdatadir.join('vocabs/yso-fi/subjects.ttl').size() > 0
+    assert testdatadir.join('vocabs/yso-fi/subjects.joblib.gz').exists()
+    assert testdatadir.join('vocabs/yso-fi/subjects.joblib.gz').size() > 0
 
 
 def test_loadvoc_ttl(testdatadir):
@@ -186,6 +192,8 @@ def test_loadvoc_ttl(testdatadir):
     assert testdatadir.join('vocabs/yso-fi/subjects').size() > 0
     assert testdatadir.join('vocabs/yso-fi/subjects.ttl').exists()
     assert testdatadir.join('vocabs/yso-fi/subjects.ttl').size() > 0
+    assert testdatadir.join('vocabs/yso-fi/subjects.joblib.gz').exists()
+    assert testdatadir.join('vocabs/yso-fi/subjects.joblib.gz').size() > 0
 
 
 def test_loadvoc_nonexistent_path():

--- a/tests/test_vocab.py
+++ b/tests/test_vocab.py
@@ -84,6 +84,25 @@ def test_update_subject_index_with_added_subjects(tmpdir):
                                  '42.42')
 
 
+def test_skos(tmpdir):
+    vocab = load_dummy_vocab(tmpdir)
+    assert tmpdir.join('vocabs/vocab-id/subjects.ttl').exists()
+    assert tmpdir.join('vocabs/vocab-id/subjects.joblib.gz').exists()
+    assert isinstance(vocab.skos, annif.corpus.SubjectFileSKOS)
+
+
+def test_skos_cache(tmpdir):
+    vocab = load_dummy_vocab(tmpdir)
+    assert tmpdir.join('vocabs/vocab-id/subjects.ttl').exists()
+    assert tmpdir.join('vocabs/vocab-id/subjects.joblib.gz').exists()
+    tmpdir.join('vocabs/vocab-id/subjects.joblib.gz').remove()
+    assert not tmpdir.join('vocabs/vocab-id/subjects.joblib.gz').exists()
+
+    assert isinstance(vocab.skos, annif.corpus.SubjectFileSKOS)
+    # cached dump file has been recreated in .skos property access
+    assert tmpdir.join('vocabs/vocab-id/subjects.joblib.gz').exists()
+
+
 def test_as_graph(tmpdir):
     vocab = load_dummy_vocab(tmpdir)
     graph = vocab.as_graph()

--- a/tests/test_vocab.py
+++ b/tests/test_vocab.py
@@ -1,8 +1,10 @@
 """Unit tests for vocabulary functionality in Annif"""
 
+import pytest
 import os
 import annif.corpus
 import annif.vocab
+from annif.exception import NotInitializedException
 import rdflib.namespace
 
 
@@ -101,6 +103,17 @@ def test_skos_cache(tmpdir):
     assert isinstance(vocab.skos, annif.corpus.SubjectFileSKOS)
     # cached dump file has been recreated in .skos property access
     assert tmpdir.join('vocabs/vocab-id/subjects.joblib.gz').exists()
+
+
+def test_skos_not_found(tmpdir):
+    vocab = load_dummy_vocab(tmpdir)
+    assert tmpdir.join('vocabs/vocab-id/subjects.ttl').exists()
+    assert tmpdir.join('vocabs/vocab-id/subjects.joblib.gz').exists()
+    tmpdir.join('vocabs/vocab-id/subjects.ttl').remove()
+    tmpdir.join('vocabs/vocab-id/subjects.joblib.gz').remove()
+
+    with pytest.raises(NotInitializedException):
+        vocab.skos
 
 
 def test_as_graph(tmpdir):


### PR DESCRIPTION
SKOS vocabulary parsing can be pretty slow. With the MLLM backend, the SKOS vocabulary needs to be parsed from a Turtle file every time models are trained. With current YSO this takes around a minute.

If we instead serialize the rdflib.Graph using joblib during loadvoc, it will be much faster to load during train runs.

I tested two versions (on i7-8550U laptop), one with uncompressed dumps and another with gzip compression, using the Annif-tutorial yso-nlf data set and the train command from the MLLM exercise. Note that the benchmark wasn't very scientific.

**-**|**loadvoc (s)**|**train mllm (s)**|**dump size**
-----|:-----:|:-----:|:-----:
Before|72|893|-
Uncompressed|106 (+34)|844 (-49)|51MB
Compressed|102 (+30)|856 (-37)|22MB

The gzip version seems better. Basically, this will add ~30s to `loadvoc` but subsequent MLLM training takes ~40s less.

Opening a draft PR to get feedback from QA tools. Unit tests are still needed.