### PR TITLE
Update Docker baseimage to Debian Bullseye

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-slim-buster AS builder
+FROM python:3.8-slim-bullseye AS builder
 
 LABEL maintainer="Juho Inkinen <juho.inkinen@helsinki.fi>"
 
@@ -10,7 +10,7 @@ RUN apt-get update \
 		fasttext==0.9.2
 
 
-FROM python:3.8-slim-buster
+FROM python:3.8-slim-bullseye
 
 COPY --from=builder /usr/local/lib/python3.8 /usr/local/lib/python3.8
 


### PR DESCRIPTION
Updates the baseimage of Annif's Docker image to a newer Debian release.

The new Bullseye release has these Voikko packges:
```
libvoikko1/now 4.3-1+b1
voikko-fi/now 2.4-1
```
While the old Buster release has:
```
libvoikko1/now 4.2-1
voikko-fi/now 2.2-1.1
```

The update of the Voikko packages resolves the bad lemmatization results incorrectly producing "Määri" lemma, and this PR fixes #492.