### PR TITLE
Support TOML as a configuration file format alongside CFG/INI.

### DIFF
--- a/annif/cli.py
+++ b/annif/cli.py
@@ -110,7 +110,7 @@ def set_project_config_file_path(ctx, param, value):
 def common_options(f):
     """Decorator to add common options for all CLI commands"""
     f = click.option(
-        '-p', '--projects', help='Set path to projects.cfg',
+        '-p', '--projects', help='Set path to project configuration file',
         type=click.Path(dir_okay=False, exists=True),
         callback=set_project_config_file_path, expose_value=False,
         is_eager=True)(f)

--- a/annif/config.py
+++ b/annif/config.py
@@ -45,7 +45,8 @@ class AnnifConfigTOML:
                     f"Reading configuration file {filename} in TOML format")
                 self._config = tomli.load(projf)
             except tomli.TOMLDecodeError as err:
-                raise ConfigurationException(err)
+                raise ConfigurationException(
+                    f"Parsing TOML file '{filename}' failed: {err}")
 
     @property
     def project_ids(self):

--- a/annif/config.py
+++ b/annif/config.py
@@ -55,7 +55,7 @@ class AnnifConfigTOML:
         return self._config[key]
 
 
-def parse_config(projects_file):
+def find_config(projects_file):
     if projects_file:
         if not os.path.exists(projects_file):
             logger.warning(
@@ -65,21 +65,31 @@ def parse_config(projects_file):
                 'file using the ANNIF_PROJECTS environment ' +
                 'variable or the command-line option "--projects".')
             return None
-    else:
-        if os.path.exists('projects.cfg'):
-            projects_file = 'projects.cfg'
-        elif os.path.exists('projects.toml'):
-            projects_file = 'projects.toml'
         else:
-            logger.warning(
-                'Could not find project configuration file ' +
-                '"projects.cfg" or "projects.toml". ' +
-                'You can set the path to the project configuration ' +
-                'file using the ANNIF_PROJECTS environment ' +
-                'variable or the command-line option "--projects".')
-            return None
+            return projects_file
 
-    if projects_file.endswith('.toml'):  # TOML format
-        return AnnifConfigTOML(projects_file)
+    if os.path.exists('projects.cfg'):
+        return 'projects.cfg'
+
+    if os.path.exists('projects.toml'):
+        return 'projects.toml'
+
+    logger.warning(
+        'Could not find project configuration file ' +
+        '"projects.cfg" or "projects.toml". ' +
+        'You can set the path to the project configuration ' +
+        'file using the ANNIF_PROJECTS environment ' +
+        'variable or the command-line option "--projects".')
+    return None
+
+
+def parse_config(projects_file):
+    filename = find_config(projects_file)
+
+    if not filename:  # not found
+        return None
+
+    if filename.endswith('.toml'):  # TOML format
+        return AnnifConfigTOML(filename)
     else:  # classic CFG/INI style format
-        return AnnifConfigCFG(projects_file)
+        return AnnifConfigCFG(filename)

--- a/annif/config.py
+++ b/annif/config.py
@@ -1,9 +1,11 @@
 """Configuration file handling"""
 
 
+import os.path
 import configparser
 import tomli
 import annif
+import annif.util
 from annif.exception import ConfigurationException
 
 
@@ -51,3 +53,33 @@ class AnnifConfigTOML:
 
     def __getitem__(self, key):
         return self._config[key]
