### PR TITLE
Avoid running duplicated tests on PRs

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -3,8 +3,12 @@
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
 name: CI/CD
-
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+  workflow_dispatch:
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The PR checks list is a bit cluttered by 6 unit test runs: tests for both `push` and `pull_request` events on 3 Python versions, while testing on both events is (mostly) useless as they are (nearly) identical cases. 

On the `pull_request` event the tests are run on ["as the PR was merged"](https://stackoverflow.com/questions/57683943/github-actions-how-to-build-a-pull-request-as-if-it-were-merged?rq=1), so it is more meaningful case to test, and is needed also as the `push` event is not available from forks.

Running tests on all `push` events, however, is not so useful. On pushes the workflow is usually needed to be run only when the target is master branch (typically when a PR is merged or a release is made).

This changes the `push` event trigger to exclude other branches than master. Also adds `workflow_dispatch` trigger, which allows [manually running the workflow](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow#configuring-a-workflow-to-run-manually) for any branch, which may sometimes be wanted for branches without PR.

(Based on [this discussion](https://github.community/t/how-to-trigger-an-action-on-push-or-pull-request-but-not-both/16662), also to follow in future for possible improvements.)