### PR TITLE
Add tags trigger to GH Actions CI workflow

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
     - master
+    tags:
   pull_request:
   workflow_dispatch:
 env:


### PR DESCRIPTION
In PR #574 the general `push` event workflow trigger was replaced by a branch-specific push trigger (namely `push.branches.master`). However, this or any branch-specific push trigger does not fire on pushing tags (even to the selected branch); there has to be also the `tags` trigger, as explained in the [docs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushbranchestagsbranches-ignoretags-ignore).

I already tried to make the 0.57 release by pushing tags, which did not work out. So, I'll merge this fix, update the git tag, and push the tags again, and then the release workflow/job is supposed to be run...