### PR TITLE
Make vocabularies multilingual

### DIFF
--- a/annif/cli.py
+++ b/annif/cli.py
@@ -187,7 +187,7 @@ def run_loadvoc(project_id, force, subjectfile):
     proj = get_project(project_id)
     if annif.corpus.SubjectFileSKOS.is_rdf_file(subjectfile):
         # SKOS/RDF file supported by rdflib
-        subjects = annif.corpus.SubjectFileSKOS(subjectfile, proj.language)
+        subjects = annif.corpus.SubjectFileSKOS(subjectfile)
     else:
         # probably a TSV file
         subjects = annif.corpus.SubjectFileTSV(subjectfile)

--- a/annif/corpus/skos.py
+++ b/annif/corpus/skos.py
@@ -52,10 +52,10 @@ class SubjectFileSKOS(SubjectCorpus):
         for concept in self.concepts:
             for label_type in self.PREF_LABEL_PROPERTIES:
                 for label in self.graph.objects(concept, label_type):
-                    if label.language is not None:
-                        langs.add(label.language)
+                    langs.add(label.language)
 
-        return langs
+        # return only real language tags, not None or ''
+        return list(filter(None, langs))
 
     def subjects(self, language):
         for concept in self.concepts:

--- a/annif/corpus/skos.py
+++ b/annif/corpus/skos.py
@@ -36,9 +36,8 @@ class SubjectFileSKOS(SubjectCorpus):
 
     PREF_LABEL_PROPERTIES = (SKOS.prefLabel, RDFS.label)
 
-    def __init__(self, path, language):
+    def __init__(self, path):
         self.path = path
-        self.language = language
         if path.endswith('.dump.gz'):
             self.graph = joblib.load(path)
         else:
@@ -58,11 +57,10 @@ class SubjectFileSKOS(SubjectCorpus):
 
         return langs
 
-    @property
-    def subjects(self):
+    def subjects(self, language):
         for concept in self.concepts:
             labels = self.get_concept_labels(
-                concept, self.PREF_LABEL_PROPERTIES, self.language)
+                concept, self.PREF_LABEL_PROPERTIES, language)
             # Use first label if available, else use qualified name (from URI)
             label = (labels[0] if labels
                      else self.graph.namespace_manager.qname(concept))

--- a/annif/corpus/skos.py
+++ b/annif/corpus/skos.py
@@ -47,15 +47,11 @@ class SubjectFileSKOS(SubjectCorpus):
 
     @property
     def languages(self):
-        langs = set()
-
-        for concept in self.concepts:
-            for label_type in self.PREF_LABEL_PROPERTIES:
-                for label in self.graph.objects(concept, label_type):
-                    langs.add(label.language)
-
-        # return only real language tags, not None or ''
-        return list(filter(None, langs))
+        return {label.language
+                for concept in self.concepts
+                for label_type in self.PREF_LABEL_PROPERTIES
+                for label in self.graph.objects(concept, label_type)
+                if label.language is not None}
 
     def subjects(self, language):
         for concept in self.concepts:

--- a/annif/corpus/skos.py
+++ b/annif/corpus/skos.py
@@ -34,6 +34,8 @@ def serialize_subjects_to_skos(subjects, language, path):
 class SubjectFileSKOS(SubjectCorpus):
     """A subject corpus that uses SKOS files"""
 
+    PREF_LABEL_PROPERTIES = (SKOS.prefLabel, RDFS.label)
+
     def __init__(self, path, language):
         self.path = path
         self.language = language
@@ -45,10 +47,22 @@ class SubjectFileSKOS(SubjectCorpus):
                              format=rdflib.util.guess_format(self.path))
 
     @property
+    def languages(self):
+        langs = set()
+
+        for concept in self.concepts:
+            for label_type in self.PREF_LABEL_PROPERTIES:
+                for label in self.graph.objects(concept, label_type):
+                    if label.language is not None:
+                        langs.add(label.language)
+
+        return langs
+
+    @property
     def subjects(self):
         for concept in self.concepts:
             labels = self.get_concept_labels(
-                concept, [SKOS.prefLabel, RDFS.label], self.language)
+                concept, self.PREF_LABEL_PROPERTIES, self.language)
             # Use first label if available, else use qualified name (from URI)
             label = (labels[0] if labels
                      else self.graph.namespace_manager.qname(concept))

