### PR TITLE
Use least frequent token as key in TokenSetIndex used by MLLM

### DIFF
--- a/annif/lexical/mllm.py
+++ b/annif/lexical/mllm.py
@@ -141,9 +141,15 @@ class MLLMModel:
         )
         label_corpus = self._vectorizer.fit_transform((t.label for t in terms))
 
+        # frequency of each token used in labels - how rare each word is
+        token_freq = np.bincount(label_corpus.indices,
+                                 minlength=label_corpus.shape[1])
+
         self._index = TokenSetIndex()
         for term, label_matrix in zip(terms, label_corpus):
             tokens = label_matrix.nonzero()[1]
+            # sort tokens by frequency - use the rarest token as index key
+            tokens = sorted(tokens, key=token_freq.__getitem__)
             tset = TokenSet(tokens, term.subject_id, term.is_pref)
             self._index.add(tset)
 

--- a/annif/lexical/tokenset.py
+++ b/annif/lexical/tokenset.py
@@ -10,6 +10,7 @@ class TokenSet:
 
     def __init__(self, tokens, subject_id=None, is_pref=False):
         self._tokens = set(tokens)
+        self.key = tokens[0] if len(tokens) else None
         self.subject_id = subject_id
         self.is_pref = is_pref
 
@@ -25,13 +26,6 @@ class TokenSet:
 
         return other._tokens.issubset(self._tokens)
 
-    def sample(self):
-        """Return an arbitrary token from this TokenSet, or None if empty"""
-        try:
-            return next(iter(self._tokens))
-        except StopIteration:
-            return None
-
 
 class TokenSetIndex:
     """A searchable index of TokenSets (representing vocabulary terms)"""
@@ -44,9 +38,8 @@ class TokenSetIndex:
 
     def add(self, tset):
         """Add a TokenSet into this index"""
-        token = tset.sample()
-        if token is not None:
-            self._index[token].add(tset)
+        if tset.key is not None:
+            self._index[tset.key].add(tset)
 
     def _find_subj_tsets(self, tset):
         """return a dict (subject_id : TokenSet) of matches contained in the

--- a/tests/test_lexical_tokenset.py
+++ b/tests/test_lexical_tokenset.py
@@ -13,11 +13,11 @@ def test_mllm_tokenset():
     assert tset.contains(TokenSet(tokens))
     assert tset.contains(TokenSet([1]))
     assert not tset.contains(TokenSet([0]))
-    assert tset.sample() in tokens
+    assert tset.key in tokens
 
 
-def test_mllm_tokenset_empty_sample():
-    assert TokenSet([]).sample() is None
+def test_mllm_tokenset_empty_key():
+    assert TokenSet([]).key is None
 
 
 def test_mllm_tokensetindex():


### PR DESCRIPTION
This PR improves the performance of the MLLM algorithm on large vocabularies with lots of repetition in the labels. The TokenSetIndex keeps the token sets indexed using a key token. Previously this key token was picked randomly, but this PR changes it so that the rarest token (among the terms of the subject vocabulary) is used as the key.

For example, if the vocabulary contains person entities like "John Smith", "John Taylor", "John Doe" and "John Johnson", they could all have been put in the index under the token `john`. Every time the document text contains the name "John", the index has to be searched and the tokens in the sentence compared with all the above token sets (`{john, smith}, {john, taylor}, {john, doe}, {john, johnson}`).

Instead the tokensets are now indexed under the rarest token (e.g. `smith`, `taylor`, `doe`, `johnson` - assuming here that there are no other persons with those surnames!) which is more efficient to search. Only when the text contains e.g. "Taylor", is the sentence compared to the set `{john, taylor}` (but not the others).

The difference in performance is very small in the case of YSO, where there isn't much repetition, but for GND this seems to reduce processing times by around 2 seconds per document!