### PR TITLE
Drop Python 3.6 support

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2
@@ -30,16 +30,16 @@ jobs:
         python -m nltk.downloader punkt
         # Selectively install the optional dependencies for some Python versions
         # Install the optional neural network dependencies (TensorFlow and LMDB)
-        # - except for one Python version (3.7) so that we can test also without them
-        if [[ ${{ matrix.python-version }} != '3.7' ]]; then pip install .[nn]; fi
+        # - except for one Python version (3.8) so that we can test also without them
+        if [[ ${{ matrix.python-version }} != '3.8' ]]; then pip install .[nn]; fi
         # Install the optional Omikuji and YAKE dependencies
-        # - except for one Python version (3.7) so that we can test also without them
-        if [[ ${{ matrix.python-version }} != '3.7' ]]; then pip install .[omikuji,yake]; fi
-        # Install the optional fastText dependencies for Python 3.7 only
-        if [[ ${{ matrix.python-version }} == '3.7' ]]; then pip install .[fasttext]; fi
-        # For Python 3.6
+        # - except for one Python version (3.8) so that we can test also without them
+        if [[ ${{ matrix.python-version }} != '3.8' ]]; then pip install .[omikuji,yake]; fi
+        # Install the optional fastText dependencies for Python 3.8 only
+        if [[ ${{ matrix.python-version }} == '3.8' ]]; then pip install .[fasttext]; fi
+        # For Python 3.7
         # - voikko and pycld3 dependencies
-        if [[ ${{ matrix.python-version }} == '3.6' ]]; then python -m pip install .[voikko,pycld3]; fi
+        if [[ ${{ matrix.python-version }} == '3.7' ]]; then python -m pip install .[voikko,pycld3]; fi
 
     - name: Lint with flake8
       run: |

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ already functional for many common tasks.
 
 # Basic install
 
-You will need Python 3.6+ to install Annif.
+You will need Python 3.7+ to install Annif.
 
 The recommended way is to install Annif from
 [PyPI](https://pypi.org/project/annif/) into a virtual environment.

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     zip_safe=False,
-    python_requires='>=3.6',
+    python_requires='>=3.7',
     install_requires=[
         'connexion[swagger-ui]',
         'swagger_ui_bundle',


### PR DESCRIPTION
The latest versions of many dependencies have dropped support for Python 3.6, so to be able to use them, also for Annif the support for Python 3.6 is dropped. See the discussion in #549.

With this PR that essentially means only removing running CI unit tests on Python 3.6 and updating the [requirement in `setup.py`](https://github.com/NatLibFi/Annif/blob/17108947010bb9cd7ea23811c92f0641c5588649/setup.py#L21).