### PR TITLE
Skip unimportant subjects in _vector_to_list_suggestion

### DIFF
--- a/annif/suggestion.py
+++ b/annif/suggestion.py
@@ -103,7 +103,7 @@ class VectorSuggestionResult(SuggestionResult):
         for subject_id in self.subject_order:
             score = self._vector[subject_id]
             if score <= 0.0:
-                continue  # we can skip the remaining ones
+                break  # we can skip the remaining ones
             subject = subject_index[subject_id]
             hits.append(
                 SubjectSuggestion(


### PR DESCRIPTION
This one-line PR fixes a performance bug in the VectorSuggestionResult._vector_to_list_suggestion method. As the (pre-existing) comment on the line hints, the conversion from VectorSuggestionResult to ListSuggestionResult needs to consider only the subjects with scores above 0, and since the highest scores are processed first, we can stop once we encounter a zero score and skip the remaining subjects.

But instead of `break` there was a `continue` statement, meaning that all subjects would still be checked. This is very inefficient, especially if the vocabulary is large.