### PR TITLE
Lazy import of spaCy to avoid startup overhead

### DIFF
--- a/annif/analyzer/spacy.py
+++ b/annif/analyzer/spacy.py
@@ -1,6 +1,5 @@
 """spaCy analyzer for Annif which uses spaCy for lemmatization"""
 
-import spacy
 from . import analyzer
 from annif.exception import OperationFailedException
 import annif.util
@@ -12,6 +11,7 @@ class SpacyAnalyzer(analyzer.Analyzer):
     name = "spacy"
 
     def __init__(self, param, **kwargs):
+        import spacy
         self.param = param
         try:
             self.nlp = spacy.load(param, exclude=['ner', 'parser'])

--- a/tests/test_analyzer_spacy.py
+++ b/tests/test_analyzer_spacy.py
@@ -4,7 +4,7 @@ import pytest
 import annif.analyzer
 from annif.exception import OperationFailedException
 
-spacy = pytest.importorskip("annif.analyzer.spacy")
+spacy = pytest.importorskip("spacy")
 
 
 def test_spacy_model_not_found():


### PR DESCRIPTION
This PR moves the import of spaCy inside the SpacyAnalyzer class so that it will be imported only when actually used. It reduces the startup overhead of Annif by around 2 seconds when the optional spacy feature has been installed. 