### PR TITLE
Allow NN ensemble to be used for parallel eval

### DIFF
--- a/annif/backend/backend.py
+++ b/annif/backend/backend.py
@@ -64,7 +64,7 @@ class AnnifBackend(metaclass=abc.ABCMeta):
         beparams = self._get_backend_params(params)
         return self._train(corpus, params=beparams, jobs=jobs)
 
-    def initialize(self):
+    def initialize(self, parallel=False):
         """This method can be overridden by backends. It should cause the
         backend to pre-load all data it needs during operation."""
         pass

--- a/annif/backend/backend.py
+++ b/annif/backend/backend.py
@@ -66,7 +66,9 @@ class AnnifBackend(metaclass=abc.ABCMeta):
 
     def initialize(self, parallel=False):
         """This method can be overridden by backends. It should cause the
-        backend to pre-load all data it needs during operation."""
+        backend to pre-load all data it needs during operation.
+        If parallel is True, the backend should expect to be used for
+        parallel operation."""
         pass
 
     @abc.abstractmethod

--- a/annif/backend/dummy.py
+++ b/annif/backend/dummy.py
@@ -16,7 +16,7 @@ class DummyBackend(backend.AnnifLearningBackend):
     def default_params(self):
         return backend.AnnifBackend.DEFAULT_PARAMETERS
 
-    def initialize(self):
+    def initialize(self, parallel=False):
         self.initialized = True
 
     def _suggest(self, text, params):

--- a/annif/backend/ensemble.py
+++ b/annif/backend/ensemble.py
@@ -19,12 +19,12 @@ class BaseEnsembleBackend(backend.AnnifBackend):
         return [getattr(self.project.registry.get_project(project_id), attr)
                 for project_id, _ in sources]
 
-    def initialize(self):
+    def initialize(self, parallel=False):
         # initialize all the source projects
         params = self._get_backend_params(None)
         for project_id, _ in annif.util.parse_sources(params['sources']):
             project = self.project.registry.get_project(project_id)
-            project.initialize()
+            project.initialize(parallel)
 
     def _normalize_hits(self, hits, source_project):
         """Hook for processing hits from backends. Intended to be overridden

--- a/annif/backend/fasttext.py
+++ b/annif/backend/fasttext.py
@@ -64,7 +64,7 @@ class FastTextBackend(mixins.ChunkingBackend, backend.AnnifBackend):
         fasttext.FastText.eprint = orig_eprint
         return model
 
-    def initialize(self):
+    def initialize(self, parallel=False):
         if self._model is None:
             path = os.path.join(self.datadir, self.MODEL_FILE)
             self.debug('loading fastText model from {}'.format(path))

--- a/annif/backend/mllm.py
+++ b/annif/backend/mllm.py
@@ -108,7 +108,7 @@ class MLLMBackend(hyperopt.AnnifHyperoptBackend):
                 'train data file {} not found'.format(path),
                 backend_id=self.backend_id)
 
-    def initialize(self):
+    def initialize(self, parallel=False):
         if self._model is None:
             self._model = self._load_model()
 

--- a/annif/backend/nn_ensemble.py
+++ b/annif/backend/nn_ensemble.py
@@ -109,10 +109,14 @@ class NNEnsembleBackend(
         params.update(self.DEFAULT_PARAMETERS)
         return params
 
-    def initialize(self):
-        super().initialize()
+    def initialize(self, parallel=False):
+        super().initialize(parallel)
         if self._model is not None:
             return  # already initialized
+        if parallel:
+            # Don't load TF model just before parallel execution,
+            # since it won't work after forking worker processes
+            return
         model_filename = os.path.join(self.datadir, self.MODEL_FILE)
         if not os.path.exists(model_filename):
             raise NotInitializedException(

--- a/annif/backend/omikuji.py
+++ b/annif/backend/omikuji.py
@@ -46,7 +46,7 @@ class OmikujiBackend(mixins.TfidfVectorizerMixin, backend.AnnifBackend):
                     'model {} not found'.format(path),
                     backend_id=self.backend_id)
 
-    def initialize(self):
+    def initialize(self, parallel=False):
         self.initialize_vectorizer()
         self._initialize_model()
 

--- a/annif/backend/pav.py
+++ b/annif/backend/pav.py
@@ -32,8 +32,8 @@ class PAVBackend(ensemble.BaseEnsembleBackend):
         params.update(self.DEFAULT_PARAMETERS)
         return params
 
-    def initialize(self):
-        super().initialize()
+    def initialize(self, parallel=False):
+        super().initialize(parallel)
         if self._models is not None:
             return  # already initialized
         self._models = {}

--- a/annif/backend/stwfsa.py
+++ b/annif/backend/stwfsa.py
@@ -63,7 +63,7 @@ class StwfsaBackend(backend.AnnifBackend):
 
     _model = None
 
-    def initialize(self):
+    def initialize(self, parallel=False):
         if self._model is None:
             path = os.path.join(self.datadir, self.MODEL_FILE)
             self.debug(f'Loading STWFSA model from {path}.')

--- a/annif/backend/svc.py
+++ b/annif/backend/svc.py
@@ -43,7 +43,7 @@ class SVCBackend(mixins.TfidfVectorizerMixin, backend.AnnifBackend):
                     'model {} not found'.format(path),
                     backend_id=self.backend_id)
 
