### PR TITLE
Make importlib_metadata regular dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,8 @@ setup(
         'optuna==2.10.*',
         'stwfsapy==0.3.*',
         'python-dateutil',
-        'tomli==2.0.*'
+        'tomli==2.0.*',
+        'importlib_metadata'
     ],
     tests_require=['py', 'pytest', 'requests'],
     extras_require={
@@ -61,7 +62,6 @@ setup(
             'pytest-flake8',
             'bumpversion',
             'autopep8',
-            'importlib_metadata'
         ]
     },
     entry_points={


### PR DESCRIPTION
When some DeprecationWarnings of unit tests were resolved in #575, I [put `importlib_metadata` installation under dev dependencies](bfb7a1a6a99ab070eef56cad87151301c7b77cf3), but it should be a regular dependency.