### PR TITLE
Make Drone builds start on all git tag events

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -59,8 +59,6 @@ steps:
       <<: *docker_settings
       auto_tag: true
     when:
-      branch:
-      - master
       event:
       - tag
 


### PR DESCRIPTION
Since Annif 0.53 Drone has not automatically built Docker images on git tag events as previously. The reason for the change is unclear to me, but removing the branch condition (restriction to `master`) from Drone build step triggers resolves the problem. 

Note that this also helps making patch releases: there is no more need to manually hardcode the tags in `.drone.yml` and the triggering branch as previously. 