--- a/annif/corpus/subject.py
+++ b/annif/corpus/subject.py
@@ -25,8 +25,7 @@ class SubjectFileTSV:
         # we don't have information about the language(s) of labels
         return None
 
-    @property
-    def subjects(self):
+    def subjects(self, language):
         with open(self.path, encoding='utf-8-sig') as subjfile:
             for line in subjfile:
                 yield from self._parse_line(line)
@@ -34,24 +33,27 @@ class SubjectFileTSV:
     def save_skos(self, path, language):
         """Save the contents of the subject vocabulary into a SKOS/Turtle
         file with the given path name."""
-        serialize_subjects_to_skos(self.subjects, language, path)
+        serialize_subjects_to_skos(self.subjects(language), language, path)
 
 
 class SubjectIndex:
     """An index that remembers the associations between integers subject IDs
     and their URIs and labels."""
 
-    def __init__(self, corpus=None):
-        """Initialize the subject index from a subject corpus."""
+    def __init__(self):
         self._uris = []
         self._labels = []
         self._notations = []
         self._uri_idx = {}
         self._label_idx = {}
-        if corpus is not None:
-            for subject_id, subject in enumerate(corpus.subjects):
-                self._append(subject_id, subject.uri, subject.label,
-                             subject.notation)
+
+    def load_subjects(self, corpus, language):
+        """Initialize the subject index from a subject corpus using labels
+        in the given language."""
+
+        for subject_id, subject in enumerate(corpus.subjects(language)):
+            self._append(subject_id, subject.uri, subject.label,
+                         subject.notation)
 
     def __len__(self):
         return len(self._uris)
@@ -141,7 +143,9 @@ class SubjectIndex:
         """Load a subject index from a TSV file and return it."""
 
         corpus = SubjectFileTSV(path)
-        return cls(corpus)
+        subject_index = cls()
+        subject_index.load_subjects(corpus, None)
+        return subject_index
 
 
 class SubjectSet:

--- a/annif/corpus/subject.py
+++ b/annif/corpus/subject.py
@@ -21,6 +21,11 @@ class SubjectFileTSV:
         yield Subject(uri=clean_uri, label=label, notation=notation, text=None)
 
     @property
+    def languages(self):
+        # we don't have information about the language(s) of labels
+        return None
+
+    @property
     def subjects(self):
         with open(self.path, encoding='utf-8-sig') as subjfile:
             for line in subjfile:

--- a/annif/project.py
+++ b/annif/project.py
@@ -2,7 +2,6 @@
 
 import enum
 import os.path
-import re
 from shutil import rmtree
 import annif
 import annif.transform
@@ -14,7 +13,6 @@ import annif.vocab
 from annif.datadir import DatadirMixin
 from annif.exception import AnnifException, ConfigurationException, \
     NotSupportedException, NotInitializedException
-from annif.util import parse_args
 
 logger = annif.logger
 
@@ -157,17 +155,10 @@ class AnnifProject(DatadirMixin):
             if self.vocab_spec is None:
                 raise ConfigurationException("vocab setting is missing",
                                              project_id=self.project_id)
-            match = re.match(r'(\w+)(\((.*)\))?', self.vocab_spec)
-            if match is None:
-                raise ConfigurationException("vocab setting is invalid",
-                                             project_id=self.project_id)
-            vocab_id = match.group(1)
-            posargs, kwargs = parse_args(match.group(3))
-            language = posargs[0] if posargs else self.language
+            self._vocab = annif.vocab.get_vocab(self.vocab_spec,
+                                                self._base_datadir,
+                                                self.language)
 
-            self._vocab = annif.vocab.AnnifVocabulary(vocab_id,
-                                                      self._base_datadir,
-                                                      language)
         return self._vocab
 
     @property

