### PR TITLE
Remove swagger-tester dependency 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,6 @@ setup(
             'pytest-watch',
             'pytest-flask',
             'pytest-flake8',
-            'swagger-tester',
             'bumpversion',
             'autopep8'
         ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,8 @@ import os.path
 import shutil
 import pytest
 import py.path
+import time
+import threading
 import unittest.mock
 import annif
 import annif.analyzer
@@ -32,6 +34,21 @@ def app_with_initialize():
     app = annif.create_app(
         config_name='annif.default_config.TestingInitializeConfig')
     return app
+
+
+@pytest.fixture(scope='module')
+def app_with_server(app):
+    # run a Flask/Connexion server in a background thread
+    def run_app():
+        # We need to set this env var to 'false' because otherwise Flask
+        # thinks, due to the CLI tests that could have run before, that
+        # it has been started via its  CLI and refuses to run.
+        os.environ['FLASK_RUN_FROM_CLI'] = 'false'
+        app.run(port=8000)
+
+    thread = threading.Thread(target=run_app, daemon=True)
+    thread.start()
+    time.sleep(1)
 
 
 @pytest.fixture(scope='module')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,8 +4,6 @@ import os.path
 import shutil
 import pytest
 import py.path
-import time
-import threading
 import unittest.mock
 import annif
 import annif.analyzer
@@ -36,19 +34,10 @@ def app_with_initialize():
     return app
 
 
-@pytest.fixture(scope='module')
-def app_with_server(app):
-    # run a Flask/Connexion server in a background thread
-    def run_app():
-        # We need to set this env var to 'false' because otherwise Flask
-        # thinks, due to the CLI tests that could have run before, that
-        # it has been started via its  CLI and refuses to run.
-        os.environ['FLASK_RUN_FROM_CLI'] = 'false'
-        app.run(port=8000)
-
-    thread = threading.Thread(target=run_app, daemon=True)
-    thread.start()
-    time.sleep(1)
+@pytest.fixture
+def app_client(app):
+    with app.test_client() as app_client:
+        yield app_client
 
 
 @pytest.fixture(scope='module')

--- a/tests/test_swagger.py
+++ b/tests/test_swagger.py
@@ -1,27 +1,38 @@
 """Unit tests for Annif REST API / Swagger spec"""
 
-from swagger_tester import swagger_test
-import time
-import threading
-import os
 import requests
 
 
-def test_swagger(app):
-
-    # run a Flask/Connexion server in a background thread
-    def run_app():
-        # We need to set this env var to 'false' because otherwise Flask
-        # thinks, due to the CLI tests that could have run before, that
-        # it has been started via its  CLI and refuses to run.
-        os.environ['FLASK_RUN_FROM_CLI'] = 'false'
-        app.run(port=8000)
-
-    thread = threading.Thread(target=run_app, daemon=True)
-    thread.start()
-    time.sleep(1)
-    swagger_test(app_url='http://localhost:8000/v1')
-
+def test_swagger_cors(app_with_server):
+    # fixture needed once to start server in background
     # test that the service supports CORS
     req = requests.get('http://localhost:8000/v1/projects')
     assert req.headers['access-control-allow-origin'] == '*'
+
+
+def test_swagger_list_projects():
+    req = requests.get('http://localhost:8000/v1/projects')
+    assert req.status_code == 200
+    assert 'projects' in req.json()
+
+
+def test_swagger_show_project():
+    req = requests.get('http://localhost:8000/v1/projects/dummy-fi')
+    assert req.status_code == 200
+    assert req.json()['project_id'] == 'dummy-fi'
+
+
+def test_swagger_suggest():
+    data = {'text': 'example text'}
+    req = requests.post('http://localhost:8000/v1/projects/dummy-fi/suggest',
+                        data=data)
+    assert req.status_code == 200
+    assert 'results' in req.json()
+
+
+def test_swagger_learn():
+    data = [{'text': 'the quick brown fox',
+            'subjects': [{'uri': 'http://example.org/fox', 'label': 'fox'}]}]
+    req = requests.post('http://localhost:8000/v1/projects/dummy-fi/learn',
+                        json=data)
+    assert req.status_code == 204

--- a/tests/test_swagger.py
+++ b/tests/test_swagger.py
@@ -1,71 +1,68 @@
 """Unit tests for Annif REST API / Swagger spec"""
 
-import requests
 
-
-def test_swagger_cors(app_with_server):
-    # fixture needed once to start server in background
+def test_swagger_cors(app_client):
     # test that the service supports CORS
-    req = requests.get('http://localhost:8000/v1/projects')
+    req = app_client.get('http://localhost:8000/v1/projects')
     assert req.headers['access-control-allow-origin'] == '*'
 
 
-def test_swagger_list_projects():
-    req = requests.get('http://localhost:8000/v1/projects')
+def test_swagger_list_projects(app_client):
+    req = app_client.get('http://localhost:8000/v1/projects')
     assert req.status_code == 200
-    assert 'projects' in req.json()
+    assert 'projects' in req.get_json()
 
 
-def test_swagger_show_project():
-    req = requests.get('http://localhost:8000/v1/projects/dummy-fi')
+def test_swagger_show_project(app_client):
+    req = app_client.get('http://localhost:8000/v1/projects/dummy-fi')
     assert req.status_code == 200
-    assert req.json()['project_id'] == 'dummy-fi'
+    assert req.get_json()['project_id'] == 'dummy-fi'
 
 
-def test_swagger_show_project_nonexistent():
-    req = requests.get('http://localhost:8000/v1/projects/nonexistent')
+def test_swagger_show_project_nonexistent(app_client):
+    req = app_client.get('http://localhost:8000/v1/projects/nonexistent')
     assert req.status_code == 404
 
 
-def test_swagger_suggest():
+def test_swagger_suggest(app_client):
     data = {'text': 'example text'}
-    req = requests.post('http://localhost:8000/v1/projects/dummy-fi/suggest',
-                        data=data)
+    req = app_client.post(
+        'http://localhost:8000/v1/projects/dummy-fi/suggest', data=data)
     assert req.status_code == 200
-    assert 'results' in req.json()
+    assert 'results' in req.get_json()
 
 
-def test_swagger_suggest_nonexistent():
+def test_swagger_suggest_nonexistent(app_client):
     data = {'text': 'example text'}
-    req = requests.post(
+    req = app_client.post(
         'http://localhost:8000/v1/projects/nonexistent/suggest', data=data)
     assert req.status_code == 404
 
 
-def test_swagger_suggest_novocab():
+def test_swagger_suggest_novocab(app_client):
     data = {'text': 'example text'}
-    req = requests.post('http://localhost:8000/v1/projects/novocab/suggest',
-                        data=data)
+    req = app_client.post(
+        'http://localhost:8000/v1/projects/novocab/suggest', data=data)
     assert req.status_code == 503
 
 
-def test_swagger_learn():
+def test_swagger_learn(app_client):
     data = [{'text': 'the quick brown fox',
             'subjects': [{'uri': 'http://example.org/fox', 'label': 'fox'}]}]
-    req = requests.post('http://localhost:8000/v1/projects/dummy-fi/learn',
-                        json=data)
+    req = app_client.post(
+        'http://localhost:8000/v1/projects/dummy-fi/learn', json=data)
     assert req.status_code == 204
 
 
-def test_swagger_learn_nonexistent():
+def test_swagger_learn_nonexistent(app_client):
     data = []
-    req = requests.post('http://localhost:8000/v1/projects/nonexistent/learn',
-                        json=data)
+    req = app_client.post(
+        'http://localhost:8000/v1/projects/nonexistent/learn', json=data)
     assert req.status_code == 404
 
 
-def test_swagger_learn_novocab():
+def test_swagger_learn_novocab(app_client):
     data = []
-    req = requests.post('http://localhost:8000/v1/projects/novocab/learn',
-                        json=data)
+    req = app_client.post(
+        'http://localhost:8000/v1/projects/novocab/learn', json=data)
     assert req.status_code == 503

--- a/tests/test_swagger.py
+++ b/tests/test_swagger.py
@@ -22,6 +22,11 @@ def test_swagger_show_project():
     assert req.json()['project_id'] == 'dummy-fi'
 
 
+def test_swagger_show_project_nonexistent():
+    req = requests.get('http://localhost:8000/v1/projects/nonexistent')
+    assert req.status_code == 404
+
+
 def test_swagger_suggest():
     data = {'text': 'example text'}
     req = requests.post('http://localhost:8000/v1/projects/dummy-fi/suggest',
@@ -30,9 +35,37 @@ def test_swagger_suggest():
     assert 'results' in req.json()
 
 
+def test_swagger_suggest_nonexistent():
+    data = {'text': 'example text'}
+    req = requests.post(
+        'http://localhost:8000/v1/projects/nonexistent/suggest', data=data)
+    assert req.status_code == 404
+
+
+def test_swagger_suggest_novocab():
+    data = {'text': 'example text'}
+    req = requests.post('http://localhost:8000/v1/projects/novocab/suggest',
+                        data=data)
+    assert req.status_code == 503
+
+
 def test_swagger_learn():
     data = [{'text': 'the quick brown fox',
             'subjects': [{'uri': 'http://example.org/fox', 'label': 'fox'}]}]
     req = requests.post('http://localhost:8000/v1/projects/dummy-fi/learn',
                         json=data)
     assert req.status_code == 204
+
+
+def test_swagger_learn_nonexistent():
+    data = []
+    req = requests.post('http://localhost:8000/v1/projects/nonexistent/learn',
+                        json=data)
+    assert req.status_code == 404
+
+
+def test_swagger_learn_novocab():
+    data = []
+    req = requests.post('http://localhost:8000/v1/projects/novocab/learn',
+                        json=data)
+    assert req.status_code == 503


### PR DESCRIPTION
The [swagger-tester](https://github.com/Trax-air/swagger-tester) seems unmaintained and depends on [connexion](https://github.com/zalando/connexion). Since Annif is switching to install connexion (#549) from its new PyPI project (named [connexion2](https://pypi.org/project/connexion2/)), the result is that connexion ends up to be installed twice (currently as `connexion v2.7.0` and `connexion2 v2.10.0`).

This PR removes the swagger-tester dev dependency from Annif and adds self-written tests for REST API methods, so only `connexion2` will be installed. 

Also avoids running Flask in a background thread (at least explicitly) by [using Flask's TestClient](https://flask.palletsprojects.com/en/2.0.x/testing/#the-testing-skeleton).

Now the tests cover basically only the status codes related to cases defined in [`swagger/annif.yaml`](https://github.com/NatLibFi/Annif/blob/master/annif/swagger/annif.yaml). Should there be more detailed tests as in the tests in [`test_rest.py`](https://github.com/NatLibFi/Annif/blob/master/tests/test_rest.py)? (Or are these tests already overlapping, like testing the same functionality...?)