### PR TITLE
Update dependencies v0.56

### DIFF
--- a/annif/backend/omikuji.py
+++ b/annif/backend/omikuji.py
@@ -5,7 +5,8 @@ import os.path
 import shutil
 import annif.util
 from annif.suggestion import SubjectSuggestion, ListSuggestionResult
-from annif.exception import NotInitializedException, NotSupportedException
+from annif.exception import NotInitializedException, NotSupportedException, \
+    OperationFailedException
 from . import backend
 from . import mixins
 
@@ -40,7 +41,12 @@ class OmikujiBackend(mixins.TfidfVectorizerMixin, backend.AnnifBackend):
             path = os.path.join(self.datadir, self.MODEL_FILE)
             self.debug('loading model from {}'.format(path))
             if os.path.exists(path):
-                self._model = omikuji.Model.load(path)
+                try:
+                    self._model = omikuji.Model.load(path)
+                except RuntimeError:
+                    raise OperationFailedException(
+                        "Omikuji models trained on Annif versions older than "
+                        "0.56 cannot be loaded. Please retrain your project.")
             else:
                 raise NotInitializedException(
                     'model {} not found'.format(path),

--- a/annif/backend/pav.py
+++ b/annif/backend/pav.py
@@ -95,9 +95,9 @@ class PAVBackend(ensemble.BaseEnsembleBackend):
         scores = coo_matrix((data, (row, col)),
                             shape=(ndocs, len(source_project.subjects)),
                             dtype=np.float32)
-        true = coo_matrix((np.ones(len(trow), dtype=np.bool), (trow, tcol)),
+        true = coo_matrix((np.ones(len(trow), dtype=bool), (trow, tcol)),
                           shape=(ndocs, len(source_project.subjects)),
-                          dtype=np.bool)
+                          dtype=bool)
         return csc_matrix(scores), csc_matrix(true)
 
     def _create_pav_model(self, source_project_id, min_docs, corpus):

--- a/annif/backend/tfidf.py
+++ b/annif/backend/tfidf.py
@@ -4,17 +4,12 @@ TF-IDF normalized bag-of-words vector space"""
 import os.path
 import tempfile
 import annif.util
+import gensim.similarities
+from gensim.matutils import Sparse2Corpus
 from annif.suggestion import VectorSuggestionResult
 from annif.exception import NotInitializedException, NotSupportedException
 from . import backend
 from . import mixins
-
-# Filter UserWarnings due to not-installed python-Levenshtein package
-import warnings
-with warnings.catch_warnings():
-    warnings.simplefilter('ignore')
-    import gensim.similarities
-    from gensim.matutils import Sparse2Corpus
 
 
 class SubjectBuffer:

--- a/annif/eval.py
+++ b/annif/eval.py
@@ -15,7 +15,7 @@ def filter_pred_top_k(preds, limit):
 
     masks = []
     for pred in preds:
-        mask = np.zeros_like(pred, dtype=np.bool)
+        mask = np.zeros_like(pred, dtype=bool)
         top_k = np.argsort(pred)[::-1][:limit]
         mask[top_k] = True
         masks.append(mask)

--- a/annif/lexical/mllm.py
+++ b/annif/lexical/mllm.py
@@ -82,7 +82,7 @@ def candidates_to_features(candidates, mdata):
 
     matrix = np.zeros((len(candidates), len(Feature)), dtype=np.float32)
     c_ids = [c.subject_id for c in candidates]
-    c_vec = np.zeros(mdata.related.shape[0], dtype=np.bool)
+    c_vec = np.zeros(mdata.related.shape[0], dtype=bool)
     c_vec[c_ids] = True
     broader = mdata.broader.multiply(c_vec).sum(axis=1)
     narrower = mdata.narrower.multiply(c_vec).sum(axis=1)

--- a/annif/lexical/util.py
+++ b/annif/lexical/util.py
@@ -3,7 +3,6 @@
 import collections
 from rdflib import URIRef
 from rdflib.namespace import SKOS
-import numpy as np
 from scipy.sparse import lil_matrix, csc_matrix
 
 
@@ -16,7 +15,7 @@ def get_subject_labels(graph, uri, properties, language):
 
 def make_relation_matrix(graph, vocab, property):
     n_subj = len(vocab.subjects)
-    matrix = lil_matrix((n_subj, n_subj), dtype=np.bool)
+    matrix = lil_matrix((n_subj, n_subj), dtype=bool)
 
     for subj, obj in graph.subject_objects(property):
         subj_id = vocab.subjects.by_uri(str(subj), warnings=False)
@@ -36,7 +35,7 @@ def make_collection_matrix(graph, vocab):
             c_members[str(coll)].append(member_id)
 
     c_matrix = lil_matrix((len(c_members), len(vocab.subjects)),
-                          dtype=np.bool)
+                          dtype=bool)
 
     # populate the matrix for collection -> subject_id
     for c_id, members in enumerate(c_members.values()):

--- a/annif/suggestion.py
+++ b/annif/suggestion.py
@@ -135,7 +135,7 @@ class VectorSuggestionResult(SuggestionResult):
         mask = (self._vector > threshold)
         deprecated_ids = subject_index.deprecated_ids()
         if limit is not None:
-            limit_mask = np.zeros_like(self._vector, dtype=np.bool)
+            limit_mask = np.zeros_like(self._vector, dtype=bool)
             deprecated_set = set(deprecated_ids)
             top_k_subjects = itertools.islice(
                                 (subj for subj in self.subject_order
@@ -143,7 +143,7 @@ class VectorSuggestionResult(SuggestionResult):
             limit_mask[list(top_k_subjects)] = True
             mask = mask & limit_mask
         else:
-            deprecated_mask = np.ones_like(self._vector, dtype=np.bool)
+            deprecated_mask = np.ones_like(self._vector, dtype=bool)
             deprecated_mask[deprecated_ids] = False
             mask = mask & deprecated_mask
         vsr = VectorSuggestionResult(self._vector * mask)

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
         'scipy==1.7.*',
         'rdflib>=4.2,<7.0',
         'gunicorn',
-        'numpy==1.19.*',
+        'numpy==1.21.*',
         'optuna==2.10.*',
         'stwfsapy==0.3.*',
         'python-dateutil',

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
         'joblib==1.1.0',
         'nltk',
         'gensim==4.1.*',
-        'scikit-learn==0.24.2',
+        'scikit-learn==1.0.2',
         'scipy==1.7.*',
         'rdflib>=4.2,<7.0',
         'gunicorn',

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
         'fasttext': ['fasttext==0.9.2'],
         'voikko': ['voikko'],
         'nn': ['tensorflow-cpu==2.5.0', 'lmdb==1.2.1'],
-        'omikuji': ['omikuji==0.3.*'],
+        'omikuji': ['omikuji==0.4.*'],
         'yake': ['yake==0.4.5'],
         'pycld3': ['pycld3'],
         'dev': [

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     zip_safe=False,
     python_requires='>=3.7',
     install_requires=[
-        'connexion[swagger-ui]',
+        'connexion2[swagger-ui]',
         'swagger_ui_bundle',
         'flask>=1.0.4,<2',
         'flask-cors',

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
         'click-log',
         'joblib==1.0.1',
         'nltk',
-        'gensim==4.0.*',
+        'gensim==4.1.*',
         'scikit-learn==0.24.2',
         'scipy==1.5.4',
         'rdflib>=4.2,<7.0',

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     install_requires=[
         'connexion2[swagger-ui]',
         'swagger_ui_bundle',
-        'flask>=1.0.4,<2',
+        'flask>=1.0.4,<3',
         'flask-cors',
         'click==7.1.*',
         'click-log',

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     extras_require={
         'fasttext': ['fasttext==0.9.2'],
         'voikko': ['voikko'],
-        'nn': ['tensorflow-cpu==2.6.2', 'lmdb==1.3.0'],
+        'nn': ['tensorflow-cpu==2.7.0', 'lmdb==1.3.0'],
         'omikuji': ['omikuji==0.4.*'],
         'yake': ['yake==0.4.5'],
         'pycld3': ['pycld3'],

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
         'swagger_ui_bundle',
         'flask>=1.0.4,<3',
         'flask-cors',
-        'click==7.1.*',
+        'click==8.0.*',
         'click-log',
         'joblib==1.1.0',
         'nltk',

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     extras_require={
         'fasttext': ['fasttext==0.9.2'],
         'voikko': ['voikko'],
-        'nn': ['tensorflow-cpu==2.5.0', 'lmdb==1.2.1'],
+        'nn': ['tensorflow-cpu==2.6.2', 'lmdb==1.3.0'],
         'omikuji': ['omikuji==0.4.*'],
         'yake': ['yake==0.4.5'],
         'pycld3': ['pycld3'],

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
         'flask-cors',
         'click==7.1.*',
         'click-log',
-        'joblib==1.0.1',
+        'joblib==1.1.0',
         'nltk',
         'gensim==4.1.*',
         'scikit-learn==0.24.2',

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
         'rdflib>=4.2,<7.0',
         'gunicorn',
         'numpy==1.19.*',
-        'optuna==2.8.0',
+        'optuna==2.10.*',
         'stwfsapy==0.3.*',
         'python-dateutil',
     ],

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
         'nltk',
         'gensim==4.1.*',
         'scikit-learn==0.24.2',
-        'scipy==1.5.4',
+        'scipy==1.7.*',
         'rdflib>=4.2,<7.0',
         'gunicorn',
         'numpy==1.19.*',


### PR DESCRIPTION
Dependency updates for Annif v0.56.

Updates to (edited):
- Omikuji 0.4.x
- TensorFlow 2.7.0 & lmbd 1.3.0
- Gensim 4.1.x
- joblib 1.1.0
- Optuna 2.10.x
- SciPy 1.7.x
- Scikit-learn 1.0.2
- NumPy 1.21.x
- Click 8.0.x
- Flask >=1.0.4,<3
- Connexion to use [connexion2 PyPI project](https://pypi.org/project/connexion2/)

Below is a table of Omikuji 0.3.4 and 0.4.1 models comparison. Training was performed on full Finnish Finna dataset (real and user times include preprocessing), and evaluation in parallel.

|                    |                     | v0.3   | v0.4   |
|--------------------|---------------------|--------|--------|
| train time         |                     |        |        |
|                    | real                | 190m   | 174m   |
|                    | user                | 2061m  | 1789m  |
|                    | reported by Omikuji | 7776s  | 6783s  |
| eval time          |                     |        |        |
|                    | real                | 2m59s  | 2m3s   |
|                    | user                | 53m55s | 14m33s |
|                    | sys                 | 3m18s  | 1m47s  |
|                    |                     |        |        |
| model size on disk |                     | 3.8G   | 3.4G   |
|                    |                     |        |        |
| eval results       |                     |        |        |
|                    | JYU-theses          | 0.4716 | 0.4759 |
|                    | kirjaesittelyt2021  | 0.4511 | 0.4496 |
|                    | kirjastonhoitaja    | 0.2759 | 0.2824 |
|                    | satakunnan-kansa    | 0.2808 | 0.2524 |
|                    | vapaakappaleet-orig | 0.4648 | 0.4613 |
|                    | average             | 0.3888 | 0.3843 |