### PR TITLE
Optimize startup time using lazy imports

### DIFF
--- a/annif/analyzer/analyzer.py
+++ b/annif/analyzer/analyzer.py
@@ -3,7 +3,6 @@
 import abc
 import functools
 import unicodedata
-import nltk.tokenize
 
 _KEY_TOKEN_MIN_LENGTH = 'token_min_length'
 
@@ -22,6 +21,7 @@ class Analyzer(metaclass=abc.ABCMeta):
 
     def tokenize_sentences(self, text):
         """Tokenize a piece of text (e.g. a document) into sentences."""
+        import nltk.tokenize
         return nltk.tokenize.sent_tokenize(text)
 
     @functools.lru_cache(maxsize=50000)
@@ -37,6 +37,7 @@ class Analyzer(metaclass=abc.ABCMeta):
 
     def tokenize_words(self, text):
         """Tokenize a piece of text (e.g. a sentence) into words."""
+        import nltk.tokenize
         return [self.normalize_word(word)
                 for word in nltk.tokenize.word_tokenize(text)
                 if self.is_valid_token(word)]

--- a/annif/analyzer/snowball.py
+++ b/annif/analyzer/snowball.py
@@ -1,7 +1,6 @@
 """Snowball analyzer for Annif, based on nltk Snowball stemmer."""
 
 import functools
-import nltk.stem.snowball
 from . import analyzer
 
 
@@ -10,6 +9,7 @@ class SnowballAnalyzer(analyzer.Analyzer):
 
     def __init__(self, param, **kwargs):
         self.param = param
+        import nltk.stem.snowball
         self.stemmer = nltk.stem.snowball.SnowballStemmer(param)
         super().__init__(**kwargs)
 

--- a/annif/backend/__init__.py
+++ b/annif/backend/__init__.py
@@ -1,61 +1,99 @@
 """Registry of backend types for Annif"""
 
-from . import dummy
-from . import ensemble
-from . import http
-from . import tfidf
-from . import pav
-from . import stwfsa
-from . import mllm
-from . import svc
-import annif
+
+# define functions for lazily importing each backend (alphabetical order)
+def _dummy():
+    from . import dummy
+    return dummy.DummyBackend
 
 
-_backend_types = {}
+def _ensemble():
+    from . import ensemble
+    return ensemble.EnsembleBackend
 
 
-def register_backend(backend):
-    _backend_types[backend.name] = backend
+def _fasttext():
+    try:
+        from . import fasttext
+        return fasttext.FastTextBackend
+    except ImportError:
+        raise ValueError("fastText not available, cannot use fasttext backend")
+
+
+def _http():
+    from . import http
+    return http.HTTPBackend
+
+
+def _mllm():
+    from . import mllm
+    return mllm.MLLMBackend
+
+
+def _nn_ensemble():
+    try:
+        from . import nn_ensemble
+        return nn_ensemble.NNEnsembleBackend
+    except ImportError:
+        raise ValueError("Keras and TensorFlow not available, cannot use " +
+                         "nn_ensemble backend")
+
+
+def _omikuji():
+    try:
+        from . import omikuji
+        return omikuji.OmikujiBackend
+    except ImportError:
+        raise ValueError("Omikuji not available, cannot use omikuji backend")
+
+
+def _pav():
+    from . import pav
+    return pav.PAVBackend
+
+
+def _stwfsa():
+    from . import stwfsa
+    return stwfsa.StwfsaBackend
+
+
+def _svc():
+    from . import svc
+    return svc.SVCBackend
+
+
+def _tfidf():
+    from . import tfidf
+    return tfidf.TFIDFBackend
+
+
+def _yake():
+    try:
+        from . import yake
+        return yake.YakeBackend
+    except ImportError:
+        raise ValueError("YAKE not available, cannot use yake backend")
+
+
+# registry of the above functions
+_backend_fns = {
+    'dummy': _dummy,
+    'ensemble': _ensemble,
+    'fasttext': _fasttext,
+    'http': _http,
+    'mllm': _mllm,
+    'nn_ensemble': _nn_ensemble,
+    'omikuji': _omikuji,
+    'pav': _pav,
+    'stwfsa': _stwfsa,
+    'svc': _svc,
+    'tfidf': _tfidf,
+    'yake': _yake
+}
 
 
 def get_backend(backend_id):
