### PR TITLE
Allow selecting installed optional dependencies in Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,16 @@ FROM python:3.8-slim-bullseye AS builder
 
 LABEL maintainer="Juho Inkinen <juho.inkinen@helsinki.fi>"
 
-# Install fastText, which needs to be built, and therefore also some system packages:
-RUN apt-get update \
-	&& apt-get install -y --no-install-recommends \
-		build-essential \
-	&& pip install --no-cache-dir \
-		fasttext==0.9.2
+SHELL ["/bin/bash", "-c"]
+ARG optional_dependencies=dev,voikko,pycld3,fasttext,nn,omikuji,yake
+# Bulding fastText needs some system packages
+RUN if [[ $optional_dependencies =~ "fasttext" ]]; then \
+		apt-get update && \
+		apt-get install -y --no-install-recommends \
+			build-essential && \
+		pip install --no-cache-dir \
+			fasttext==0.9.2; \
+	fi
 
 
 FROM python:3.8-slim-bullseye

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,9 +26,11 @@ RUN apt-get update \
 WORKDIR /Annif
 RUN pip install --upgrade pip --no-cache-dir
 
-# Install all optional dependencies:
 COPY setup.py README.md LICENSE.txt projects.cfg.dist /Annif/
-RUN pip install .[dev,voikko,pycld3,fasttext,nn,omikuji,yake] --no-cache-dir
+# Install dependencies for optional features.
+ARG optional_dependencies=dev,voikko,pycld3,fasttext,nn,omikuji,yake
+RUN echo "Installing dependencies for optional features: $optional_dependencies" \
+	&& pip install .[$optional_dependencies] --no-cache-dir
 
 # Download nltk data (handle occasional timeout in with 3 tries):
 RUN for i in 1 2 3; do python -m nltk.downloader punkt -d /usr/share/nltk_data && break || sleep 1; done


### PR DESCRIPTION
Currently we provide a Dockerfile and an image in quay.io with dependencies for all the optional features.

If someone does not need all the features, but e.g. uses only Omikuji backend and would like build their own image (e.g. for smaller size), they could edit the Dockerfile dropping the unwanted (Python) dependencies from the pip install command. However, using `--build-arg` option of `docker build` provides a way to pass the user-defined list of dependencies to install that overrides the default list:
```
docker build -t annif-omikuji-voikko --build-arg optional_dependencies=omikuji,voikko .
```
A user wanting to have a Docker image to use with Xtransfomer could add `pecos` to the default list in build time.