### PR TITLE
Avoid coverage 6.3 as it causes some tests to hang

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ setup(
         'spacy': ['spacy==3.2.*'],
         'dev': [
             'codecov',
+            'coverage<=6.2',
             'pytest-cov',
             'pytest-watch',
             'pytest-flask',


### PR DESCRIPTION
This PR is a stopgap fix to avoid CI jobs getting stuck. This seems to be caused by changes in Coverage 6.3 - see https://github.com/nedbat/coveragepy/issues/1310

A better fix may be needed later but let's see what happens on the Coverage side first. Until then, this change should work around the problem.

Fixes #564