+
+
+def parse_config(projects_file):
+    if projects_file:
+        if not os.path.exists(projects_file):
+            logger.warning(
+                f'Project configuration file "{projects_file}" is ' +
+                'missing. Please provide one. ' +
+                'You can set the path to the project configuration ' +
+                'file using the ANNIF_PROJECTS environment ' +
+                'variable or the command-line option "--projects".')
+            return None
+    else:
+        if os.path.exists('projects.cfg'):
+            projects_file = 'projects.cfg'
+        elif os.path.exists('projects.toml'):
+            projects_file = 'projects.toml'
+        else:
+            logger.warning(
+                'Could not find project configuration file ' +
+                '"projects.cfg" or "projects.toml". ' +
+                'You can set the path to the project configuration ' +
+                'file using the ANNIF_PROJECTS environment ' +
+                'variable or the command-line option "--projects".')
+            return None
+
+    if projects_file.endswith('.toml'):  # TOML format
+        return AnnifConfigTOML(projects_file)
+    else:  # classic CFG/INI style format
+        return AnnifConfigCFG(projects_file)

--- a/annif/config.py
+++ b/annif/config.py
@@ -1,0 +1,53 @@
+"""Configuration file handling"""
+
+
+import configparser
+import tomli
+import annif
+from annif.exception import ConfigurationException
+
+
+logger = annif.logger
+
+
+class AnnifConfigCFG:
+    """Class for reading configuration in CFG/INI format"""
+
+    def __init__(self, filename):
+        self._config = configparser.ConfigParser()
+        self._config.optionxform = annif.util.identity
+        with open(filename, encoding='utf-8-sig') as projf:
+            try:
+                logger.debug(
+                    f"Reading configuration file {filename} in CFG format")
+                self._config.read_file(projf)
+            except (configparser.DuplicateOptionError,
+                    configparser.DuplicateSectionError) as err:
+                raise ConfigurationException(err)
+
+    @property
+    def project_ids(self):
+        return self._config.sections()
+
+    def __getitem__(self, key):
+        return self._config[key]
+
+
+class AnnifConfigTOML:
+    """Class for reading configuration in TOML format"""
+
+    def __init__(self, filename):
+        with open(filename, "rb") as projf:
+            try:
+                logger.debug(
+                    f"Reading configuration file {filename} in TOML format")
+                self._config = tomli.load(projf)
+            except tomli.TOMLDecodeError as err:
+                raise ConfigurationException(err)
+
+    @property
+    def project_ids(self):
+        return self._config.keys()
+
+    def __getitem__(self, key):
+        return self._config[key]

--- a/annif/config.py
+++ b/annif/config.py
@@ -57,7 +57,9 @@ class AnnifConfigTOML:
 
 def find_config(projects_file):
     if projects_file:
-        if not os.path.exists(projects_file):
+        if os.path.exists(projects_file):
+            return projects_file
+        else:
             logger.warning(
                 f'Project configuration file "{projects_file}" is ' +
                 'missing. Please provide one. ' +
@@ -65,14 +67,10 @@ def find_config(projects_file):
                 'file using the ANNIF_PROJECTS environment ' +
                 'variable or the command-line option "--projects".')
             return None
-        else:
-            return projects_file
 
