### PR TITLE
SKOS graph cache enhancements

### DIFF
--- a/annif/corpus/skos.py
+++ b/annif/corpus/skos.py
@@ -25,7 +25,7 @@ def serialize_subjects_to_skos(subjects, language, path):
                    rdflib.Literal(subject.notation)))
     graph.serialize(destination=path, format='turtle')
     # also dump the graph in joblib format which is faster to load
-    joblib.dump(graph, path.replace('.ttl', '.joblib.gz'))
+    joblib.dump(graph, path.replace('.ttl', '.dump.gz'))
 
 
 class SubjectFileSKOS(SubjectCorpus):
@@ -34,7 +34,7 @@ class SubjectFileSKOS(SubjectCorpus):
     def __init__(self, path, language):
         self.path = path
         self.language = language
-        if path.endswith('.joblib.gz'):
+        if path.endswith('.dump.gz'):
             self.graph = joblib.load(path)
         else:
             self.graph = rdflib.Graph()
@@ -88,4 +88,4 @@ class SubjectFileSKOS(SubjectCorpus):
             # need to serialize into Turtle
             self.graph.serialize(destination=path, format='turtle')
         # also dump the graph in joblib format which is faster to load
-        joblib.dump(self.graph, path.replace('.ttl', '.joblib.gz'))
+        joblib.dump(self.graph, path.replace('.ttl', '.dump.gz'))

--- a/annif/corpus/skos.py
+++ b/annif/corpus/skos.py
@@ -6,6 +6,7 @@ import joblib
 import rdflib
 import rdflib.util
 from rdflib.namespace import SKOS, RDF, OWL
+import annif.util
 from .types import Subject, SubjectCorpus
 
 
@@ -25,7 +26,9 @@ def serialize_subjects_to_skos(subjects, language, path):
                    rdflib.Literal(subject.notation)))
     graph.serialize(destination=path, format='turtle')
     # also dump the graph in joblib format which is faster to load
-    joblib.dump(graph, path.replace('.ttl', '.dump.gz'))
+    annif.util.atomic_save(graph,
+                           *os.path.split(path.replace('.ttl', '.dump.gz')),
+                           method=joblib.dump)
 
 
 class SubjectFileSKOS(SubjectCorpus):
@@ -88,4 +91,7 @@ class SubjectFileSKOS(SubjectCorpus):
             # need to serialize into Turtle
             self.graph.serialize(destination=path, format='turtle')
         # also dump the graph in joblib format which is faster to load
-        joblib.dump(self.graph, path.replace('.ttl', '.dump.gz'))
+        annif.util.atomic_save(self.graph,
+                               *os.path.split(
+                                   path.replace('.ttl', '.dump.gz')),
+                               method=joblib.dump)

--- a/annif/vocab.py
+++ b/annif/vocab.py
@@ -63,7 +63,7 @@ class AnnifVocabulary(DatadirMixin):
             return self._skos_vocab
 
         # attempt to load graph from dump file
