### PR TITLE
Add deprecation warning to Maui & vw_multi train commands

### DIFF
--- a/annif/backend/maui.py
+++ b/annif/backend/maui.py
@@ -155,6 +155,8 @@ class MauiBackend(backend.AnnifBackend):
             time.sleep(1)
 
     def _train(self, corpus, params, jobs=0):
+        self.warning('Deprecation: This backend will no longer be available in'
+                     ' version 0.56')
         if corpus == 'cached':
             raise NotSupportedException(
                 'Training maui project from cached data not supported.')

--- a/annif/backend/vw_multi.py
+++ b/annif/backend/vw_multi.py
@@ -228,6 +228,8 @@ class VWMultiBackend(mixins.ChunkingBackend, backend.AnnifLearningBackend):
                                method=self._write_train_file)
 
     def _train(self, corpus, params, jobs=0):
+        self.warning('Deprecation: This backend will no longer be available in'
+                     ' version 0.56')
         if corpus != 'cached':
             self._create_train_file(corpus)
         else:


### PR DESCRIPTION
Maui and vw_multi backends will be removed in release 0.56. This PR makes Annif show a deprecation warning when training these backends.