### PR TITLE
Delete .coveragerc configuration file 

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,0 @@
-[run]
-omit = annif_env/*


### PR DESCRIPTION
This file seems to be unnecessary nowdays. Noticed while working with #587.