### PR TITLE
Pin flake8 to version 4.x to avoid pytest-flake8 breakage

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,7 @@ setup(
             'pytest-watch',
             'pytest-flask',
             'pytest-flake8',
+            'flake8<5',
             'bumpversion',
             'autopep8',
             'importlib_metadata'


### PR DESCRIPTION
This PR fixes a recently surfaced [incompatibility](https://github.com/tholo/pytest-flake8/issues/87) that causes CI tests to fail. pytest-flake8 (version 1.1.1) is not compatible with flake8 version 5, released a few days ago. The PR pins the version of flake8 to 4.x, which fixes the issue for now but is probably not a good long term solution.

I think we need to reconsider the use of pytest-flake8. Many folks [seem](https://github.com/pypa/pep517/pull/147) [to](https://github.com/pytest-dev/pytest/issues/9217#issuecomment-965144375) [be](https://github.com/miketheman/pytest-socket/issues/82) abandoning this flaky (heh) integration and instead switching to a setup where flake8 is run outside pytest. I will open a separate issue about this.