--- a/annif/vocab.py
+++ b/annif/vocab.py
@@ -113,11 +113,9 @@ class AnnifVocabulary(DatadirMixin):
         or more subject index files as well as a SKOS/Turtle file for later
         use. If force=True, replace the existing subject index completely."""
 
-        languages = subject_corpus.languages
-        if not languages:
-            # subject corpus isn't language-aware or can't detect languages
-            # default to language from project config instead
-            languages = [default_language]
+        # default to language from project config if subject corpus isn't
+        # language-aware or can't detect languages
+        languages = subject_corpus.languages or [default_language]
 
         for language in languages:
             if not force and os.path.exists(

--- a/annif/vocab.py
+++ b/annif/vocab.py
@@ -1,13 +1,26 @@
 """Vocabulary management functionality for Annif"""
 
 import os.path
+import re
 import annif
 import annif.corpus
 import annif.util
 from annif.datadir import DatadirMixin
 from annif.exception import NotInitializedException
+from annif.util import parse_args
 
 logger = annif.logger
+
+
+def get_vocab(vocab_spec, datadir, default_language):
+    match = re.match(r'(\w+)(\((.*)\))?', vocab_spec)
+    if match is None:
+        raise ValueError(f"Invalid vocabulary specification: {vocab_spec}")
+    vocab_id = match.group(1)
+    posargs, kwargs = parse_args(match.group(3))
+    language = posargs[0] if posargs else default_language
+
+    return AnnifVocabulary(vocab_id, datadir, language)
 
 
 class AnnifVocabulary(DatadirMixin):

--- a/annif/vocab.py
+++ b/annif/vocab.py
@@ -95,15 +95,16 @@ class AnnifVocabulary(DatadirMixin):
 
         raise NotInitializedException(f'graph file {path} not found')
 
-    def load_vocabulary(self, subject_corpus, project_language, force=False):
+    def load_vocabulary(self, subject_corpus, default_language, force=False):
         """Load subjects from a subject corpus and save them into one
         or more subject index files as well as a SKOS/Turtle file for later
         use. If force=True, replace the existing subject index completely."""
 
         languages = subject_corpus.languages
-        if languages is None:
-            # subject corpus isn't language-aware, default to project language
-            languages = [project_language]
+        if not languages:
+            # subject corpus isn't language-aware or can't detect languages
+            # default to language from project config instead
+            languages = [default_language]
 
         for language in languages:
             if not force and os.path.exists(
@@ -114,11 +115,11 @@ class AnnifVocabulary(DatadirMixin):
             else:
                 subjects = self._create_subject_index(subject_corpus, language)
 
-            if language == project_language:
+            if language == default_language:
                 self._subjects = subjects
 
         subject_corpus.save_skos(os.path.join(self.datadir, 'subjects.ttl'),
-                                 project_language)
+                                 default_language)
 
     def as_skos_file(self):
         """return the vocabulary as a file object, in SKOS/Turtle syntax"""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,7 +23,9 @@ def app():
     app = annif.create_app(config_name='annif.default_config.TestingConfig')
     with app.app_context():
         project = annif.registry.get_project('dummy-en')
+        # the vocab is needed for both English and Finnish language projects
         project.vocab.load_vocabulary(vocab, 'en')
+        project.vocab.load_vocabulary(vocab, 'fi')
     return app
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -80,7 +80,7 @@ def vocabulary(datadir):
         'corpora',
         'archaeology',
         'yso-archaeology.ttl')
-    subjects = annif.corpus.SubjectFileSKOS(subjfile, 'fi')
+    subjects = annif.corpus.SubjectFileSKOS(subjfile)
     vocab.load_vocabulary(subjects, 'fi')
     return vocab
 

--- a/tests/projects.cfg
+++ b/tests/projects.cfg
@@ -69,21 +69,21 @@ name=TF-IDF Finnish using default params
 language=fi
 backend=tfidf
 analyzer=snowball(finnish)
-vocab=yso-fi
+vocab=yso
 
 [noparams-fasttext-fi]
 name=fastText Finnish using default params
 language=fi
 backend=fasttext
 analyzer=snowball(finnish)
-vocab=yso-fi
+vocab=yso
 
 [pav]
 name=PAV Ensemble Finnish
 language=fi
 backend=pav
 sources=tfidf-fi,fasttext-fi
-vocab=yso-fi
+vocab=yso
 
 [tfidf-fi]
 name=TF-IDF Finnish
@@ -91,7 +91,7 @@ language=fi
 backend=tfidf
 analyzer=snowball(finnish)
 limit=10
-vocab=yso-fi
+vocab=yso
 
 [tfidf-en]
 name=TF-IDF English
@@ -99,7 +99,7 @@ language=en
 backend=tfidf
 analyzer=snowball(english)
 limit=10
-vocab=yso-en
+vocab=yso
 
 [fasttext-en]
 name=fastText English
@@ -112,7 +112,7 @@ epoch=5
 loss=hs
 limit=100
 chunksize=24
-vocab=yso-en
+vocab=yso
 
 [fasttext-fi]
 name=fastText Finnish
@@ -125,4 +125,4 @@ epoch=5
 loss=hs
 limit=100
 chunksize=24
-vocab=yso-fi
+vocab=yso

--- a/tests/projects.cfg
+++ b/tests/projects.cfg
@@ -22,7 +22,7 @@ name=Dummy+Dummy combination
 language=en
 backend=dummy
 analyzer=snowball(english)
-vocab=dummy
+vocab=dummy(fi)
 access=private
 
 [dummy-transform]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -125,12 +125,12 @@ def test_loadvoc_tsv(testdatadir):
     result = runner.invoke(annif.cli.cli, ['loadvoc', 'tfidf-fi', subjectfile])
     assert not result.exception
     assert result.exit_code == 0
-    assert testdatadir.join('vocabs/yso-fi/subjects.fi.tsv').exists()
-    assert testdatadir.join('vocabs/yso-fi/subjects.fi.tsv').size() > 0
-    assert testdatadir.join('vocabs/yso-fi/subjects.ttl').exists()
-    assert testdatadir.join('vocabs/yso-fi/subjects.ttl').size() > 0
-    assert testdatadir.join('vocabs/yso-fi/subjects.dump.gz').exists()
-    assert testdatadir.join('vocabs/yso-fi/subjects.dump.gz').size() > 0
+    assert testdatadir.join('vocabs/yso/subjects.fi.tsv').exists()
+    assert testdatadir.join('vocabs/yso/subjects.fi.tsv').size() > 0
+    assert testdatadir.join('vocabs/yso/subjects.ttl').exists()
+    assert testdatadir.join('vocabs/yso/subjects.ttl').size() > 0
+    assert testdatadir.join('vocabs/yso/subjects.dump.gz').exists()
+    assert testdatadir.join('vocabs/yso/subjects.dump.gz').size() > 0
 
 
 def test_loadvoc_tsv_with_bom(testdatadir):
@@ -146,12 +146,12 @@ def test_loadvoc_tsv_with_bom(testdatadir):
     result = runner.invoke(annif.cli.cli, ['loadvoc', 'tfidf-fi', subjectfile])
     assert not result.exception
     assert result.exit_code == 0
-    assert testdatadir.join('vocabs/yso-fi/subjects.fi.tsv').exists()
-    assert testdatadir.join('vocabs/yso-fi/subjects.fi.tsv').size() > 0
-    assert testdatadir.join('vocabs/yso-fi/subjects.ttl').exists()
-    assert testdatadir.join('vocabs/yso-fi/subjects.ttl').size() > 0
-    assert testdatadir.join('vocabs/yso-fi/subjects.dump.gz').exists()
-    assert testdatadir.join('vocabs/yso-fi/subjects.dump.gz').size() > 0
+    assert testdatadir.join('vocabs/yso/subjects.fi.tsv').exists()
+    assert testdatadir.join('vocabs/yso/subjects.fi.tsv').size() > 0
+    assert testdatadir.join('vocabs/yso/subjects.ttl').exists()
+    assert testdatadir.join('vocabs/yso/subjects.ttl').size() > 0
+    assert testdatadir.join('vocabs/yso/subjects.dump.gz').exists()
+    assert testdatadir.join('vocabs/yso/subjects.dump.gz').size() > 0
 
 
 def test_loadvoc_rdf(testdatadir):
@@ -167,12 +167,12 @@ def test_loadvoc_rdf(testdatadir):
     result = runner.invoke(annif.cli.cli, ['loadvoc', 'tfidf-fi', subjectfile])
     assert not result.exception
     assert result.exit_code == 0
-    assert testdatadir.join('vocabs/yso-fi/subjects.fi.tsv').exists()
-    assert testdatadir.join('vocabs/yso-fi/subjects.fi.tsv').size() > 0
-    assert testdatadir.join('vocabs/yso-fi/subjects.ttl').exists()
-    assert testdatadir.join('vocabs/yso-fi/subjects.ttl').size() > 0
-    assert testdatadir.join('vocabs/yso-fi/subjects.dump.gz').exists()
-    assert testdatadir.join('vocabs/yso-fi/subjects.dump.gz').size() > 0
+    assert testdatadir.join('vocabs/yso/subjects.fi.tsv').exists()
+    assert testdatadir.join('vocabs/yso/subjects.fi.tsv').size() > 0
+    assert testdatadir.join('vocabs/yso/subjects.ttl').exists()
+    assert testdatadir.join('vocabs/yso/subjects.ttl').size() > 0
+    assert testdatadir.join('vocabs/yso/subjects.dump.gz').exists()
+    assert testdatadir.join('vocabs/yso/subjects.dump.gz').size() > 0
 
 
 def test_loadvoc_ttl(testdatadir):
@@ -188,12 +188,12 @@ def test_loadvoc_ttl(testdatadir):
     result = runner.invoke(annif.cli.cli, ['loadvoc', 'tfidf-fi', subjectfile])
     assert not result.exception
     assert result.exit_code == 0
-    assert testdatadir.join('vocabs/yso-fi/subjects.fi.tsv').exists()
-    assert testdatadir.join('vocabs/yso-fi/subjects.fi.tsv').size() > 0
-    assert testdatadir.join('vocabs/yso-fi/subjects.ttl').exists()
-    assert testdatadir.join('vocabs/yso-fi/subjects.ttl').size() > 0
-    assert testdatadir.join('vocabs/yso-fi/subjects.dump.gz').exists()
-    assert testdatadir.join('vocabs/yso-fi/subjects.dump.gz').size() > 0
+    assert testdatadir.join('vocabs/yso/subjects.fi.tsv').exists()
+    assert testdatadir.join('vocabs/yso/subjects.fi.tsv').size() > 0
+    assert testdatadir.join('vocabs/yso/subjects.ttl').exists()
+    assert testdatadir.join('vocabs/yso/subjects.ttl').size() > 0
+    assert testdatadir.join('vocabs/yso/subjects.dump.gz').exists()
+    assert testdatadir.join('vocabs/yso/subjects.dump.gz').size() > 0
 
 
 def test_loadvoc_nonexistent_path():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -114,7 +114,7 @@ def test_clear_project_nonexistent_data(testdatadir, caplog):
 
 def test_loadvoc_tsv(testdatadir):
     with contextlib.suppress(FileNotFoundError):
-        os.remove(str(testdatadir.join('projects/tfidf-fi/subjects')))
+        os.remove(str(testdatadir.join('projects/tfidf-fi/subjects.fi.tsv')))
     with contextlib.suppress(FileNotFoundError):
         os.remove(str(testdatadir.join('projects/tfidf-fi/subjects.ttl')))
     subjectfile = os.path.join(
@@ -125,8 +125,8 @@ def test_loadvoc_tsv(testdatadir):
     result = runner.invoke(annif.cli.cli, ['loadvoc', 'tfidf-fi', subjectfile])
     assert not result.exception
     assert result.exit_code == 0
-    assert testdatadir.join('vocabs/yso-fi/subjects').exists()
-    assert testdatadir.join('vocabs/yso-fi/subjects').size() > 0
+    assert testdatadir.join('vocabs/yso-fi/subjects.fi.tsv').exists()
+    assert testdatadir.join('vocabs/yso-fi/subjects.fi.tsv').size() > 0
     assert testdatadir.join('vocabs/yso-fi/subjects.ttl').exists()
     assert testdatadir.join('vocabs/yso-fi/subjects.ttl').size() > 0
     assert testdatadir.join('vocabs/yso-fi/subjects.dump.gz').exists()
@@ -135,7 +135,7 @@ def test_loadvoc_tsv(testdatadir):
 
 def test_loadvoc_tsv_with_bom(testdatadir):
     with contextlib.suppress(FileNotFoundError):
-        os.remove(str(testdatadir.join('projects/tfidf-fi/subjects')))
+        os.remove(str(testdatadir.join('projects/tfidf-fi/subjects.fi.tsv')))
     with contextlib.suppress(FileNotFoundError):
         os.remove(str(testdatadir.join('projects/tfidf-fi/subjects.ttl')))
     subjectfile = os.path.join(
@@ -146,8 +146,8 @@ def test_loadvoc_tsv_with_bom(testdatadir):
     result = runner.invoke(annif.cli.cli, ['loadvoc', 'tfidf-fi', subjectfile])
     assert not result.exception
     assert result.exit_code == 0
-    assert testdatadir.join('vocabs/yso-fi/subjects').exists()
-    assert testdatadir.join('vocabs/yso-fi/subjects').size() > 0
+    assert testdatadir.join('vocabs/yso-fi/subjects.fi.tsv').exists()
+    assert testdatadir.join('vocabs/yso-fi/subjects.fi.tsv').size() > 0
     assert testdatadir.join('vocabs/yso-fi/subjects.ttl').exists()
     assert testdatadir.join('vocabs/yso-fi/subjects.ttl').size() > 0
     assert testdatadir.join('vocabs/yso-fi/subjects.dump.gz').exists()
@@ -156,7 +156,7 @@ def test_loadvoc_tsv_with_bom(testdatadir):
 
 def test_loadvoc_rdf(testdatadir):
     with contextlib.suppress(FileNotFoundError):
-        os.remove(str(testdatadir.join('projects/tfidf-fi/subjects')))
+        os.remove(str(testdatadir.join('projects/tfidf-fi/subjects.fi.tsv')))
     with contextlib.suppress(FileNotFoundError):
         os.remove(str(testdatadir.join('projects/tfidf-fi/subjects.ttl')))
     subjectfile = os.path.join(
@@ -167,8 +167,8 @@ def test_loadvoc_rdf(testdatadir):
     result = runner.invoke(annif.cli.cli, ['loadvoc', 'tfidf-fi', subjectfile])
     assert not result.exception
     assert result.exit_code == 0
-    assert testdatadir.join('vocabs/yso-fi/subjects').exists()
-    assert testdatadir.join('vocabs/yso-fi/subjects').size() > 0
+    assert testdatadir.join('vocabs/yso-fi/subjects.fi.tsv').exists()
+    assert testdatadir.join('vocabs/yso-fi/subjects.fi.tsv').size() > 0
     assert testdatadir.join('vocabs/yso-fi/subjects.ttl').exists()
     assert testdatadir.join('vocabs/yso-fi/subjects.ttl').size() > 0
     assert testdatadir.join('vocabs/yso-fi/subjects.dump.gz').exists()
@@ -177,7 +177,7 @@ def test_loadvoc_rdf(testdatadir):
 
 def test_loadvoc_ttl(testdatadir):
     with contextlib.suppress(FileNotFoundError):
-        os.remove(str(testdatadir.join('projects/tfidf-fi/subjects')))
+        os.remove(str(testdatadir.join('projects/tfidf-fi/subjects.fi.tsv')))
     with contextlib.suppress(FileNotFoundError):
         os.remove(str(testdatadir.join('projects/tfidf-fi/subjects.ttl')))
     subjectfile = os.path.join(
@@ -188,8 +188,8 @@ def test_loadvoc_ttl(testdatadir):
     result = runner.invoke(annif.cli.cli, ['loadvoc', 'tfidf-fi', subjectfile])
     assert not result.exception
     assert result.exit_code == 0
-    assert testdatadir.join('vocabs/yso-fi/subjects').exists()
-    assert testdatadir.join('vocabs/yso-fi/subjects').size() > 0
+    assert testdatadir.join('vocabs/yso-fi/subjects.fi.tsv').exists()
+    assert testdatadir.join('vocabs/yso-fi/subjects.fi.tsv').size() > 0
     assert testdatadir.join('vocabs/yso-fi/subjects.ttl').exists()
     assert testdatadir.join('vocabs/yso-fi/subjects.ttl').size() > 0
     assert testdatadir.join('vocabs/yso-fi/subjects.dump.gz').exists()

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -44,6 +44,9 @@ def test_get_project_dummydummy(registry):
     assert project.language == 'en'
     assert project.analyzer.name == 'snowball'
     assert project.analyzer.param == 'english'
+    # project uses the dummy vocab, with language overridden to Finnish
+    assert project.vocab.vocab_id == 'dummy'
+    assert project.vocab.language == 'fi'
     assert project.access == Access.private
     assert isinstance(project.backend, annif.backend.dummy.DummyBackend)
 

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -126,8 +126,8 @@ def test_get_project_invalid_config_file():
 def test_project_load_vocabulary_tfidf(registry, subject_file, testdatadir):
     project = registry.get_project('tfidf-fi')
     project.vocab.load_vocabulary(subject_file, 'fi')
-    assert testdatadir.join('vocabs/yso-fi/subjects').exists()
-    assert testdatadir.join('vocabs/yso-fi/subjects').size() > 0
+    assert testdatadir.join('vocabs/yso-fi/subjects.fi.tsv').exists()
+    assert testdatadir.join('vocabs/yso-fi/subjects.fi.tsv').size() > 0
 
 
 def test_project_tfidf_is_not_trained(registry):
@@ -193,8 +193,8 @@ def test_project_load_vocabulary_fasttext(registry, subject_file, testdatadir):
     pytest.importorskip("annif.backend.fasttext")
     project = registry.get_project('fasttext-fi')
     project.vocab.load_vocabulary(subject_file, 'fi')
-    assert testdatadir.join('vocabs/yso-fi/subjects').exists()
-    assert testdatadir.join('vocabs/yso-fi/subjects').size() > 0
+    assert testdatadir.join('vocabs/yso-fi/subjects.fi.tsv').exists()
+    assert testdatadir.join('vocabs/yso-fi/subjects.fi.tsv').size() > 0
 
 
 def test_project_train_fasttext(registry, document_corpus, testdatadir):

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -126,8 +126,8 @@ def test_get_project_invalid_config_file():
 def test_project_load_vocabulary_tfidf(registry, subject_file, testdatadir):
     project = registry.get_project('tfidf-fi')
     project.vocab.load_vocabulary(subject_file, 'fi')
-    assert testdatadir.join('vocabs/yso-fi/subjects.fi.tsv').exists()
-    assert testdatadir.join('vocabs/yso-fi/subjects.fi.tsv').size() > 0
+    assert testdatadir.join('vocabs/yso/subjects.fi.tsv').exists()
+    assert testdatadir.join('vocabs/yso/subjects.fi.tsv').size() > 0
 
 
 def test_project_tfidf_is_not_trained(registry):
@@ -193,8 +193,8 @@ def test_project_load_vocabulary_fasttext(registry, subject_file, testdatadir):
     pytest.importorskip("annif.backend.fasttext")
     project = registry.get_project('fasttext-fi')
     project.vocab.load_vocabulary(subject_file, 'fi')
-    assert testdatadir.join('vocabs/yso-fi/subjects.fi.tsv').exists()
-    assert testdatadir.join('vocabs/yso-fi/subjects.fi.tsv').size() > 0
+    assert testdatadir.join('vocabs/yso/subjects.fi.tsv').exists()
+    assert testdatadir.join('vocabs/yso/subjects.fi.tsv').size() > 0
 
 
 def test_project_train_fasttext(registry, document_corpus, testdatadir):

--- a/tests/test_vocab.py
+++ b/tests/test_vocab.py
@@ -19,6 +19,12 @@ def load_dummy_vocab(tmpdir):
     return vocab
 
 
+def test_get_vocab_invalid():
+    with pytest.raises(ValueError) as excinfo:
+        annif.vocab.get_vocab('', None, None)
+    assert 'Invalid vocabulary specification' in str(excinfo.value)
+
+
 def test_update_subject_index_with_no_changes(tmpdir):
     vocab = load_dummy_vocab(tmpdir)
 

--- a/tests/test_vocab_skos.py
+++ b/tests/test_vocab_skos.py
@@ -1,6 +1,8 @@
 """Unit tests for SKOS vocabulary functionality in Annif"""
 
 
+import os.path
+
 from annif.corpus.skos import SubjectFileSKOS
 
 
@@ -100,3 +102,17 @@ ex:conc3 a skos:Concept .
     assert 'Concept 1' in labels
     assert 'Concept 2' in labels
     assert 'ex:conc3' in labels
+
+
+def test_load_turtle_get_languages(testdatadir):
+    subjectfile = os.path.join(
+        os.path.dirname(__file__),
+        'corpora',
+        'archaeology',
+        'yso-archaeology.ttl')
+    corpus = SubjectFileSKOS(subjectfile, 'en')
+    langs = corpus.languages
+    assert len(langs) == 3
+    assert 'fi' in langs
+    assert 'sv' in langs
+    assert 'en' in langs

--- a/tests/test_vocab_skos.py
+++ b/tests/test_vocab_skos.py
@@ -46,8 +46,8 @@ yso:p9285
         "neolitisk tid"@sv .
     """)
 
