### PR TITLE
Update Scrutinizer config

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -4,12 +4,10 @@ checks:
     duplicate_code: true
 build:
   environment:
-    python: 3.6.3
+    python: 3.8.12
   dependencies:
     override:
-     - pip install pipenv
-     - pipenv run pip install pip==19.*
-     - pipenv install --dev --skip-lock
+     - pip install .[dev]
   tests:
     override:
      - py-scrutinizer-run


### PR DESCRIPTION
I noticed Scrutinizer was still running on Python 3.6 and installing code with pipenv, although those are not anymore in use with Annif (since #550 and #405). So in Scrutinizer runs this changes 

- Python version to 3.8.12
- Use directly pip instead of pipenv

(Draft PR first to see if this works.)