### PR TITLE
Add --force option to loadvoc CLI command

### DIFF
--- a/annif/cli.py
+++ b/annif/cli.py
@@ -175,8 +175,11 @@ def run_clear_project(project_id):
 @cli.command('loadvoc')
 @click.argument('project_id')
 @click.argument('subjectfile', type=click.Path(exists=True, dir_okay=False))
+@click.option('--force', '-f', default=False, is_flag=True,
+              help='Replace existing vocabulary completely ' + \
+                   'instead of updating it')
 @common_options
-def run_loadvoc(project_id, subjectfile):
+def run_loadvoc(project_id, force, subjectfile):
     """
     Load a vocabulary for a project.
     """
@@ -187,7 +190,7 @@ def run_loadvoc(project_id, subjectfile):
     else:
         # probably a TSV file
         subjects = annif.corpus.SubjectFileTSV(subjectfile)
-    proj.vocab.load_vocabulary(subjects, proj.language)
+    proj.vocab.load_vocabulary(subjects, proj.language, force=force)
 
 
 @cli.command('train')

--- a/annif/cli.py
+++ b/annif/cli.py
@@ -176,7 +176,7 @@ def run_clear_project(project_id):
 @click.argument('project_id')
 @click.argument('subjectfile', type=click.Path(exists=True, dir_okay=False))
 @click.option('--force', '-f', default=False, is_flag=True,
-              help='Replace existing vocabulary completely ' + \
+              help='Replace existing vocabulary completely ' +
                    'instead of updating it')
 @common_options
 def run_loadvoc(project_id, force, subjectfile):

--- a/annif/vocab.py
+++ b/annif/vocab.py
@@ -87,11 +87,13 @@ class AnnifVocabulary(DatadirMixin):
 
         raise NotInitializedException(f'graph file {path} not found')
 
-    def load_vocabulary(self, subject_corpus, language):
-        """load subjects from a subject corpus and save them into a
-        SKOS/Turtle file for later use"""
+    def load_vocabulary(self, subject_corpus, language, force=False):
+        """Load subjects from a subject corpus and save them into a
+        SKOS/Turtle file for later use. If force=True, replace the
+        existing vocabulary completely."""
 
-        if os.path.exists(os.path.join(self.datadir, 'subjects')):
+        if not force and os.path.exists(os.path.join(self.datadir,
+                                                     'subjects')):
             logger.info('updating existing vocabulary')
             self._update_subject_index(subject_corpus)
         else:

--- a/tests/test_vocab.py
+++ b/tests/test_vocab.py
@@ -86,6 +86,23 @@ def test_update_subject_index_with_added_subjects(tmpdir):
                                  '42.42')
 
 
+def test_update_subject_index_force(tmpdir):
+    vocab = load_dummy_vocab(tmpdir)
+    subjfile_new = tmpdir.join('subjects_new.tsv')
+    subjfile_new.write("<http://example.org/dummy>\tdummy\n" +
+                       "<http://example.org/new-dummy>\tnew dummy\t42.42\n" +
+                       "<http://example.org/new-none>\tnew none\n")
+    subjects_new = annif.corpus.SubjectFileTSV(str(subjfile_new))
+
+    vocab.load_vocabulary(subjects_new, 'en', force=True)
+    assert len(vocab.subjects) == 3
+    assert vocab.subjects.by_uri('http://example.org/dummy') == 0
+    assert vocab.subjects[0] == ('http://example.org/dummy', 'dummy', None)
+    assert vocab.subjects.by_uri('http://example.org/new-dummy') == 1
+    assert vocab.subjects[1] == ('http://example.org/new-dummy', 'new dummy',
+                                 '42.42')
+
+
 def test_skos(tmpdir):
     vocab = load_dummy_vocab(tmpdir)
     assert tmpdir.join('vocabs/vocab-id/subjects.ttl').exists()


### PR DESCRIPTION
This PR adds a `--force` option to the `annif loadvoc` command which will force replacing the vocabulary completely even when a vocabulary (subject index) exists.

Fixes #526