### PR TITLE
Add wildcard tags workflow trigger

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -4,6 +4,7 @@ on:
     branches:
     - master
     tags:
+    - '*'
   pull_request:
   workflow_dispatch:
 env:


### PR DESCRIPTION
Apparently the tags trigger of #581 needs a list of allowed tags (not like PR trigger, why so...), so I try `*` wildcard. [It could work](https://github.community/t/how-to-run-github-actions-workflow-only-for-new-tags/16075/15).