-    def initialize(self):
+    def initialize(self, parallel=False):
         self.initialize_vectorizer()
         self._initialize_model()
 

--- a/annif/backend/tfidf.py
+++ b/annif/backend/tfidf.py
@@ -95,7 +95,7 @@ class TFIDFBackend(mixins.TfidfVectorizerMixin, backend.AnnifBackend):
                     'similarity index {} not found'.format(path),
                     backend_id=self.backend_id)
 
-    def initialize(self):
+    def initialize(self, parallel=False):
         self.initialize_vectorizer()
         self._initialize_index()
 

--- a/annif/backend/vw_multi.py
+++ b/annif/backend/vw_multi.py
@@ -46,7 +46,7 @@ class VWMultiBackend(mixins.ChunkingBackend, backend.AnnifLearningBackend):
 
     DEFAULT_PARAMETERS = {'algorithm': 'oaa'}
 
-    def initialize(self):
+    def initialize(self, parallel=False):
         if self._model is None:
             path = os.path.join(self.datadir, self.MODEL_FILE)
             if not os.path.exists(path):

--- a/annif/backend/yake.py
+++ b/annif/backend/yake.py
@@ -60,7 +60,7 @@ class YakeBackend(backend.AnnifBackend):
                 raise ConfigurationException(
                     f'invalid label type {lt}', backend_id=self.backend_id)
 
-    def initialize(self):
+    def initialize(self, parallel=False):
         self._initialize_index()
 
     def _initialize_index(self):

--- a/annif/cli.py
+++ b/annif/cli.py
@@ -362,7 +362,7 @@ def run_eval(
 
     jobs, pool_class = annif.parallel.get_pool(jobs)
 
-    project.initialize()
+    project.initialize(parallel=True)
     psmap = annif.parallel.ProjectSuggestMap(
         project.registry, [project_id], backend_params, limit, threshold)
 

--- a/annif/project.py
+++ b/annif/project.py
@@ -87,8 +87,9 @@ class AnnifProject(DatadirMixin):
             logger.warning(err.format_message())
 
     def initialize(self, parallel=False):
-        """initialize this project and its backend so that they are ready to
-        be used"""
+        """Initialize this project and its backend so that they are ready to
+        be used. If parallel is True, expect that the project will be used
+        for parallel processing."""
 
         if self.initialized:
             return

--- a/annif/project.py
+++ b/annif/project.py
@@ -90,6 +90,9 @@ class AnnifProject(DatadirMixin):
         """initialize this project and its backend so that they are ready to
         be used"""
 
+        if self.initialized:
+            return
+
         logger.debug("Initializing project '%s'", self.project_id)
 
         self._initialize_analyzer()

--- a/annif/project.py
+++ b/annif/project.py
@@ -76,17 +76,17 @@ class AnnifProject(DatadirMixin):
         except AnnifException as err:
             logger.warning(err.format_message())
 
-    def _initialize_backend(self):
+    def _initialize_backend(self, parallel):
         logger.debug("Project '%s': initializing backend", self.project_id)
         try:
             if not self.backend:
                 logger.debug("Cannot initialize backend: does not exist")
                 return
-            self.backend.initialize()
+            self.backend.initialize(parallel)
         except AnnifException as err:
             logger.warning(err.format_message())
 
-    def initialize(self):
+    def initialize(self, parallel=False):
         """initialize this project and its backend so that they are ready to
         be used"""
 
@@ -97,7 +97,7 @@ class AnnifProject(DatadirMixin):
 
         self._initialize_analyzer()
         self._initialize_subjects()
-        self._initialize_backend()
+        self._initialize_backend(parallel)
 
         self.initialized = True
 

--- a/tests/test_backend_nn_ensemble.py
+++ b/tests/test_backend_nn_ensemble.py
@@ -16,6 +16,18 @@ def test_lmdb_idx_to_key_to_idx():
     assert annif.backend.nn_ensemble.key_to_idx(b'00000042') == 42
 
 
+def test_nn_ensemble_initialize_parallel(project):
+    nn_ensemble_type = annif.backend.get_backend('nn_ensemble')
+    nn_ensemble = nn_ensemble_type(
+        backend_id='nn_ensemble',
+        config_params={'sources': 'dummy-en'},
+        project=project)
+
+    nn_ensemble.initialize(parallel=True)
+    # model is still not loaded since we're preparing for parallel execution
+    assert nn_ensemble._model is None
+
+
 def test_nn_ensemble_suggest_no_model(project):
     nn_ensemble_type = annif.backend.get_backend('nn_ensemble')
     nn_ensemble = nn_ensemble_type(


### PR DESCRIPTION
Fixes #453 by introducing a `parallel` parameter to project.initialize() and backend.initialize() methods. Setting it to True warns the project/backend that it will be used for parallel execution. The NN ensemble heeds this warning and delays loading the TensorFlow model until later, avoiding the lockup that otherwise happens.

Some unscientific benchmark results for the `eval` command examples in #453 using i5-7200U:

**-**|**user time (s)**|**wall time (m:s)**|
-----|:-----:|:-----:|
Before PR|279|4:42|
jobs=1|251|4:11|
jobs=2|329|2:47|
jobs=0|413|2:04|

Opening draft PR for QA tool results.