### PR TITLE
Declare dateutil dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,8 @@ setup(
         'gunicorn',
         'numpy==1.19.*',
         'optuna==2.8.0',
-        'stwfsapy==0.2.*'
+        'stwfsapy==0.2.*',
+        'python-dateutil',
     ],
     tests_require=['py', 'pytest', 'requests'],
     extras_require={


### PR DESCRIPTION
The http backend uses dateutil (since PR #432). This library was previously pulled in indirectly via alembic that optuna depends on. But the latest version of alembic makes this dependency optional, so it's no longer installed alongside optuna - and now installs are broken and CI tests are failing.

In any case, it's good practice to declare explicit dependencies to all the modules used in the codebase.