-    corpus = SubjectFileSKOS(str(tmpfile), 'fi')
-    subjects = list(corpus.subjects)
+    corpus = SubjectFileSKOS(str(tmpfile))
+    subjects = list(corpus.subjects('fi'))
     assert len(subjects) == 1  # one of the concepts was deprecated
     assert subjects[0].uri == 'http://www.yso.fi/onto/yso/p8993'
     assert subjects[0].label == 'hylyt'
@@ -68,8 +68,8 @@ yso:p8993
     skos:related yso:p8869 .
     """)
 
-    corpus = SubjectFileSKOS(str(tmpfile), 'fi')
-    subjects = list(corpus.subjects)
+    corpus = SubjectFileSKOS(str(tmpfile))
+    subjects = list(corpus.subjects('fi'))
     assert subjects[0].uri == 'http://www.yso.fi/onto/yso/p8993'
     assert subjects[0].label == 'hylyt'
     assert subjects[0].notation == '42.42'
@@ -93,8 +93,8 @@ ex:conc2 a skos:Concept;
 ex:conc3 a skos:Concept .
     """)
 
-    corpus = SubjectFileSKOS(str(tmpfile), 'en')
-    subjects = list(corpus.subjects)
+    corpus = SubjectFileSKOS(str(tmpfile))
+    subjects = list(corpus.subjects('en'))
     assert len(subjects) == 3
 
     # check that the vocabulary contains the expected labels
@@ -110,7 +110,7 @@ def test_load_turtle_get_languages(testdatadir):
         'corpora',
         'archaeology',
         'yso-archaeology.ttl')
-    corpus = SubjectFileSKOS(subjectfile, 'en')
+    corpus = SubjectFileSKOS(subjectfile)
     langs = corpus.languages
     assert len(langs) == 3
     assert 'fi' in langs


### PR DESCRIPTION
This PR implements #559 - making vocabularies multilingual, so that there is no need to use separate language-specific vocabulary id's such as `yso-fi`, `yso-sv` and `yso-en`. Instead the vocabulary id `yso` can be used for all projects and the `loadvoc` command needs to be executed just once as it will detect which languages are available in the vocabulary and load the labels in all available languages.

It's also possible to define/override the language of labels, for example to use `vocab=lcsh(en)` in a Finnish language project.

The changes need to be carefully tested as they are quite disruptive. Documentation (including the Annif tutorial) should be updated, mainly by stripping language suffixes from vocabulary id's in examples. However, old examples (vocabulary id's with a language suffix) should still keep working.