### PR TITLE
Fix readthedocs documentation builds

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,6 +5,11 @@
 # Required
 version: 2
 
+build:
+  os: "ubuntu-20.04"
+  tools:
+    python: "3.9"
+
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: docs/conf.py

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-sphinx==1.8.*
+sphinx==4.5.*
 sphinx-rtd-theme
 sphinxcontrib-apidoc==0.3.0
 docutils<0.18


### PR DESCRIPTION
The [builds for readthedocs documentation](https://readthedocs.org/projects/annif/builds/16552879/) were not succeeding due to `ImportError: cannot import name 'contextfunction' from 'jinja2'`. This is fixed by upgrading sphinx to version 4.5.*. 

This PR also pins the build platform (Ubuntu and Python versions).