-        dumppath = os.path.join(self.datadir, 'subjects.joblib.gz')
+        dumppath = os.path.join(self.datadir, 'subjects.dump.gz')
         if os.path.exists(dumppath):
             logger.debug(f'loading graph dump from {dumppath}')
             self._skos_vocab = annif.corpus.SubjectFileSKOS(dumppath,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -129,8 +129,8 @@ def test_loadvoc_tsv(testdatadir):
     assert testdatadir.join('vocabs/yso-fi/subjects').size() > 0
     assert testdatadir.join('vocabs/yso-fi/subjects.ttl').exists()
     assert testdatadir.join('vocabs/yso-fi/subjects.ttl').size() > 0
-    assert testdatadir.join('vocabs/yso-fi/subjects.joblib.gz').exists()
-    assert testdatadir.join('vocabs/yso-fi/subjects.joblib.gz').size() > 0
+    assert testdatadir.join('vocabs/yso-fi/subjects.dump.gz').exists()
+    assert testdatadir.join('vocabs/yso-fi/subjects.dump.gz').size() > 0
 
 
 def test_loadvoc_tsv_with_bom(testdatadir):
@@ -150,8 +150,8 @@ def test_loadvoc_tsv_with_bom(testdatadir):
     assert testdatadir.join('vocabs/yso-fi/subjects').size() > 0
     assert testdatadir.join('vocabs/yso-fi/subjects.ttl').exists()
     assert testdatadir.join('vocabs/yso-fi/subjects.ttl').size() > 0
-    assert testdatadir.join('vocabs/yso-fi/subjects.joblib.gz').exists()
-    assert testdatadir.join('vocabs/yso-fi/subjects.joblib.gz').size() > 0
+    assert testdatadir.join('vocabs/yso-fi/subjects.dump.gz').exists()
+    assert testdatadir.join('vocabs/yso-fi/subjects.dump.gz').size() > 0
 
 
 def test_loadvoc_rdf(testdatadir):
@@ -171,8 +171,8 @@ def test_loadvoc_rdf(testdatadir):
     assert testdatadir.join('vocabs/yso-fi/subjects').size() > 0
     assert testdatadir.join('vocabs/yso-fi/subjects.ttl').exists()
     assert testdatadir.join('vocabs/yso-fi/subjects.ttl').size() > 0
-    assert testdatadir.join('vocabs/yso-fi/subjects.joblib.gz').exists()
-    assert testdatadir.join('vocabs/yso-fi/subjects.joblib.gz').size() > 0
+    assert testdatadir.join('vocabs/yso-fi/subjects.dump.gz').exists()
+    assert testdatadir.join('vocabs/yso-fi/subjects.dump.gz').size() > 0
 
 
 def test_loadvoc_ttl(testdatadir):
@@ -192,8 +192,8 @@ def test_loadvoc_ttl(testdatadir):
     assert testdatadir.join('vocabs/yso-fi/subjects').size() > 0
     assert testdatadir.join('vocabs/yso-fi/subjects.ttl').exists()
     assert testdatadir.join('vocabs/yso-fi/subjects.ttl').size() > 0
-    assert testdatadir.join('vocabs/yso-fi/subjects.joblib.gz').exists()
-    assert testdatadir.join('vocabs/yso-fi/subjects.joblib.gz').size() > 0
+    assert testdatadir.join('vocabs/yso-fi/subjects.dump.gz').exists()
+    assert testdatadir.join('vocabs/yso-fi/subjects.dump.gz').size() > 0
 
 
 def test_loadvoc_nonexistent_path():

--- a/tests/test_vocab.py
+++ b/tests/test_vocab.py
@@ -89,28 +89,28 @@ def test_update_subject_index_with_added_subjects(tmpdir):
 def test_skos(tmpdir):
     vocab = load_dummy_vocab(tmpdir)
     assert tmpdir.join('vocabs/vocab-id/subjects.ttl').exists()
-    assert tmpdir.join('vocabs/vocab-id/subjects.joblib.gz').exists()
+    assert tmpdir.join('vocabs/vocab-id/subjects.dump.gz').exists()
     assert isinstance(vocab.skos, annif.corpus.SubjectFileSKOS)
 
 
 def test_skos_cache(tmpdir):
     vocab = load_dummy_vocab(tmpdir)
     assert tmpdir.join('vocabs/vocab-id/subjects.ttl').exists()
-    assert tmpdir.join('vocabs/vocab-id/subjects.joblib.gz').exists()
-    tmpdir.join('vocabs/vocab-id/subjects.joblib.gz').remove()
-    assert not tmpdir.join('vocabs/vocab-id/subjects.joblib.gz').exists()
+    assert tmpdir.join('vocabs/vocab-id/subjects.dump.gz').exists()
+    tmpdir.join('vocabs/vocab-id/subjects.dump.gz').remove()
+    assert not tmpdir.join('vocabs/vocab-id/subjects.dump.gz').exists()
 
     assert isinstance(vocab.skos, annif.corpus.SubjectFileSKOS)
     # cached dump file has been recreated in .skos property access
-    assert tmpdir.join('vocabs/vocab-id/subjects.joblib.gz').exists()
+    assert tmpdir.join('vocabs/vocab-id/subjects.dump.gz').exists()
 
 
 def test_skos_not_found(tmpdir):
     vocab = load_dummy_vocab(tmpdir)
     assert tmpdir.join('vocabs/vocab-id/subjects.ttl').exists()
-    assert tmpdir.join('vocabs/vocab-id/subjects.joblib.gz').exists()
+    assert tmpdir.join('vocabs/vocab-id/subjects.dump.gz').exists()
     tmpdir.join('vocabs/vocab-id/subjects.ttl').remove()
-    tmpdir.join('vocabs/vocab-id/subjects.joblib.gz').remove()
+    tmpdir.join('vocabs/vocab-id/subjects.dump.gz').remove()
 
     with pytest.raises(NotInitializedException):
         vocab.skos


### PR DESCRIPTION
This is a follow-up to PR #513 which introduced caching for parsed SKOS graphs as joblib dumps. Two small improvements:

- the filename is now `subjects.dump.gz` instead of `subjects.joblib.gz` which is hopefully a bit more descriptive
- `annif.util.atomic_save` is used to avoid file corruption problems in case the dumping gets interrupted