### PR TITLE
Allow private projects to be accessed from CLI

### DIFF
--- a/annif/cli.py
+++ b/annif/cli.py
@@ -31,7 +31,8 @@ def get_project(project_id):
     """
     Helper function to get a project by ID and bail out if it doesn't exist"""
     try:
-        return annif.registry.get_project(project_id, min_access=Access.hidden)
+        return annif.registry.get_project(project_id,
+                                          min_access=Access.private)
     except ValueError:
         click.echo(
             "No projects found with id \'{0}\'.".format(project_id),


### PR DESCRIPTION
Fixes #521 

The intent was always that private projects can be accessed from CLI; the `access` setting only applies to the REST API. But this wasn't actually the case; hidden projects couldn't be used from most CLI commands due to a simple bug, fixed in this PR.