### PR TITLE
Output eval metrics as a JSON file compatible with DVC

### DIFF
--- a/annif/cli.py
+++ b/annif/cli.py
@@ -19,6 +19,7 @@ import annif.registry
 from annif.project import Access
 from annif.suggestion import SuggestionFilter, ListSuggestionResult
 from annif.exception import ConfigurationException, NotSupportedException
+from annif.util import metric_code
 
 logger = annif.logger
 click_log.basic_config(logger)
@@ -389,7 +390,9 @@ def run_eval(
     for metric, score in metrics.items():
         click.echo(template.format(metric + ":", score))
     if metrics_file:
-        json.dump(metrics, metrics_file, indent=2)
+        json.dump(
+            {metric_code(metric): val for metric, val in metrics.items()},
+            metrics_file, indent=2)
 
 
 @cli.command('optimize')

--- a/annif/cli.py
+++ b/annif/cli.py
@@ -6,6 +6,7 @@ import collections
 import os.path
 import re
 import sys
+import json
 import click
 import click_log
 from flask import current_app
@@ -312,6 +313,16 @@ def run_index(project_id, directory, suffix, force,
               type=click.IntRange(0, None),
               help='Maximum number of documents to use')
 @click.option(
+    '--metrics-file',
+    '-M',
+    type=click.File(
+        'w',
+        encoding='utf-8',
+        errors='ignore',
+        lazy=True),
+    help="""Specify file in order to write evaluation metrics in JSON format.
+    File directory must exist, existing file will be overwritten.""")
+@click.option(
     '--results-file',
     '-r',
     type=click.File(
@@ -333,6 +344,7 @@ def run_eval(
         limit,
         threshold,
         docs_limit,
+        metrics_file,
         results_file,
         jobs,
         backend_param):
@@ -373,8 +385,12 @@ def run_eval(
                                 annif.corpus.SubjectSet((uris, labels)))
 
     template = "{0:<30}\t{1}"
-    for metric, score in eval_batch.results(results_file=results_file).items():
+    metrics = eval_batch.results(results_file=results_file)
+    for metric, score in metrics.items():
         click.echo(template.format(metric + ":", score))
+    if metrics_file:
+        print(metrics)
+        json.dump(metrics, metrics_file, indent=2)
 
 
 @cli.command('optimize')

--- a/annif/cli.py
+++ b/annif/cli.py
@@ -389,7 +389,6 @@ def run_eval(
     for metric, score in metrics.items():
         click.echo(template.format(metric + ":", score))
     if metrics_file:
-        print(metrics)
         json.dump(metrics, metrics_file, indent=2)
 
 

--- a/annif/eval.py
+++ b/annif/eval.py
@@ -25,19 +25,19 @@ def filter_pred_top_k(preds, limit):
 def true_positives(y_true, y_pred):
     """calculate the number of true positives using bitwise operations,
     emulating the way sklearn evaluation metric functions work"""
-    return (y_true & y_pred).sum()
+    return int((y_true & y_pred).sum())
 
 
 def false_positives(y_true, y_pred):
     """calculate the number of false positives using bitwise operations,
     emulating the way sklearn evaluation metric functions work"""
-    return (~y_true & y_pred).sum()
+    return int((~y_true & y_pred).sum())
 
 
 def false_negatives(y_true, y_pred):
     """calculate the number of false negatives using bitwise operations,
     emulating the way sklearn evaluation metric functions work"""
-    return (y_true & ~y_pred).sum()
+    return int((y_true & ~y_pred).sum())
 
 
 def precision_at_k_score(y_true, y_pred, limit):
@@ -221,7 +221,7 @@ class EvaluationBatch:
             hits.as_vector(self._subject_index, destination=y_pred[idx])
 
         results = self._evaluate_samples(y_true, y_pred, metrics)
-        results['Documents evaluated'] = y_true.shape[0]
+        results['Documents evaluated'] = int(y_true.shape[0])
 
         if results_file:
             self.output_result_per_subject(y_true, y_pred, results_file)

--- a/annif/util.py
+++ b/annif/util.py
@@ -95,3 +95,8 @@ def boolean(val):
 def identity(x):
     """Identity function: return the given argument unchanged"""
     return x
+
+
+def metric_code(metric):
+    """Convert a human-readable metric name into an alphanumeric string"""
+    return metric.translate(metric.maketrans(' ', '_', '()'))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -539,6 +539,8 @@ def test_eval_metricsfile(tmpdir):
     assert metrics['F1@5'] > 0.0
     assert 'NDCG' in metrics
     assert metrics['NDCG'] > 0.0
+    assert 'Precision_doc_avg' in metrics
+    assert metrics['Precision_doc_avg'] > 0.0
 
 
 def test_eval_resultsfile(tmpdir):

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -19,3 +19,17 @@ def test_boolean():
 
     for input, output in zip(inputs, outputs):
         assert annif.util.boolean(input) == output
+
+
+def test_metric_code():
+    inputs = [
+        "F1 score (doc avg)",
+        "NDCG@10",
+        "True positives"]
+    outputs = [
+        "F1_score_doc_avg",
+        "NDCG@10",
+        "True_positives"]
+
+    for input, output in zip(inputs, outputs):
+        assert annif.util.metric_code(input) == output


### PR DESCRIPTION
This PR adds an option `-M`/`--metrics-file` to the `annif eval` command, like this:

    annif eval my-project --metrics-file metrics.json /path/to/my-test-corpus/

The command writes evaluation metrics into the file in a format like this:

```json
{
  "Precision (doc avg)": 0.12429731417863835,
  "Recall (doc avg)": 0.10921187650575533,
  "F1 score (doc avg)": 0.11149022571570978,
  "Precision (subj avg)": 0.841174914733954,
  "Recall (subj avg)": 0.14326083068180426,
  "F1 score (subj avg)": 0.21448794969174276,
  "Precision (weighted subj avg)": 0.736846816147547,
  "Recall (weighted subj avg)": 0.09503311258278145,
  "F1 score (weighted subj avg)": 0.1529771375758776,
  "Precision (microavg)": 0.6067653276955602,
  "Recall (microavg)": 0.09503311258278145,
  "F1 score (microavg)": 0.16432865731462926,
  "F1@5": 0.11149022571570978,
  "NDCG": 0.1130682392238403,
  "NDCG@5": 0.11315954263925752,
  "NDCG@10": 0.1130682392238403,
  "Precision@1": 0.127420362273579,
  "Precision@3": 0.12429731417863835,
  "Precision@5": 0.12429731417863835,
  "LRAP": 0.11837633968849189,
  "True positives": 861,
  "False positives": 558,
  "False negatives": 8199,
  "Documents evaluated": 6404
}
```

Fixes #546

TODO: Still need to test whether DVC is happy with this format.