### PR TITLE
Ensure setuptools and wheel are installed & up-to-date in CI unit tests

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -26,7 +26,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
+        python -m pip install --upgrade pip setuptools
         python -m pip install .[dev]
         python -m nltk.downloader punkt
         # Selectively install the optional dependencies for some Python versions

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -26,7 +26,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip setuptools
+        python -m pip install --upgrade pip setuptools wheel
         python -m pip install .[dev]
         python -m nltk.downloader punkt
         # Selectively install the optional dependencies for some Python versions


### PR DESCRIPTION
The `wheel` package has not been available for dependency installations for unit tests in GH Actions runs. There has been messages like
[`Using legacy 'setup.py install' for pyrsistent, since package 'wheel' is not installed.`](https://github.com/NatLibFi/Annif/runs/5214072336?check_suite_focus=true#step:5:276)

Installing `wheel` gets rid of the messages, possibly also making dependency installations faster.

This PR also makes sure `setuptools` is updated, making dependency installation environment the same as in building Dockerfile.

This issue came into attention via a [comment](https://github.com/NatLibFi/Annif/pull/572#discussion_r807677553) in #572.