### PR TITLE
Adjust flask and click versions to avoid dependency mismatches

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,9 +22,9 @@ setup(
     install_requires=[
         'connexion[swagger-ui]',
         'swagger_ui_bundle',
-        'flask',
+        'flask>=1.0.4,<2',
         'flask-cors',
-        'click==8.0.*',
+        'click==7.1.*',
         'click-log',
         'joblib==1.0.1',
         'nltk',


### PR DESCRIPTION
This PR downgrades Click back to version 7.x and specifies that we don't want to use Flask 2, since it isn't compatible with the current version of Connexion that we're using (2.9.0). Hopefully this will fix the problem of installing Annif via `pipenv`

ping @mo-fu does this work for you?

Fixes #533 (hopefully)