### PR TITLE
Resolve some Warnings from unit tests

### DIFF
--- a/annif/__init__.py
+++ b/annif/__init__.py
@@ -11,7 +11,7 @@ logger = logging.getLogger('annif')
 import annif.backend  # noqa
 
 
-def create_app(script_info=None, config_name=None):
+def create_app(config_name=None):
     # 'cxapp' here is the Connexion application that has a normal Flask app
     # as a property (cxapp.app)
 

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,8 @@ setup(
             'pytest-flask',
             'pytest-flake8',
             'bumpversion',
-            'autopep8'
+            'autopep8',
+            'importlib_metadata'
         ]
     },
     entry_points={

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,7 +4,7 @@ import contextlib
 import random
 import re
 import os.path
-import pkg_resources
+import importlib_metadata
 import json
 from click.testing import CliRunner
 import annif.cli
@@ -806,5 +806,5 @@ def test_version_option():
         annif.cli.cli, ['--version'])
     assert not result.exception
     assert result.exit_code == 0
-    version = pkg_resources.require('annif')[0].version
+    version = importlib_metadata.version('annif')
     assert result.output.strip() == version.strip()


### PR DESCRIPTION
Trying to resolve Warnings emitted by unit tests. 

This PR resolves the `DeprecationWarnings`
- by Flask: `The 'script_info' argument is deprecated and will not be passed to the app factory function in Flask 2.1.`
- by pkg_resources: `Creating a LegacyVersion has been deprecated and will be removed in the next major release`

Note for the future: when the Annif support for Python 3.7 is eventually dropped, then the installation of the `importlib-metadata` package can be dropped too, as in Python 3.8+ the same functionality is provided by the [`importlib.metadata` of the standard library](https://docs.python.org/3.8/library/importlib.metadata.html?highlight=importlib%20metadata#module-importlib.metadata).

About the remaining Warnings:
- The three flake8 related warnings seem to have an [open issue](https://github.com/tholo/pytest-flake8/issues/83). 
- The `CustomMaskWarning` by TensorFlow could be resolved when TF is upgraded to v2.8 according to [StackOverflow](https://stackoverflow.com/a/70268806).
- The `DeprecationWarning` by SciPy is raised by usage of Gensim, and have an [open issue](https://github.com/RaRe-Technologies/gensim/issues/3014).