### PR TITLE
Perform suggest operations in parallel using multiprocessing in nn_ensemble

### DIFF
--- a/annif/backend/nn_ensemble.py
+++ b/annif/backend/nn_ensemble.py
@@ -183,6 +183,11 @@ class NNEnsembleBackend(
         project_weights = dict(
             annif.util.parse_sources(self.params['sources']))
 
+        # initialize the source projects before forking, to save memory
+        for project_id in project_weights.keys():
+            project = self.project.registry.get_project(project_id)
+            project.initialize(parallel=True)
+
         psmap = annif.parallel.ProjectSuggestMap(
             self.project.registry,
             list(project_weights.keys()),


### PR DESCRIPTION
During training, the NN ensemble has to process the training documents through the source projects, collecting suggestions. Previously this was done sequentially and could take a lot of time, often dominating the time it takes to train a NN ensemble.

With this PR, the suggest operations are done in parallel on multiple CPUs, controlled by the `--jobs` parameter of the `annif train` command. The default is to use all CPUs.

Fixes #429

Opening a draft PR to get feedback from QA tools. More detailed testing and benchmarking still needs to be done.