-    try:
-        return _backend_types[backend_id]
-    except KeyError:
+    if backend_id in _backend_fns:
+        return _backend_fns[backend_id]()
+    else:
         raise ValueError("No such backend type {}".format(backend_id))
-
-
-register_backend(dummy.DummyBackend)
-register_backend(ensemble.EnsembleBackend)
-register_backend(http.HTTPBackend)
-register_backend(tfidf.TFIDFBackend)
-register_backend(pav.PAVBackend)
-register_backend(stwfsa.StwfsaBackend)
-register_backend(mllm.MLLMBackend)
-register_backend(svc.SVCBackend)
-
-# Optional backends
-try:
-    from . import fasttext
-    register_backend(fasttext.FastTextBackend)
-except ImportError:
-    annif.logger.debug("fastText not available, not enabling fasttext backend")
-
-try:
-    from . import nn_ensemble
-    register_backend(nn_ensemble.NNEnsembleBackend)
-except ImportError:
-    annif.logger.debug("Keras and TensorFlow not available, not enabling " +
-                       "nn_ensemble backend")
-
-try:
-    from . import omikuji
-    register_backend(omikuji.OmikujiBackend)
-except ImportError:
-    annif.logger.debug("Omikuji not available, not enabling omikuji backend")
-
-try:
-    from . import yake
-    register_backend(yake.YakeBackend)
-except ImportError:
-    annif.logger.debug("YAKE not available, not enabling yake backend")

--- a/annif/cli.py
+++ b/annif/cli.py
@@ -12,12 +12,10 @@ from flask import current_app
 from flask.cli import FlaskGroup, ScriptInfo
 import annif
 import annif.corpus
-import annif.eval
 import annif.parallel
 import annif.project
 import annif.registry
 from annif.project import Access
-from annif.suggestion import SuggestionFilter, ListSuggestionResult
 from annif.exception import ConfigurationException, NotSupportedException
 
 logger = annif.logger
@@ -89,6 +87,8 @@ BATCH_MAX_LIMIT = 15
 
 
 def generate_filter_batches(subjects):
+    import annif.eval
+    from annif.suggestion import SuggestionFilter
     filter_batches = collections.OrderedDict()
     for limit in range(1, BATCH_MAX_LIMIT + 1):
         for threshold in [i * 0.05 for i in range(20)]:
@@ -246,6 +246,7 @@ def run_suggest(project_id, limit, threshold, backend_param):
     """
     Suggest subjects for a single document from standard input.
     """
+    from annif.suggestion import SuggestionFilter
     project = get_project(project_id)
     text = sys.stdin.read()
     backend_params = parse_backend_params(backend_param, project)
@@ -279,6 +280,7 @@ def run_index(project_id, directory, suffix, force,
     Index a directory with documents, suggesting subjects for each document.
     Write the results in TSV files with the given suffix.
     """
+    from annif.suggestion import SuggestionFilter
     project = get_project(project_id)
     backend_params = parse_backend_params(backend_param, project)
     hit_filter = SuggestionFilter(project.subjects, limit, threshold)
@@ -347,6 +349,7 @@ def run_eval(
     project = get_project(project_id)
     backend_params = parse_backend_params(backend_param, project)
 
+    import annif.eval
     eval_batch = annif.eval.EvaluationBatch(project.subjects)
 
     if results_file:
@@ -393,6 +396,7 @@ def run_optimize(project_id, paths, docs_limit, backend_param):
     values and report the precision, recall and F-measure of each combination
     of settings.
     """
+    from annif.suggestion import ListSuggestionResult
     project = get_project(project_id)
     backend_params = parse_backend_params(backend_param, project)
 

--- a/annif/corpus/skos.py
+++ b/annif/corpus/skos.py
@@ -2,7 +2,6 @@
 
 import os.path
 import shutil
-import joblib
 import rdflib
 import rdflib.util
 from rdflib.namespace import SKOS, RDF, OWL, RDFS
@@ -26,6 +25,7 @@ def serialize_subjects_to_skos(subjects, language, path):
                    rdflib.Literal(subject.notation)))
     graph.serialize(destination=path, format='turtle')
     # also dump the graph in joblib format which is faster to load
+    import joblib
     annif.util.atomic_save(graph,
                            *os.path.split(path.replace('.ttl', '.dump.gz')),
                            method=joblib.dump)
@@ -38,6 +38,7 @@ class SubjectFileSKOS(SubjectCorpus):
         self.path = path
         self.language = language
         if path.endswith('.dump.gz'):
