### PR TITLE
Much faster updating of existing large vocabulary

### DIFF
--- a/annif/corpus/subject.py
+++ b/annif/corpus/subject.py
@@ -67,7 +67,7 @@ class SubjectIndex:
         self._append(subject_id, uri, label, notation)
 
     def contains_uri(self, uri):
-        return uri in self._uris
+        return uri in self._uri_idx
 
     def by_uri(self, uri, warnings=True):
         """return the subject index of a subject by its URI, or None if not found.


### PR DESCRIPTION
Fixes #516 

When updating an existing vocabulary, every concept in the new vocabulary is checked to see if it exists in the old one. This check was implemented as a list membership check. But this O(n) check is hugely inefficient when the list is large, which is the case for a large vocabulary such as GND.

This one line PR changes the `contains_uri` to instead check for a key in a dict (which already existed within the SubjectIndex class), which is an O(1) operation and thus quick to do regardless of the size of the vocabulary.

Quick benchmark loading the GND vocabulary from a Turtle file:

- first load: 15 minutes
- update: 14 minutes

(the difference is probably not significant, it could have been due to swapping or other activity going on in the background)