### PR TITLE
Add missing import of annif.eval in MLLM backend

### DIFF
--- a/annif/backend/mllm.py
+++ b/annif/backend/mllm.py
@@ -3,6 +3,7 @@
 import os.path
 import joblib
 import numpy as np
+import annif.eval
 import annif.util
 from annif.exception import NotInitializedException
 from annif.exception import NotSupportedException


### PR DESCRIPTION
The MLLM backend was missing an import of annif.eval. This didn't always cause issues because usually it was imported by other modules such as annif.cli. It may have caused tests to occasionally hang on GitHub Actions CI.

This PR simply adds the missing import.