### PR TITLE
Include labels without language tag and concepts without labels in vocabulary

### DIFF
--- a/annif/corpus/skos.py
+++ b/annif/corpus/skos.py
@@ -49,14 +49,14 @@ class SubjectFileSKOS(SubjectCorpus):
         for concept in self.concepts:
             labels = self.get_concept_labels(
                 concept, [SKOS.prefLabel, RDFS.label], self.language)
-            if labels:
-                label = labels[0]
-            else:
-                # No labels - use qualified name instead (derived from URI)
-                label = self.graph.namespace_manager.qname(concept)
+            # Use first label if available, else use qualified name (from URI)
+            label = (labels[0] if labels
+                     else self.graph.namespace_manager.qname(concept))
+
             notation = self.graph.value(concept, SKOS.notation, None, any=True)
             if notation is not None:
                 notation = str(notation)
+
             yield Subject(uri=str(concept), label=label, notation=notation,
                           text=None)
 

--- a/annif/corpus/skos.py
+++ b/annif/corpus/skos.py
@@ -68,19 +68,22 @@ class SubjectFileSKOS(SubjectCorpus):
             yield concept
 
     def get_concept_labels(self, concept, label_types, language):
+        all_labels = [label
+                      for label_type in label_types
+                      for label in self.graph.objects(concept, label_type)]
+
         # 1. Labels with the correct language tag
-        labels = [str(label)
-                  for label_type in label_types
-                  for label in self.graph.objects(concept, label_type)
-                  if label.language == language]
-        if labels:
-            return labels
+        same_lang_labels = [str(label)
+                            for label in all_labels
+                            if label.language == language]
+
         # 2. Labels without a language tag
-        labels = [str(label)
-                  for label_type in label_types
-                  for label in self.graph.objects(concept, label_type)
-                  if label.language is None]
-        return labels
+        no_lang_labels = [str(label)
+                          for label in all_labels
+                          if label.language is None]
+
+        # Return both kinds, but better ones (with the right language) first
+        return same_lang_labels + no_lang_labels
 
     @staticmethod
     def is_rdf_file(path):

--- a/annif/lexical/mllm.py
+++ b/annif/lexical/mllm.py
@@ -145,12 +145,19 @@ class MLLMModel:
     def _candidates_to_features(self, candidates):
         return candidates_to_features(candidates, self._model_data)
 
-    def _prepare_terms(self, graph, vocab, params):
+    @staticmethod
+    def _get_label_props(params):
         pref_label_props = [SKOS.prefLabel]
+
         if annif.util.boolean(params['use_hidden_labels']):
             nonpref_label_props = [SKOS.altLabel, SKOS.hiddenLabel]
         else:
             nonpref_label_props = [SKOS.altLabel]
+
+        return (pref_label_props, nonpref_label_props)
+
+    def _prepare_terms(self, graph, vocab, params):
+        pref_label_props, nonpref_label_props = self._get_label_props(params)
 
         terms = []
         subject_ids = []

--- a/annif/lexical/mllm.py
+++ b/annif/lexical/mllm.py
@@ -146,18 +146,24 @@ class MLLMModel:
         return candidates_to_features(candidates, self._model_data)
 
     def _prepare_terms(self, graph, vocab, params):
+        pref_label_props = [SKOS.prefLabel]
         if annif.util.boolean(params['use_hidden_labels']):
-            label_props = [SKOS.altLabel, SKOS.hiddenLabel]
+            nonpref_label_props = [SKOS.altLabel, SKOS.hiddenLabel]
         else:
-            label_props = [SKOS.altLabel]
+            nonpref_label_props = [SKOS.altLabel]
 
         terms = []
         subject_ids = []
-        for subj_id, uri, pref, _ in vocab.subjects.active:
+        for subj_id, uri, _, _ in vocab.subjects.active:
             subject_ids.append(subj_id)
-            terms.append(Term(subject_id=subj_id, label=pref, is_pref=True))
 
-            for label in get_subject_labels(graph, uri, label_props,
+            for label in get_subject_labels(graph, uri, pref_label_props,
+                                            params['language']):
+                terms.append(Term(subject_id=subj_id,
+                                  label=label,
+                                  is_pref=True))
+
+            for label in get_subject_labels(graph, uri, nonpref_label_props,
                                             params['language']):
                 terms.append(Term(subject_id=subj_id,
                                   label=label,

--- a/tests/test_vocab_skos.py
+++ b/tests/test_vocab_skos.py
@@ -71,3 +71,32 @@ yso:p8993
     assert subjects[0].uri == 'http://www.yso.fi/onto/yso/p8993'
     assert subjects[0].label == 'hylyt'
     assert subjects[0].notation == '42.42'
+
+
+def test_load_turtle_missing_langtags(tmpdir):
+    tmpfile = tmpdir.join('subjects.ttl')
+    tmpfile.write("""
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix ex: <http://example.org/> .
+
+# Concept with a prefLabel in English
+ex:conc1 a skos:Concept;
+    skos:prefLabel "Concept 1"@en .
+
+# Concept with a prefLabel without a language tag
+ex:conc2 a skos:Concept;
+    skos:prefLabel "Concept 2" .
+
+# Concept without a prefLabel
+ex:conc3 a skos:Concept .
+    """)
+
+    corpus = SubjectFileSKOS(str(tmpfile), 'en')
+    subjects = list(corpus.subjects)
+    assert len(subjects) == 3
+
+    # check that the vocabulary contains the expected labels
+    labels = {subj.label for subj in subjects}
+    assert 'Concept 1' in labels
+    assert 'Concept 2' in labels
+    assert 'ex:conc3' in labels


### PR DESCRIPTION
Fixes #556 by modifying the way concepts from SKOS vocabularies are loaded. There are two main changes:

1. If a concept doesn't have a prefLabel in the configured language, but has a prefLabel without a language tag, use that instead.
2. If a concept doesn't have any suitable prefLabels (in the configured language, or without a language tag), generate a pseudo label from the qualified name (e.g. `yso:p12345` or `lcsh:sh85061212`)

This should improve the support for multilingual vocabularies and handle cases when SKOS data is missing language tags, which can happen for example when converting MARC21 records to SKOS like @macsag did when reporting #556.

Note that unlike the solution drafted in [this comment](), there is no BCP 47 style matching of language tag variants (e.g. `en` in the SKOS file would match the configured language `en-US`). I considered this out of scope for now (YAGNI principle) although it could easily be added later, but it would require using a library such as [langcodes](https://pypi.org/project/langcodes/) for the actual language tag matching. 

This PR may change the results for some multilingual corpora, for example the YSO based corpora used to train and evaluate models for Finto AI, because the vocabulary will now be larger in some cases. YSO usually lacks Swedish and/or English language labels for some recently added concepts and these used to be dropped when loading the vocabulary, but will now be included after this PR. 