### PR TITLE
Add Python 3.10 support & update dependencies

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, 3.10]
     name: test on Python ${{ matrix.python-version }}
 
     steps:

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, 3.10]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
     name: test on Python ${{ matrix.python-version }}
 
     steps:

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -39,22 +39,22 @@ jobs:
         python -m nltk.downloader punkt
         # Selectively install the optional dependencies for some Python versions
         # Install the optional neural network dependencies (TensorFlow and LMDB)
-        # - except for one Python version (3.8) so that we can test also without them
-        if [[ ${{ matrix.python-version }} != '3.8' ]]; then pip install .[nn]; fi
+        # - except for one Python version (3.9) so that we can test also without them
+        if [[ ${{ matrix.python-version }} != '3.9' ]]; then pip install .[nn]; fi
         # Install the optional Omikuji and YAKE dependencies
-        # - except for one Python version (3.8) so that we can test also without them
-        if [[ ${{ matrix.python-version }} != '3.8' ]]; then pip install .[omikuji,yake]; fi
-        # Install the optional fastText dependencies for Python 3.8 only
-        if [[ ${{ matrix.python-version }} == '3.8' ]]; then pip install .[fasttext]; fi
-        # Install the optional spaCy dependencies for Python 3.8 only
-        if [[ ${{ matrix.python-version }} == '3.8' ]]; then
+        # - except for one Python version (3.9) so that we can test also without them
+        if [[ ${{ matrix.python-version }} != '3.9' ]]; then pip install .[omikuji,yake]; fi
+        # Install the optional fastText dependencies for Python 3.9 only
+        if [[ ${{ matrix.python-version }} == '3.9' ]]; then pip install .[fasttext]; fi
+        # Install the optional spaCy dependencies for Python 3.9 only
+        if [[ ${{ matrix.python-version }} == '3.9' ]]; then
           pip install .[spacy]
           # download the small English pretrained spaCy model needed by spacy analyzer
           python -m spacy download en_core_web_sm --upgrade-strategy only-if-needed
         fi
-        # For Python 3.7
+        # For Python 3.8
         # - voikko and pycld3 dependencies
-        if [[ ${{ matrix.python-version }} == '3.7' ]]; then python -m pip install .[voikko,pycld3]; fi
+        if [[ ${{ matrix.python-version }} == '3.8' ]]; then python -m pip install .[voikko,pycld3]; fi
 
     - name: Lint with flake8
       run: |
@@ -101,10 +101,10 @@ jobs:
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.8
+    - name: Set up Python 3.9
       uses: actions/setup-python@v2
       with:
-        python-version: '3.8'
+        python-version: '3.9'
         cache: pip
         cache-dependency-path: setup.py
     - name: Build distribution

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10"]
     name: test on Python ${{ matrix.python-version }}
 
     steps:

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -55,6 +55,8 @@ jobs:
         # For Python 3.8
         # - voikko and pycld3 dependencies
         if [[ ${{ matrix.python-version }} == '3.8' ]]; then python -m pip install .[voikko,pycld3]; fi
+        # Verify installed packages have compatible dependencies:
+        python -m pip check
 
     - name: Lint with flake8
       run: |

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ already functional for many common tasks.
 
 # Basic install
 
-You will need Python 3.7+ to install Annif.
+You will need Python 3.8+ to install Annif.
 
 The recommended way is to install Annif from
 [PyPI](https://pypi.org/project/annif/) into a virtual environment.

--- a/setup.py
+++ b/setup.py
@@ -61,8 +61,7 @@ setup(
             'pytest-flask',
             'pytest-flake8',
             'bumpversion',
-            'autopep8',
-            'importlib_metadata'
+            'autopep8'
         ]
     },
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
         'omikuji': ['omikuji==0.5.*'],
         'yake': ['yake==0.4.5'],
         'pycld3': ['pycld3'],
