### PR TITLE
Improved Project links in PyPI page

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,11 @@ def read(fname):
 setup(
     name='annif',
     version='0.57.0-dev',
-    url='https://github.com/NatLibFi/Annif',
+    url='https://annif.org',
+    project_urls={
+        'Source': 'https://github.com/NatLibFi/Annif',
+        'Documentation': 'https://github.com/NatLibFi/Annif/wiki',
+    },
     author='Osma Suominen',
     author_email='osma.suominen@helsinki.fi',
     description='Automated subject indexing and classification tool',


### PR DESCRIPTION
This adds two links to the Project links section of the PyPI page and changes the Homepage link. The result should resemble e.g. the [requests PyPI page](https://pypi.org/project/requests/).

- Change Homepage link to annif.org
- Add Source link to GitHub repo
- Add Documentation link to GitHub Wiki