+            import joblib
             self.graph = joblib.load(path)
         else:
             self.graph = rdflib.Graph()
@@ -92,6 +93,7 @@ class SubjectFileSKOS(SubjectCorpus):
             # need to serialize into Turtle
             self.graph.serialize(destination=path, format='turtle')
         # also dump the graph in joblib format which is faster to load
+        import joblib
         annif.util.atomic_save(self.graph,
                                *os.path.split(
                                    path.replace('.ttl', '.dump.gz')),

--- a/annif/corpus/subject.py
+++ b/annif/corpus/subject.py
@@ -1,7 +1,6 @@
 """Classes for supporting subject corpora expressed as directories or files"""
 
 import annif.util
-import numpy as np
 from annif import logger
 from .types import Subject
 from .skos import serialize_subjects_to_skos
@@ -181,6 +180,7 @@ class SubjectSet:
            unknown URIs."""
 
         if destination is None:
+            import numpy as np
             destination = np.zeros(len(subject_index), dtype=bool)
 
         if self.has_uris():

--- a/annif/project.py
+++ b/annif/project.py
@@ -7,7 +7,6 @@ import annif
 import annif.transform
 import annif.analyzer
 import annif.corpus
-import annif.suggestion
 import annif.backend
 import annif.vocab
 from annif.datadir import DatadirMixin

--- a/annif/rest.py
+++ b/annif/rest.py
@@ -4,7 +4,6 @@ methods defined in the Swagger specification."""
 import connexion
 import annif.registry
 from annif.corpus import Document, DocumentList
-from annif.suggestion import SuggestionFilter
 from annif.exception import AnnifException
 from annif.project import Access
 
@@ -58,6 +57,7 @@ def suggest(project_id, text, limit, threshold):
     except ValueError:
         return project_not_found_error(project_id)
 
+    from annif.suggestion import SuggestionFilter
     try:
         hit_filter = SuggestionFilter(project.subjects, limit, threshold)
         result = project.suggest(text)

--- a/annif/util.py
+++ b/annif/util.py
@@ -4,9 +4,7 @@ import glob
 import os
 import os.path
 import tempfile
-import numpy as np
 from annif import logger
-from annif.suggestion import VectorSuggestionResult
 
 
 def atomic_save(obj, dirname, filename, method=None):
@@ -44,7 +42,9 @@ def merge_hits(weighted_hits, subject_index):
 
     weights = [whit.weight for whit in weighted_hits]
     scores = [whit.hits.as_vector(subject_index) for whit in weighted_hits]
+    import numpy as np
     result = np.average(scores, axis=0, weights=weights)
+    from annif.suggestion import VectorSuggestionResult
     return VectorSuggestionResult(result)
 
 


### PR DESCRIPTION
Fixes #514 

The goal of this PR is to reduce CLI startup time by avoiding useless work, especially imports that are not necessary for the requested operation.

It makes the following changes to the import statements within the Annif codebase:

- complete rewrite of `annif/backend/__init__.py`; the end result is that backends (and the libraries they require, e.g. fasttext, omikuji and tensorflow) are only imported when they are actually used
- avoid importing NLTK, sklearn, joblib and NumPy unless actually required, by moving import statements inside functions and methods

I tried to craft the changes to have minimal impact on the code so I only chose to make imports local in cases where there were very few uses within the same module. For example `annif.suggestion` uses NumPy a lot, so I didn't try to use local imports within that module, but instead avoided importing the whole `annif.suggestion` module in other parts of the codebase.

Startup time for simple commands such as `annif --help` and `annif --version` has been reduced by more than two thirds.

Before:

```
$ time annif --version
0.56.0.dev0

real	0m4,052s
user	0m4,001s
sys	0m0,568s
```

After:

```
$ time annif --version
0.56.0.dev0

real	0m1,302s
user	0m1,250s
sys	0m0,050s
```

As explained in #514, I also used [tuna](https://github.com/nschloe/tuna) to visualize where the remaining import time is spent after this PR:

![image](https://user-images.githubusercontent.com/1132830/146564388-f02a4544-740b-45ad-a1e0-afbf795eabf0.png)

The main culprits are now `connexion` (with most of the time spent initializing `openapi_spec_validator`!) and `flask`. Those are core libraries and I don't think we can avoid importing them even for the simplest CLI commands.