### PR TITLE
Update GitHub Actions

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -64,7 +64,7 @@ jobs:
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
       run: |
-        pytest --cov=./
+        pytest --cov=./ --cov-report xml
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@e3c560433a6cc60aec8812599b7844a7b4fa0d71  # v3.0.0
 

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -66,6 +66,7 @@ jobs:
       run: |
         pytest --cov=./ --cov-report xml
     - name: Upload coverage to Codecov
+      if: ${{ matrix.python-version == '3.8' }}
       uses: codecov/codecov-action@e3c560433a6cc60aec8812599b7844a7b4fa0d71  # v3.0.0
 
   publish-docker-latest:

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -82,7 +82,7 @@ jobs:
         password: ${{ secrets.YHTEENTOIMIVUUSPALVELUT_QUAY_IO_PASSWORD }}
     - name: Docker meta
       id: meta
-      uses: docker/metadata-action@f2a13332ac1ce8c0a71aeac48a150dbb1838ab67  # v3.7.0
+      uses: docker/metadata-action@69f6fc9d46f2f8bf0d5491e4aabe0bb8c6a4678a  # v4.0.1
       with:
         images: quay.io/natlibfi/annif
         tags: |
@@ -124,7 +124,7 @@ jobs:
         password: ${{ secrets.YHTEENTOIMIVUUSPALVELUT_QUAY_IO_PASSWORD }}
     - name: Docker meta
       id: meta
-      uses: docker/metadata-action@f2a13332ac1ce8c0a71aeac48a150dbb1838ab67  # v3.7.0
+      uses: docker/metadata-action@69f6fc9d46f2f8bf0d5491e4aabe0bb8c6a4678a  # v4.0.1
       with:
         images: quay.io/natlibfi/annif
         tags: |

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -66,7 +66,7 @@ jobs:
       run: |
         pytest --cov=./ --cov-report xml
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@e3c560433a6cc60aec8812599b7844a7b4fa0d71  # v3.0.0
+      uses: codecov/codecov-action@81cd2dc8148241f03f5839d295e000b8f761e378  # v3.1.0
 
   publish-docker-latest:
     name: publish latest Docker image

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -75,7 +75,7 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     steps:
     - name: Login to Quay.io
-      uses: docker/login-action@dd4fa0671be5250ee6f50aedf4cb05514abda2c7  # v1.14.1
+      uses: docker/login-action@49ed152c8eca782a232dede0303416e8f356c37b  # v2.0.0
       with:
         registry: quay.io
         username: ${{ secrets.YHTEENTOIMIVUUSPALVELUT_QUAY_IO_USERNAME }}
@@ -117,7 +117,7 @@ jobs:
         user: __token__
         password: ${{ secrets.PYPI_API_TOKEN }}
     - name: Login to Quay.io
-      uses: docker/login-action@dd4fa0671be5250ee6f50aedf4cb05514abda2c7  # v1.14.1
+      uses: docker/login-action@49ed152c8eca782a232dede0303416e8f356c37b  # v2.0.0
       with:
         registry: quay.io
         username: ${{ secrets.YHTEENTOIMIVUUSPALVELUT_QUAY_IO_USERNAME }}

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -66,7 +66,7 @@ jobs:
       run: |
         pytest --cov=./
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@e3c560433a6cc60aec8812599b7844a7b4fa0d71  # v3.0.0
 
   publish-docker-latest:
     name: publish latest Docker image

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -66,7 +66,6 @@ jobs:
       run: |
         pytest --cov=./ --cov-report xml
     - name: Upload coverage to Codecov
-      if: ${{ matrix.python-version == '3.8' }}
       uses: codecov/codecov-action@e3c560433a6cc60aec8812599b7844a7b4fa0d71  # v3.0.0
 
   publish-docker-latest:

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -112,7 +112,7 @@ jobs:
         python -m pip install wheel
         python setup.py sdist bdist_wheel
     - name: Publish distribution to PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
