### PR TITLE
Optimize limit_mask creation

### DIFF
--- a/annif/suggestion.py
+++ b/annif/suggestion.py
@@ -2,6 +2,7 @@
 
 import abc
 import collections
+import itertools
 import numpy as np
 
 
@@ -136,9 +137,10 @@ class VectorSuggestionResult(SuggestionResult):
         if limit is not None:
             limit_mask = np.zeros_like(self._vector, dtype=np.bool)
             deprecated_set = set(deprecated_ids)
-            top_k_subjects = [subj for subj in self.subject_order
-                              if subj not in deprecated_set][:limit]
-            limit_mask[top_k_subjects] = True
+            top_k_subjects = itertools.islice(
+                                (subj for subj in self.subject_order
+                                 if subj not in deprecated_set), limit)
+            limit_mask[list(top_k_subjects)] = True
             mask = mask & limit_mask
         else:
             deprecated_mask = np.ones_like(self._vector, dtype=np.bool)


### PR DESCRIPTION
This is a small optimization for the VectorSuggestionResult.filter() method. It creates a `limit_mask` object but to do so, it has to create a list containing all the subjects in the vocabulary. This list is immediately sliced to a much shorter length (typically 100 or 1000), so creating the full list is a waste of time.

This PR switches to using a generator expression instead of a list and slices it with `itertools.islice`, avoiding the list creation overhead. This saves approximately 0.2 seconds per document with the large GND vocabulary (and probably some memory too).