### PR TITLE
Set a 10 minute timeout for GitHub Actions CI jobs

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -8,6 +8,7 @@ on: [push, pull_request]
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     strategy:
       matrix:
         python-version: [3.7, 3.8, 3.9]


### PR DESCRIPTION
Recently, many GitHub Actions CI jobs have been stalling. I don't know the root cause, but they are timing out after 6 hours.
This is clearly too long, since normally the jobs should take less than 5 minutes.

This PR sets a 10 minute timeout for CI jobs to avoid them being stuck for hours and hopefully making it easier to investigate the stalled runs.