+      uses: pypa/gh-action-pypi-publish@717ba43cfbb0387f6ce311b169a825772f54d295  # v1.5.0
       with:
         user: __token__
         password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -88,7 +88,7 @@ jobs:
         tags: |
           latest
     - name: Build and push to Quay.io
-      uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a  # v2.10.0
+      uses: docker/build-push-action@ae551b19e49efd4e98792db7592c17c09b89db8d8  # v3.0.0
       with:
         push: true
         tags: ${{ steps.meta.outputs.tags }}
@@ -131,7 +131,7 @@ jobs:
           type=semver,pattern={{version}}
           type=semver,pattern={{major}}.{{minor}}
     - name: Build and push to Quay.io
-      uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a  # v2.10.0
+      uses: docker/build-push-action@ae551b19e49efd4e98792db7592c17c09b89db8d8  # v3.0.0
       with:
         push: true
         tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -82,7 +82,7 @@ jobs:
         password: ${{ secrets.YHTEENTOIMIVUUSPALVELUT_QUAY_IO_PASSWORD }}
     - name: Docker meta
       id: meta
-      uses: docker/metadata-action@e5622373a38e60fb6d795a4421e56882f2d7a681  # v3.6.2
+      uses: docker/metadata-action@f2a13332ac1ce8c0a71aeac48a150dbb1838ab67  # v3.7.0
       with:
         images: quay.io/natlibfi/annif
         tags: |
@@ -124,7 +124,7 @@ jobs:
         password: ${{ secrets.YHTEENTOIMIVUUSPALVELUT_QUAY_IO_PASSWORD }}
     - name: Docker meta
       id: meta
-      uses: docker/metadata-action@e5622373a38e60fb6d795a4421e56882f2d7a681  # v3.6.2
+      uses: docker/metadata-action@f2a13332ac1ce8c0a71aeac48a150dbb1838ab67  # v3.7.0
       with:
         images: quay.io/natlibfi/annif
         tags: |

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -27,7 +27,7 @@ jobs:
           libvoikko1 \
           voikko-fi
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
         cache: pip
@@ -102,7 +102,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.8
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: '3.8'
         cache: pip

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -20,7 +20,7 @@ jobs:
     name: test on Python ${{ matrix.python-version }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Install system packages
       run: |
         sudo apt-get install \
@@ -100,7 +100,7 @@ jobs:
     runs-on: ubuntu-20.04
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.8
       uses: actions/setup-python@v2
       with:

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -88,7 +88,7 @@ jobs:
         tags: |
           latest
     - name: Build and push to Quay.io
-      uses: docker/build-push-action@7f9d37fa544684fb73bfe4835ed7214c255ce02b  # v2.9.0
+      uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a  # v2.10.0
       with:
         push: true
         tags: ${{ steps.meta.outputs.tags }}
@@ -131,7 +131,7 @@ jobs:
           type=semver,pattern={{version}}
           type=semver,pattern={{major}}.{{minor}}
     - name: Build and push to Quay.io
-      uses: docker/build-push-action@7f9d37fa544684fb73bfe4835ed7214c255ce02b  # v2.9.0
+      uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a  # v2.10.0
       with:
         push: true
         tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
Upgrades GH Actions to latest versions, and pins the codecov and pypi-publish Actions commit hashes.

Upgrading codecov Action (from v1 to v3) necessitates generating the coverage report in xml format ([apparently this applies to both v2 and v3](https://github.com/codecov/codecov-action/issues/577)).

~Also makes the coverage report upload conditional: it is uploaded only by Python 3.8 test run. Until now, the report was uploaded three times (by Python 3.7, 3.8 and 3.9 runs). That may be the reason for weird coverage changes I have noticed (the coverage is different for different Python versions, and it is somewhat random which run finishes last, and I think the report by the last run overrides earlier ones).~

~Now I chose to upload the report by Python 3.8 run. This evens out the the running times (very slightly). This means the test coverage of NN ensemble, Omikuji and Yake backends is not tracked, while of fastText and spaCy code it is.~

Edit: Actually [codecov merges the reports that are uploaded by different runs](https://docs.codecov.com/docs/merging-reports), so it is desired to upload all of them as previously.
