### PR TITLE
Add simplemma analyzer

### DIFF
--- a/annif/analyzer/__init__.py
+++ b/annif/analyzer/__init__.py
@@ -3,6 +3,7 @@
 import re
 from . import simple
 from . import snowball
+from . import simplemma
 import annif
 from annif.util import parse_args
 
@@ -30,6 +31,7 @@ def get_analyzer(analyzerspec):
 
 register_analyzer(simple.SimpleAnalyzer)
 register_analyzer(snowball.SnowballAnalyzer)
+register_analyzer(simplemma.SimplemmaAnalyzer)
 
 # Optional analyzers
 try:

--- a/annif/analyzer/simplemma.py
+++ b/annif/analyzer/simplemma.py
@@ -1,0 +1,16 @@
+"""Simplemma analyzer for Annif, based on simplemma lemmatizer."""
+
+import simplemma
+from . import analyzer
+
+
+class SimplemmaAnalyzer(analyzer.Analyzer):
+    name = "simplemma"
+
+    def __init__(self, param, **kwargs):
+        self.lang = param
+        self.langdata = simplemma.load_data(self.lang)
+        super().__init__(**kwargs)
+
+    def _normalize_word(self, word):
+        return simplemma.lemmatize(word, self.langdata)

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,8 @@ setup(
         'optuna==2.10.*',
         'stwfsapy==0.3.*',
         'python-dateutil',
-        'tomli==2.0.*'
+        'tomli==2.0.*',
+        'simplemma==0.6.*'
     ],
     tests_require=['py', 'pytest', 'requests'],
     extras_require={


### PR DESCRIPTION
Fixes #590

This PR adds a `simplemma` analyzer based on the Simplemma lemmatizer. Opening as a draft PR to get feedback from QA tools. The analyzer itself needs more testing, e.g. the quality of results and how it works with multiprocessing.