### PR TITLE
Update Dockerfile v0.57

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,10 +27,10 @@ RUN apt-get update && \
 		apt-get install -y --no-install-recommends \
 			libvoikko1 \
 			voikko-fi; \
-	fi \
+	fi && \
 	# curl for Docker healthcheck and rsync for model transfers:
-	&& apt-get install -y --no-install-recommends curl rsync \
-	&& rm -rf /var/lib/apt/lists/* /usr/include/*
+	apt-get install -y --no-install-recommends curl rsync && \
+	rm -rf /var/lib/apt/lists/* /usr/include/*
 
 WORKDIR /Annif
 RUN pip install --upgrade pip setuptools --no-cache-dir
@@ -58,9 +58,9 @@ RUN pip install -e .
 WORKDIR /annif-projects
 
 # Switch user to non-root:
-RUN groupadd -g 998 annif_user \
-    && useradd -r -u 998 -g annif_user annif_user \
-    && chown -R annif_user:annif_user /annif-projects
+RUN groupadd -g 998 annif_user && \
+    useradd -r -u 998 -g annif_user annif_user && \
+    chown -R annif_user:annif_user /annif-projects
 USER annif_user
 
 CMD annif

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN if [[ $optional_dependencies =~ "fasttext" ]]; then \
 		apt-get update && \
 		apt-get install -y --no-install-recommends \
 			build-essential && \
+		pip install --upgrade pip setuptools --no-cache-dir && \
 		pip install --no-cache-dir \
 			fasttext==0.9.2; \
 	fi
@@ -29,7 +30,7 @@ RUN apt-get update \
 	&& rm -rf /var/lib/apt/lists/* /usr/include/*
 
 WORKDIR /Annif
-RUN pip install --upgrade pip --no-cache-dir
+RUN pip install --upgrade pip setuptools --no-cache-dir
 
 COPY setup.py README.md LICENSE.txt projects.cfg.dist /Annif/
 # Install dependencies for optional features.

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN if [[ $optional_dependencies =~ "fasttext" ]]; then \
 		apt-get update && \
 		apt-get install -y --no-install-recommends \
 			build-essential && \
-		pip install --upgrade pip setuptools --no-cache-dir && \
+		pip install --upgrade pip setuptools wheel --no-cache-dir && \
 		pip install --no-cache-dir \
 			fasttext==0.9.2; \
 	fi
@@ -33,7 +33,7 @@ RUN apt-get update && \
 	rm -rf /var/lib/apt/lists/* /usr/include/*
 
 WORKDIR /Annif
-RUN pip install --upgrade pip setuptools --no-cache-dir
+RUN pip install --upgrade pip wheel --no-cache-dir
 
 COPY setup.py README.md LICENSE.txt projects.cfg.dist /Annif/
 RUN echo "Installing dependencies for optional features: $optional_dependencies" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,11 +20,14 @@ FROM python:3.8-slim-bullseye
 SHELL ["/bin/bash", "-c"]
 COPY --from=builder /usr/local/lib/python3.8 /usr/local/lib/python3.8
 
+ARG optional_dependencies=dev,voikko,pycld3,fasttext,nn,omikuji,yake,spacy
 # Install system dependencies needed at runtime:
-RUN apt-get update \
-	&& apt-get install -y --no-install-recommends \
-		libvoikko1 \
-		voikko-fi \
+RUN apt-get update && \
+	if [[ $optional_dependencies =~ "voikko" ]]; then \
+		apt-get install -y --no-install-recommends \
+			libvoikko1 \
+			voikko-fi; \
+	fi \
 	# curl for Docker healthcheck and rsync for model transfers:
 	&& apt-get install -y --no-install-recommends curl rsync \
 	&& rm -rf /var/lib/apt/lists/* /usr/include/*
@@ -33,8 +36,6 @@ WORKDIR /Annif
 RUN pip install --upgrade pip setuptools --no-cache-dir
 
 COPY setup.py README.md LICENSE.txt projects.cfg.dist /Annif/
-# Install dependencies for optional features.
-ARG optional_dependencies=dev,voikko,pycld3,fasttext,nn,omikuji,yake,spacy
 RUN echo "Installing dependencies for optional features: $optional_dependencies" \
 	&& pip install .[$optional_dependencies] --no-cache-dir
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,8 +24,8 @@ RUN apt-get update \
 	&& apt-get install -y --no-install-recommends \
 		libvoikko1 \
 		voikko-fi \
-	# For Docker healthcheck:
-	&& apt-get install -y --no-install-recommends curl \
+	# curl for Docker healthcheck and rsync for model transfers:
+	&& apt-get install -y --no-install-recommends curl rsync \
 	&& rm -rf /var/lib/apt/lists/* /usr/include/*
 
 WORKDIR /Annif

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,8 +39,8 @@ COPY setup.py README.md LICENSE.txt projects.cfg.dist /Annif/
 RUN echo "Installing dependencies for optional features: $optional_dependencies" \
 	&& pip install .[$optional_dependencies] --no-cache-dir
 
-# Download nltk data (handle occasional timeout in with 3 tries):
-RUN for i in 1 2 3; do python -m nltk.downloader punkt -d /usr/share/nltk_data && break || sleep 1; done
+# Download nltk data
+RUN python -m nltk.downloader punkt -d /usr/share/nltk_data
 
 # Download spaCy models, if the optional feature was selected
 ARG spacy_models=en_core_web_sm


### PR DESCRIPTION
- Install rsync to allow transferring models to OpenShift environment
- Ensure pip & setuptools are updated when building
- Install voikko system packages only if Voikko is included in optional dependencies
- Remove retry loop for nltk data download (hopefully not needed anymore, as the network problems encountered in Drone should not exist in GH Actions)