### PR TITLE
Upgrade Simplemma to version 0.7

### DIFF
--- a/annif/analyzer/simplemma.py
+++ b/annif/analyzer/simplemma.py
@@ -10,17 +10,8 @@ class SimplemmaAnalyzer(analyzer.Analyzer):
 
     def __init__(self, param, **kwargs):
         self.lang = param
-        self.langdata = None
         super().__init__(**kwargs)
-
-    def __getstate__(self):
-        """Return the state of the object for pickling purposes. The langdata
-        field is set to None as it's more efficient to use load_data."""
-
-        return {'lang': self.lang, 'langdata': None}
 
     @functools.lru_cache(maxsize=500000)
     def _normalize_word(self, word):
-        if self.langdata is None:
-            self.langdata = simplemma.load_data(self.lang)
-        return simplemma.lemmatize(word, self.langdata)
+        return simplemma.lemmatize(word, self.lang)

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
         'stwfsapy==0.3.*',
         'python-dateutil',
         'tomli==2.0.*',
-        'simplemma==0.6.*'
+        'simplemma==0.7.*'
     ],
     tests_require=['py', 'pytest', 'requests'],
     extras_require={

--- a/tests/test_analyzer_simplemma.py
+++ b/tests/test_analyzer_simplemma.py
@@ -6,12 +6,6 @@ import annif.analyzer
 simplemma = pytest.importorskip("annif.analyzer.simplemma")
 
 
-def test_simplemma_getstate():
-    analyzer = annif.analyzer.get_analyzer("simplemma(fi)")
-    state = analyzer.__getstate__()
-    assert state == {'lang': 'fi', 'langdata': None}
-
-
 def test_simplemma_finnish_analyzer_normalize_word():
     analyzer = annif.analyzer.get_analyzer("simplemma(fi)")
     assert analyzer._normalize_word("xyzzy") == "xyzzy"


### PR DESCRIPTION
This PR upgrades the Simplemma dependency (which is used in the simplemma analyzer, added in #591) from version 0.6 to [0.7](https://github.com/adbar/simplemma/releases/tag/v0.7.0).

Simplemma now does the loading of language data internally, so the calling code could be simplified even more from what it was. There is no need for the `__getstate__` trick so that was deleted too.

Related to [this comment](https://github.com/NatLibFi/Annif/pull/592#issuecomment-1164140577)

Note that I haven't tested this for real (yet), just verified that the tests pass, so keeping it as a draft PR for now.