### PR TITLE
Use fulltext corpus in MLLM tests which is much faster

### DIFF
--- a/annif/lexical/mllm.py
+++ b/annif/lexical/mllm.py
@@ -113,8 +113,8 @@ class MLLMCandidateGenerator(annif.parallel.BaseWorker):
 
     @classmethod
     def generate_candidates(cls, doc_subject_ids, text):
-        candidates = generate_candidates(text, **cls.args)
-        return doc_subject_ids, candidates
+        candidates = generate_candidates(text, **cls.args)  # pragma: no cover
+        return doc_subject_ids, candidates  # pragma: no cover
 
 
 class MLLMFeatureConverter(annif.parallel.BaseWorker):

--- a/annif/parallel.py
+++ b/annif/parallel.py
@@ -18,7 +18,7 @@ class BaseWorker:
 
     @classmethod
     def init(cls, args):
-        cls.args = args
+        cls.args = args  # pragma: no cover
 
 
 class ProjectSuggestMap:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -103,6 +103,18 @@ def document_corpus(subject_index):
 
 
 @pytest.fixture(scope='module')
+def fulltext_corpus(subject_index):
+    ftdir = os.path.join(
+        os.path.dirname(__file__),
+        'corpora',
+        'archaeology',
+        'fulltext')
+    ft_corpus = annif.corpus.DocumentDirectory(ftdir)
+    ft_corpus.set_subject_index(subject_index)
+    return ft_corpus
+
+
+@pytest.fixture(scope='module')
 def pretrained_vectors():
     return py.path.local(os.path.join(
         os.path.dirname(__file__),

--- a/tests/test_backend_mllm.py
+++ b/tests/test_backend_mllm.py
@@ -25,14 +25,14 @@ def test_mllm_default_params(project):
         assert param in actual_params and actual_params[param] == val
 
 
-def test_mllm_train(datadir, document_corpus, project):
+def test_mllm_train(datadir, fulltext_corpus, project):
     mllm_type = annif.backend.get_backend("mllm")
     mllm = mllm_type(
         backend_id='mllm',
         config_params={'limit': 10, 'language': 'fi'},
         project=project)
 
-    mllm.train(document_corpus)
+    mllm.train(fulltext_corpus)
     assert mllm._model is not None
     assert datadir.join('mllm-train.gz').exists()
     assert datadir.join('mllm-train.gz').size() > 0
@@ -106,14 +106,14 @@ def test_mllm_suggest_no_matches(project):
     assert len(results) == 0
 
 
-def test_mllm_hyperopt(project, document_corpus):
+def test_mllm_hyperopt(project, fulltext_corpus):
     mllm_type = annif.backend.get_backend('mllm')
     mllm = mllm_type(
         backend_id='mllm',
         config_params={'limit': 10, 'language': 'fi'},
         project=project)
 
-    optimizer = mllm.get_hp_optimizer(document_corpus, metric='NDCG')
+    optimizer = mllm.get_hp_optimizer(fulltext_corpus, metric='NDCG')
     optimizer.optimize(n_trials=3, n_jobs=1, results_file=None)
 
 


### PR DESCRIPTION
I noticed that the unit tests weren't making use of the small fulltext document corpus included in the test suite (tests/corpora/archaeology/fulltext/). In this PR, I've added a fixture to use it and switched the MLLM tests to use it instead of document_corpus. This speeds up the MLLM tests by a lot (24s -> 2s on my laptop).