-    if os.path.exists('projects.cfg'):
-        return 'projects.cfg'
-
-    if os.path.exists('projects.toml'):
-        return 'projects.toml'
+    for filename in ('projects.cfg', 'projects.toml'):
+        if os.path.exists(filename):
+            return filename
 
     logger.warning(
         'Could not find project configuration file ' +

--- a/annif/config.py
+++ b/annif/config.py
@@ -56,19 +56,20 @@ class AnnifConfigTOML:
         return self._config[key]
 
 
-def find_config(projects_file):
-    if projects_file:
-        if os.path.exists(projects_file):
-            return projects_file
-        else:
-            logger.warning(
-                f'Project configuration file "{projects_file}" is ' +
-                'missing. Please provide one. ' +
-                'You can set the path to the project configuration ' +
-                'file using the ANNIF_PROJECTS environment ' +
-                'variable or the command-line option "--projects".')
-            return None
+def check_config(projects_file):
+    if os.path.exists(projects_file):
+        return projects_file
+    else:
+        logger.warning(
+            f'Project configuration file "{projects_file}" is ' +
+            'missing. Please provide one. ' +
+            'You can set the path to the project configuration ' +
+            'file using the ANNIF_PROJECTS environment ' +
+            'variable or the command-line option "--projects".')
+        return None
 
+
+def find_config():
     for filename in ('projects.cfg', 'projects.toml'):
         if os.path.exists(filename):
             return filename
@@ -83,7 +84,10 @@ def find_config(projects_file):
 
 
 def parse_config(projects_file):
-    filename = find_config(projects_file)
+    if projects_file:
+        filename = check_config(projects_file)
+    else:
+        filename = find_config()
 
     if not filename:  # not found
         return None

--- a/annif/default_config.py
+++ b/annif/default_config.py
@@ -11,7 +11,7 @@ import os
 class Config(object):
     DEBUG = False
     TESTING = False
-    PROJECTS_FILE = os.environ.get('ANNIF_PROJECTS', default='projects.cfg')
+    PROJECTS_FILE = os.environ.get('ANNIF_PROJECTS', default='')
     DATADIR = os.environ.get('ANNIF_DATADIR', default='data')
     INITIALIZE_PROJECTS = False
 
@@ -40,3 +40,7 @@ class TestingNoProjectsConfig(TestingConfig):
 
 class TestingInvalidProjectsConfig(TestingConfig):
     PROJECTS_FILE = 'tests/projects_invalid.cfg'
+
+
+class TestingTOMLConfig(TestingConfig):
+    PROJECTS_FILE = 'tests/projects.toml'

--- a/annif/registry.py
+++ b/annif/registry.py
@@ -1,51 +1,14 @@
 """Registry that keeps track of Annif projects"""
 
 import collections
-import configparser
 import os.path
 from flask import current_app
-import tomli
 import annif
 import annif.util
-from annif.exception import ConfigurationException
+from annif.config import AnnifConfigCFG, AnnifConfigTOML
 from annif.project import Access, AnnifProject
 
 logger = annif.logger
-
-
-class AnnifConfigCFG:
-    def __init__(self, filename):
-        self._config = configparser.ConfigParser()
-        self._config.optionxform = annif.util.identity
-        with open(filename, encoding='utf-8-sig') as projf:
-            try:
-                self._config.read_file(projf)
-            except (configparser.DuplicateOptionError,
-                    configparser.DuplicateSectionError) as err:
-                raise ConfigurationException(err)
-
-    @property
-    def project_ids(self):
-        return self._config.sections()
-
-    def __getitem__(self, key):
-        return self._config[key]
-
-
-class AnnifConfigTOML:
-    def __init__(self, filename):
-        with open(filename, "rb") as projf:
-            try:
-                self._config = tomli.load(projf)
-            except tomli.TOMLDecodeError as err:
-                raise ConfigurationException(err)
-
-    @property
-    def project_ids(self):
-        return self._config.keys()
-
-    def __getitem__(self, key):
-        return self._config[key]
 
 
 class AnnifRegistry:

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(
         'optuna==2.10.*',
         'stwfsapy==0.3.*',
         'python-dateutil',
+        'tomli==2.0.*'
     ],
     tests_require=['py', 'pytest', 'requests'],
     extras_require={

--- a/tests/projects.toml
+++ b/tests/projects.toml
@@ -1,6 +1,6 @@
 # Project configuration for Annif unit tests
 
-[dummy-fi]
+[dummy-fi-toml]
 name="Dummy Finnish"
 language="fi"
 backend="dummy"
@@ -9,7 +9,7 @@ key="value"
 vocab="dummy"
 access="public"
 
-[dummy-en]
+[dummy-en-toml]
 name="Dummy English"
 language="en"
 backend="dummy"

--- a/tests/projects.toml
+++ b/tests/projects.toml
@@ -1,0 +1,18 @@
+# Project configuration for Annif unit tests
+
+[dummy-fi]
+name="Dummy Finnish"
+language="fi"
+backend="dummy"
+analyzer="snowball(finnish)"
+key="value"
+vocab="dummy"
+access="public"
+
+[dummy-en]
+name="Dummy English"
+language="en"
+backend="dummy"
+analyzer="snowball(english)"
+vocab="dummy"
+access="hidden"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -40,8 +40,17 @@ def test_find_config_not_exists_default(monkeypatch, caplog):
     assert 'Could not find project configuration file' in caplog.text
 
 
-def test_parse_config_cfg():
+def test_parse_config_cfg_nondefault():
     cfg = annif.config.parse_config('tests/projects.cfg')
+    assert isinstance(cfg, annif.config.AnnifConfigCFG)
+    assert len(cfg.project_ids) == 16
+    assert cfg['dummy-fi'] is not None
+
+
+def test_parse_config_cfg_default(monkeypatch):
+    # temporarily chdir to the tests directory
+    monkeypatch.chdir('tests')
+    cfg = annif.config.parse_config('')
     assert isinstance(cfg, annif.config.AnnifConfigCFG)
     assert len(cfg.project_ids) == 16
     assert cfg['dummy-fi'] is not None

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,52 @@
+"""Unit tests for configuration handling in Annif"""
+
+import logging
+import annif.config
+
+
+def test_find_config_exists_cfg():
+    cfg = annif.config.find_config('tests/projects.cfg')
+    assert cfg == 'tests/projects.cfg'
+
+
+def test_find_config_exists_toml():
+    cfg = annif.config.find_config('tests/projects.toml')
+    assert cfg == 'tests/projects.toml'
+
+
+def test_find_config_not_exists(caplog):
+    with caplog.at_level(logging.WARNING):
+        cfg = annif.config.find_config('tests/notfound.cfg')
+    assert cfg is None
+    assert 'Project configuration file "tests/notfound.cfg" is missing' \
+        in caplog.text
+
+
+def test_find_config_exists_default(monkeypatch):
+    # temporarily chdir to the tests directory
+    monkeypatch.chdir('tests')
+    cfg = annif.config.find_config('')
+    assert cfg == 'projects.cfg'
+
+
+def test_find_config_not_exists_default(monkeypatch, caplog):
+    # temporarily chdir to the tests/corpora directory
+    monkeypatch.chdir('tests/corpora')
+    with caplog.at_level(logging.WARNING):
+        cfg = annif.config.find_config('')
+    assert cfg is None
+    assert 'Could not find project configuration file' in caplog.text
+
+
+def test_parse_config_cfg():
+    cfg = annif.config.parse_config('tests/projects.cfg')
+    assert isinstance(cfg, annif.config.AnnifConfigCFG)
+    assert len(cfg.project_ids) == 16
+    assert cfg['dummy-fi'] is not None
+
+
+def test_parse_config_toml():
+    cfg = annif.config.parse_config('tests/projects.toml')
+    assert isinstance(cfg, annif.config.AnnifConfigTOML)
+    assert len(cfg.project_ids) == 2
+    assert cfg['dummy-fi-toml'] is not None

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,7 +1,9 @@
 """Unit tests for configuration handling in Annif"""
 
 import logging
+import pytest
 import annif.config
+from annif.exception import ConfigurationException
 
 
 def test_find_config_exists_cfg():
@@ -50,3 +52,11 @@ def test_parse_config_toml():
     assert isinstance(cfg, annif.config.AnnifConfigTOML)
     assert len(cfg.project_ids) == 2
     assert cfg['dummy-fi-toml'] is not None
+
+
+def test_parse_config_toml_failed(tmpdir):
+    conffile = tmpdir.join('projects.toml')
+    conffile.write("[section]\nkey=unquoted\n")
+    with pytest.raises(ConfigurationException) as excinfo:
+        annif.config.parse_config(str(conffile))
+    assert 'Invalid value' in str(excinfo.value)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,19 +6,19 @@ import annif.config
 from annif.exception import ConfigurationException
 
 
-def test_find_config_exists_cfg():
-    cfg = annif.config.find_config('tests/projects.cfg')
+def test_check_config_exists_cfg():
+    cfg = annif.config.check_config('tests/projects.cfg')
     assert cfg == 'tests/projects.cfg'
 
 
-def test_find_config_exists_toml():
-    cfg = annif.config.find_config('tests/projects.toml')
+def test_check_config_exists_toml():
+    cfg = annif.config.check_config('tests/projects.toml')
     assert cfg == 'tests/projects.toml'
 
 
-def test_find_config_not_exists(caplog):
+def test_check_config_not_exists(caplog):
     with caplog.at_level(logging.WARNING):
-        cfg = annif.config.find_config('tests/notfound.cfg')
+        cfg = annif.config.check_config('tests/notfound.cfg')
     assert cfg is None
     assert 'Project configuration file "tests/notfound.cfg" is missing' \
         in caplog.text
@@ -27,7 +27,7 @@ def test_find_config_not_exists(caplog):
 def test_find_config_exists_default(monkeypatch):
     # temporarily chdir to the tests directory
     monkeypatch.chdir('tests')
-    cfg = annif.config.find_config('')
+    cfg = annif.config.find_config()
     assert cfg == 'projects.cfg'
 
 
@@ -35,7 +35,7 @@ def test_find_config_not_exists_default(monkeypatch, caplog):
     # temporarily chdir to the tests/corpora directory
     monkeypatch.chdir('tests/corpora')
     with caplog.at_level(logging.WARNING):
-        cfg = annif.config.find_config('')
+        cfg = annif.config.find_config()
     assert cfg is None
     assert 'Could not find project configuration file' in caplog.text
 

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -263,3 +263,12 @@ def test_project_file_not_found():
     with app.app_context():
         with pytest.raises(ValueError):
             annif.registry.get_project('dummy-en')
+
+
+def test_project_file_toml():
+    app = annif.create_app(
+        config_name='annif.default_config.TestingTOMLConfig')
+    with app.app_context():
+        assert len(annif.registry.get_projects()) == 2
+        assert annif.registry.get_project('dummy-fi').project_id == 'dummy-fi'
+        assert annif.registry.get_project('dummy-en').project_id == 'dummy-en'

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -270,5 +270,7 @@ def test_project_file_toml():
         config_name='annif.default_config.TestingTOMLConfig')
     with app.app_context():
         assert len(annif.registry.get_projects()) == 2
-        assert annif.registry.get_project('dummy-fi').project_id == 'dummy-fi'
-        assert annif.registry.get_project('dummy-en').project_id == 'dummy-en'
+        assert annif.registry.get_project('dummy-fi-toml').project_id \
+            == 'dummy-fi-toml'
+        assert annif.registry.get_project('dummy-en-toml').project_id \
+            == 'dummy-en-toml'


### PR DESCRIPTION
Using Annif efficiently with DVC requires that DVC understands the Annif configuration file; the current INI-style format is not supported by DVC (see #547).

This PR adds support for TOML as a configuration file format alongside the current one (which still works). Unless the path to the configuration file has been set using the `ANNIF_PROJECTS` environment variable or the `-p` command line option, the configuration will be read from `projects.cfg` if it exists, otherwise from `projects.toml`.

The main difference in the configuration syntax is that TOML requires string values to be quoted, e.g.

    language="fi"

instead of

    language=fi

The [tomli](https://github.com/hukkin/tomli) parser is used for parsing project configuration files with a `.toml` extension. It's a very minimal read-only, pure Python TOML parser; in the future, similar functionality (based on tomli) may be included in the Python standard library - see [PEP 680](https://www.python.org/dev/peps/pep-0680/).

Fixes #547

Opening as draft PR to get early feedback from CI tools. Probably some refactoring will be necessary, as well as additional unit tests.