-        'spacy': ['spacy==3.2.*'],
+        'spacy': ['spacy==3.3.*'],
         'dev': [
             'codecov',
             'coverage<=6.2',

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
         'click-log',
         'joblib==1.1.0',
         'nltk',
-        'gensim==4.1.*',
+        'gensim==4.2.*',
         'scikit-learn==1.0.2',
         'scipy==1.7.*',
         'rdflib>=4.2,<7.0',

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     zip_safe=False,
-    python_requires='>=3.7',
+    python_requires='>=3.8',
     install_requires=[
         'connexion[swagger-ui]==2.12.*',
         'swagger_ui_bundle',

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
         'nltk',
         'gensim==4.2.*',
         'scikit-learn==1.0.2',
-        'scipy==1.7.*',
+        'scipy==1.8.*',
         'rdflib>=4.2,<7.0',
         'gunicorn',
         'numpy==1.22.*',

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
         'scipy==1.7.*',
         'rdflib>=4.2,<7.0',
         'gunicorn',
-        'numpy==1.21.*',
+        'numpy==1.22.*',
         'optuna==2.10.*',
         'stwfsapy==0.3.*',
         'python-dateutil',

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
         'joblib==1.1.0',
         'nltk',
         'gensim==4.2.*',
-        'scikit-learn==1.0.2',
+        'scikit-learn==1.1.1',
         'scipy==1.8.*',
         'rdflib>=4.2,<7.0',
         'gunicorn',

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
         'scipy==1.8.*',
         'rdflib>=4.2,<7.0',
         'gunicorn',
-        'numpy==1.22.*',
+        'numpy==1.23.*',
         'optuna==2.10.*',
         'stwfsapy==0.3.*',
         'python-dateutil',

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     zip_safe=False,
     python_requires='>=3.8',
     install_requires=[
-        'connexion[swagger-ui]==2.13.*',
+        'connexion[swagger-ui]==2.14.*',
         'swagger_ui_bundle',
         'flask>=1.0.4,<3',
         'flask-cors',

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     zip_safe=False,
     python_requires='>=3.8',
     install_requires=[
-        'connexion[swagger-ui]==2.12.*',
+        'connexion[swagger-ui]==2.13.*',
         'swagger_ui_bundle',
         'flask>=1.0.4,<3',
         'flask-cors',

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     extras_require={
         'fasttext': ['fasttext==0.9.2'],
         'voikko': ['voikko'],
-        'nn': ['tensorflow-cpu==2.7.1', 'lmdb==1.3.0'],
+        'nn': ['tensorflow-cpu==2.9.1', 'lmdb==1.3.0'],
         'omikuji': ['omikuji==0.5.*'],
         'yake': ['yake==0.4.5'],
         'pycld3': ['pycld3'],

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,7 +4,7 @@ import contextlib
 import random
 import re
 import os.path
-import importlib_metadata
+import importlib
 import json
 from click.testing import CliRunner
 import annif.cli
@@ -806,5 +806,5 @@ def test_version_option():
         annif.cli.cli, ['--version'])
     assert not result.exception
     assert result.exit_code == 0
-    version = importlib_metadata.version('annif')
+    version = importlib.metadata.version('annif')
     assert result.output.strip() == version.strip()


### PR DESCRIPTION
This changes CI/CD tests to be run on Python 3.8-3.10 instead on 3.7-3.9 and updates mentions of Python version support to 3.8+. Wiki may still need updates for this.

Also 
- upgrades pinned dependencies to newest available (except for [simplemma](https://github.com/adbar/simplemma/releases/tag/v0.7.0) as there is some breaking change), which is now possible since dropping Python 3.7 support
- switches to [use importlib of the standard library](https://github.com/NatLibFi/Annif/pull/592/commits/61df4def91065295709d5b45f8fb2ad4a1c7bc28), previously the 3rd party package was needed for Python 3.7
- [verifies installed packages have compatible dependencies](https://github.com/NatLibFi/Annif/pull/592/commits/3714fcd3d8adeb9fadcd4c050af23332f89ae3a7) using `pip check`

Compatibility of models trained with older dependencies should still be checked and documented.

Closes #589.