### PR TITLE
Update dependencies v0.57

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -45,14 +45,14 @@ jobs:
         # Install the optional fastText dependencies for Python 3.8 only
         if [[ ${{ matrix.python-version }} == '3.8' ]]; then pip install .[fasttext]; fi
         # Install the optional spaCy dependencies for Python 3.8 only
-        # and download the small English pretrained spaCy model needed by spacy analyzer
         if [[ ${{ matrix.python-version }} == '3.8' ]]; then
-        pip install \
-          .[spacy] https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.2.0/en_core_web_sm-3.2.0-py3-none-any.whl
+          pip install .[spacy]
+          # download the small English pretrained spaCy model needed by spacy analyzer
+          python -m spacy download en_core_web_sm
         fi
         # For Python 3.7
         # - voikko and pycld3 dependencies
-        if [[ ${{ matrix.python-version }} == '3.7' ]]; then pip install .[voikko,pycld3]; fi
+        if [[ ${{ matrix.python-version }} == '3.7' ]]; then python -m pip install .[voikko,pycld3]; fi
 
     - name: Lint with flake8
       run: |

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -48,7 +48,7 @@ jobs:
         if [[ ${{ matrix.python-version }} == '3.8' ]]; then
           pip install .[spacy]
           # download the small English pretrained spaCy model needed by spacy analyzer
-          python -m spacy download en_core_web_sm
+          python -m spacy download en_core_web_sm --upgrade-strategy only-if-needed
         fi
         # For Python 3.7
         # - voikko and pycld3 dependencies

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -45,10 +45,10 @@ jobs:
         # Install the optional fastText dependencies for Python 3.8 only
         if [[ ${{ matrix.python-version }} == '3.8' ]]; then pip install .[fasttext]; fi
         # Install the optional spaCy dependencies for Python 3.8 only
+        # and download the small English pretrained spaCy model needed by spacy analyzer
         if [[ ${{ matrix.python-version }} == '3.8' ]]; then
-        pip install .[spacy]
-        # download the small English pretrained spaCy model needed by spacy analyzer
-        pip install https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.2.0/en_core_web_sm-3.2.0-py3-none-any.whl
+        pip install \
+          .[spacy] https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.2.0/en_core_web_sm-3.2.0-py3-none-any.whl
         fi
         # For Python 3.7
         # - voikko and pycld3 dependencies

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -52,7 +52,7 @@ jobs:
         fi
         # For Python 3.7
         # - voikko and pycld3 dependencies
-        if [[ ${{ matrix.python-version }} == '3.7' ]]; then python -m pip install .[voikko,pycld3]; fi
+        if [[ ${{ matrix.python-version }} == '3.7' ]]; then pip install .[voikko,pycld3]; fi
 
     - name: Lint with flake8
       run: |

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -46,9 +46,9 @@ jobs:
         if [[ ${{ matrix.python-version }} == '3.8' ]]; then pip install .[fasttext]; fi
         # Install the optional spaCy dependencies for Python 3.8 only
         if [[ ${{ matrix.python-version }} == '3.8' ]]; then
-          pip install .[spacy]
-          # download the small English pretrained spaCy model needed by spacy analyzer
-          python -m spacy download en_core_web_sm
+        pip install .[spacy]
+        # download the small English pretrained spaCy model needed by spacy analyzer
+        pip install https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.2.0/en_core_web_sm-3.2.0-py3-none-any.whl
         fi
         # For Python 3.7
         # - voikko and pycld3 dependencies

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
     extras_require={
         'fasttext': ['fasttext==0.9.2'],
         'voikko': ['voikko'],
-        'nn': ['tensorflow-cpu==2.7.0', 'lmdb==1.3.0'],
+        'nn': ['tensorflow-cpu==2.7.1', 'lmdb==1.3.0'],
         'omikuji': ['omikuji==0.5.*'],
         'yake': ['yake==0.4.5'],
         'pycld3': ['pycld3'],

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
         'fasttext': ['fasttext==0.9.2'],
         'voikko': ['voikko'],
         'nn': ['tensorflow-cpu==2.7.0', 'lmdb==1.3.0'],
-        'omikuji': ['omikuji==0.4.*'],
+        'omikuji': ['omikuji==0.5.*'],
         'yake': ['yake==0.4.5'],
         'pycld3': ['pycld3'],
         'spacy': ['spacy==3.2.*'],

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     zip_safe=False,
     python_requires='>=3.7',
     install_requires=[
-        'connexion[swagger-ui]',
+        'connexion[swagger-ui]==2.12.*',
         'swagger_ui_bundle',
         'flask>=1.0.4,<3',
         'flask-cors',

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     zip_safe=False,
     python_requires='>=3.7',
     install_requires=[
-        'connexion2[swagger-ui]',
+        'connexion[swagger-ui]',
         'swagger_ui_bundle',
         'flask>=1.0.4,<3',
         'flask-cors',


### PR DESCRIPTION
Dependency updates for Annif v0.57.

Updates to:

- Omikuji 0.5.x to [enable symlinking Omikuji datafiles](https://github.com/tomtung/omikuji/issues/38)
- TensorFlow 2.7.1 to [fix many vulnerabilities](https://github.com/tensorflow/tensorflow/releases/tag/v2.7.1)
- Connexion to again use its [original/main PyPI project](https://pypi.org/project/connexion/) instead of the [Connexion2 project](https://pypi.org/project/connexion2/) (which now seems to be abandoned).

I don't think there are other dependencies that can be upgraded (to keep Python 3.6-3.9 support) or are worth upgrading now, or are there some?

Still needs to check that old Omikuji and NN ensemble models keep working, but I would suppose so.