### PR TITLE
Refactor SubjectSuggestion to store subject_id - not uri, label, notation

### DIFF
--- a/annif/backend/backend.py
+++ b/annif/backend/backend.py
@@ -12,7 +12,6 @@ class AnnifBackend(metaclass=abc.ABCMeta):
     non-implemented methods should be overridden in subclasses."""
 
     name = None
-    needs_subject_index = False
 
     DEFAULT_PARAMETERS = {'limit': 100}
 

--- a/annif/backend/dummy.py
+++ b/annif/backend/dummy.py
@@ -8,8 +8,7 @@ from . import backend
 class DummyBackend(backend.AnnifLearningBackend):
     name = "dummy"
     initialized = False
-    uri = 'http://example.org/dummy'
-    label = 'dummy'
+    subject_id = 0
     is_trained = True
     modification_time = None
 
@@ -21,18 +20,23 @@ class DummyBackend(backend.AnnifLearningBackend):
 
     def _suggest(self, text, params):
         score = float(params.get('score', 1.0))
-        notation = params.get('notation', None)
-        return ListSuggestionResult([SubjectSuggestion(uri=self.uri,
-                                                       label=self.label,
-                                                       notation=notation,
-                                                       score=score)])
+
+        # allow overriding returned subject via uri parameter
+        if 'uri' in params:
+            subject_id = self.project.subjects.by_uri(params['uri'])
+        else:
+            subject_id = self.subject_id
+
+        return ListSuggestionResult(
+            [SubjectSuggestion(subject_id=subject_id,
+                               score=score)])
 
     def _learn(self, corpus, params):
-        # in this dummy backend we "learn" by picking up the URI and label
+        # in this dummy backend we "learn" by picking up the subject ID
         # of the first subject of the first document in the learning set
         # and using that in subsequent analysis results
         for doc in corpus.documents:
-            if doc.uris and doc.labels:
-                self.uri = list(doc.uris)[0]
-                self.label = list(doc.labels)[0]
+            if doc.uris:
+                first_uri = list(doc.uris)[0]
+                self.subject_id = self.project.subjects.by_uri(first_uri)
             break

--- a/annif/backend/ensemble.py
+++ b/annif/backend/ensemble.py
@@ -50,7 +50,8 @@ class BaseEnsembleBackend(backend.AnnifBackend):
     def _merge_hits_from_sources(self, hits_from_sources, params):
         """Hook for merging hits from sources. Can be overridden by
         subclasses."""
-        return annif.util.merge_hits(hits_from_sources, self.project.subjects)
+        return annif.util.merge_hits(hits_from_sources,
+                                     len(self.project.subjects))
 
     def _suggest(self, text, params):
         sources = annif.util.parse_sources(params['sources'])
@@ -115,7 +116,7 @@ class EnsembleOptimizer(hyperopt.HyperparameterOptimizer):
             batch.evaluate(
                 annif.util.merge_hits(
                     weighted_hits,
-                    self._backend.project.subjects),
+                    len(self._backend.project.subjects)),
                 goldsubj)
         results = batch.results(metrics=[self._metric])
         return results[self._metric]

--- a/annif/backend/fasttext.py
+++ b/annif/backend/fasttext.py
@@ -81,10 +81,9 @@ class FastTextBackend(mixins.ChunkingBackend, backend.AnnifBackend):
     def _id_to_label(subject_id):
         return "__label__{:d}".format(subject_id)
 
-    def _label_to_subject(self, label):
+    def _label_to_subject_id(self, label):
         labelnum = label.replace('__label__', '')
-        subject_id = int(labelnum)
-        return self.project.subjects[subject_id]
+        return int(labelnum)
 
     def _write_train_file(self, corpus, filename):
         with open(filename, 'w', encoding='utf-8') as trainfile:
@@ -155,10 +154,7 @@ class FastTextBackend(mixins.ChunkingBackend, backend.AnnifBackend):
 
         results = []
         for score, label in best_labels[:limit]:
-            subject = self._label_to_subject(label)
             results.append(SubjectSuggestion(
-                uri=subject[0],
-                label=subject[1],
-                notation=subject[2],
+                subject_id=self._label_to_subject_id(label),
                 score=score / len(chunktexts)))
         return ListSuggestionResult(results)

--- a/annif/backend/fasttext.py
+++ b/annif/backend/fasttext.py
@@ -14,7 +14,6 @@ class FastTextBackend(mixins.ChunkingBackend, backend.AnnifBackend):
     """fastText backend for Annif"""
 
     name = "fasttext"
-    needs_subject_index = True
 
     FASTTEXT_PARAMS = {
         'lr': float,

--- a/annif/backend/http.py
+++ b/annif/backend/http.py
@@ -68,14 +68,11 @@ class HTTPBackend(backend.AnnifBackend):
 
         try:
             subject_suggestions = [SubjectSuggestion(
-                uri=hit['uri'],
-                label=None,
-                notation=None,
+                subject_id=self.project.subjects.by_uri(hit['uri']),
                 score=hit['score'])
                 for hit in results if hit['score'] > 0.0]
         except (TypeError, ValueError) as err:
             self.warning("Problem interpreting JSON data: {}".format(err))
             return ListSuggestionResult([])
 
-        return ListSuggestionResult.create_from_index(subject_suggestions,
-                                                      self.project.subjects)
+        return ListSuggestionResult(subject_suggestions)

--- a/annif/backend/mllm.py
+++ b/annif/backend/mllm.py
@@ -67,7 +67,6 @@ class MLLMOptimizer(hyperopt.HyperparameterOptimizer):
 class MLLMBackend(hyperopt.AnnifHyperoptBackend):
     """Maui-like Lexical Matching backend for Annif"""
     name = "mllm"
-    needs_subject_index = True
 
     # defaults for unitialized instances
     _model = None

--- a/annif/backend/nn_ensemble.py
+++ b/annif/backend/nn_ensemble.py
@@ -128,7 +128,7 @@ class NNEnsembleBackend(
                                  custom_objects={'MeanLayer': MeanLayer})
 
     def _merge_hits_from_sources(self, hits_from_sources, params):
-        score_vector = np.array([np.sqrt(hits.as_vector(subjects))
+        score_vector = np.array([np.sqrt(hits.as_vector(len(subjects)))
                                  * weight * len(hits_from_sources)
                                  for hits, weight, subjects
                                  in hits_from_sources],
@@ -205,7 +205,7 @@ class NNEnsembleBackend(
                     psmap.suggest, corpus.documents):
                 doc_scores = []
                 for project_id, p_hits in hits.items():
-                    vector = p_hits.as_vector(self.project.subjects)
+                    vector = p_hits.as_vector(len(self.project.subjects))
                     doc_scores.append(np.sqrt(vector)
                                       * sources[project_id]
                                       * len(sources))

--- a/annif/backend/omikuji.py
+++ b/annif/backend/omikuji.py
@@ -14,7 +14,6 @@ from . import mixins
 class OmikujiBackend(mixins.TfidfVectorizerMixin, backend.AnnifBackend):
     """Omikuji based backend for Annif"""
     name = "omikuji"
-    needs_subject_index = True
 
     # defaults for uninitialized instances
     _model = None

--- a/annif/backend/omikuji.py
+++ b/annif/backend/omikuji.py
@@ -132,10 +132,7 @@ class OmikujiBackend(mixins.TfidfVectorizerMixin, backend.AnnifBackend):
         results = []
         limit = int(params['limit'])
         for subj_id, score in self._model.predict(feature_values, top_k=limit):
-            subject = self.project.subjects[subj_id]
             results.append(SubjectSuggestion(
-                uri=subject[0],
-                label=subject[1],
-                notation=subject[2],
+                subject_id=subj_id,
                 score=score))
         return ListSuggestionResult(results)

--- a/annif/backend/pav.py
+++ b/annif/backend/pav.py
@@ -56,7 +56,7 @@ class PAVBackend(ensemble.BaseEnsembleBackend):
     def _normalize_hits(self, hits, source_project):
         reg_models = self._get_model(source_project.project_id)
         pav_result = []
-        for hit in hits.as_list(source_project.subjects):
+        for hit in hits.as_list():
             if hit.subject_id in reg_models:
                 score = reg_models[hit.subject_id].predict([hit.score])[0]
             else:  # default to raw score

--- a/annif/backend/pav.py
+++ b/annif/backend/pav.py
@@ -57,15 +57,13 @@ class PAVBackend(ensemble.BaseEnsembleBackend):
         reg_models = self._get_model(source_project.project_id)
         pav_result = []
         for hit in hits.as_list(source_project.subjects):
-            if hit.uri in reg_models:
-                score = reg_models[hit.uri].predict([hit.score])[0]
+            if hit.subject_id in reg_models:
+                score = reg_models[hit.subject_id].predict([hit.score])[0]
             else:  # default to raw score
                 score = hit.score
             pav_result.append(
                 annif.suggestion.SubjectSuggestion(
-                    uri=hit.uri,
-                    label=hit.label,
-                    notation=hit.notation,
+                    subject_id=hit.subject_id,
                     score=score))
         pav_result.sort(key=lambda hit: hit.score, reverse=True)
         return annif.suggestion.ListSuggestionResult(pav_result)
@@ -114,7 +112,7 @@ class PAVBackend(ensemble.BaseEnsembleBackend):
             reg = IsotonicRegression(out_of_bounds='clip')
             cid_scores = scores[:, cid].toarray().flatten().astype(np.float64)
             reg.fit(cid_scores, true[:, cid].toarray().flatten())
-            pav_regressions[source_project.subjects[cid][0]] = reg
+            pav_regressions[cid] = reg
         self.info("created PAV model for {} concepts".format(
             len(pav_regressions)))
         model_filename = self.MODEL_FILE_PREFIX + source_project_id

--- a/annif/backend/pav.py
+++ b/annif/backend/pav.py
@@ -78,7 +78,7 @@ class PAVBackend(ensemble.BaseEnsembleBackend):
         ndocs = 0
         for docid, doc in enumerate(corpus.documents):
             hits = source_project.suggest(doc.text)
-            vector = hits.as_vector(source_project.subjects)
+            vector = hits.as_vector(len(source_project.subjects))
             for cid in np.flatnonzero(vector):
                 data.append(vector[cid])
                 row.append(docid)

--- a/annif/backend/stwfsa.py
+++ b/annif/backend/stwfsa.py
@@ -117,14 +117,10 @@ class StwfsaBackend(backend.AnnifBackend):
         suggestions = []
         for uri, score in result:
             subject_id = self.project.subjects.by_uri(uri)
-            if subject_id:
-                label = self.project.subjects[subject_id][1]
-            else:
-                label = None
+            if not subject_id:
+                continue
             suggestion = SubjectSuggestion(
-                uri,
-                label,
-                None,
-                score)
+                subject_id=subject_id,
+                score=score)
             suggestions.append(suggestion)
         return ListSuggestionResult(suggestions)

--- a/annif/backend/stwfsa.py
+++ b/annif/backend/stwfsa.py
@@ -25,7 +25,6 @@ _KEY_USE_TXT_VEC = 'use_txt_vec'
 class StwfsaBackend(backend.AnnifBackend):
 
     name = "stwfsa"
-    needs_subject_index = True
 
     STWFSA_PARAMETERS = {
         _KEY_CONCEPT_TYPE_URI: str,

--- a/annif/backend/stwfsa.py
+++ b/annif/backend/stwfsa.py
@@ -117,10 +117,7 @@ class StwfsaBackend(backend.AnnifBackend):
         suggestions = []
         for uri, score in result:
             subject_id = self.project.subjects.by_uri(uri)
-            if not subject_id:
-                continue
-            suggestion = SubjectSuggestion(
-                subject_id=subject_id,
-                score=score)
-            suggestions.append(suggestion)
+            if subject_id is not None:
+                suggestions.append(SubjectSuggestion(subject_id=subject_id,
+                                                     score=score))
         return ListSuggestionResult(suggestions)

--- a/annif/backend/svc.py
+++ b/annif/backend/svc.py
@@ -15,7 +15,6 @@ from . import mixins
 class SVCBackend(mixins.TfidfVectorizerMixin, backend.AnnifBackend):
     """Support vector classifier backend for Annif"""
     name = "svc"
-    needs_subject_index = True
 
     # defaults for uninitialized instances
     _model = None

--- a/annif/backend/svc.py
+++ b/annif/backend/svc.py
@@ -89,11 +89,8 @@ class SVCBackend(mixins.TfidfVectorizerMixin, backend.AnnifBackend):
             class_uri = self._model.classes_[class_id]
             subject_id = self.project.subjects.by_uri(class_uri)
             if subject_id is not None:
-                uri, label, notation = self.project.subjects[subject_id]
                 results.append(SubjectSuggestion(
-                    uri=uri,
-                    label=label,
-                    notation=notation,
+                    subject_id=subject_id,
                     score=scores[class_id]))
         return ListSuggestionResult(results)
 

--- a/annif/backend/tfidf.py
+++ b/annif/backend/tfidf.py
@@ -53,7 +53,6 @@ class SubjectBuffer:
 class TFIDFBackend(mixins.TfidfVectorizerMixin, backend.AnnifBackend):
     """TF-IDF vector space similarity based backend for Annif"""
     name = "tfidf"
-    needs_subject_index = True
 
     # defaults for uninitialized instances
     _index = None

--- a/annif/backend/yake.py
+++ b/annif/backend/yake.py
@@ -128,13 +128,10 @@ class YakeBackend(backend.AnnifBackend):
         suggestions = self._keyphrases2suggestions(keyphrases)
 
         subject_suggestions = [SubjectSuggestion(
-                uri=uri,
-                label=None,
-                notation=None,
+                subject_id=self.project.subjects.by_uri(uri),
                 score=score)
                 for uri, score in suggestions[:limit] if score > 0.0]
-        return ListSuggestionResult.create_from_index(subject_suggestions,
-                                                      self.project.subjects)
+        return ListSuggestionResult(subject_suggestions)
 
     def _keyphrases2suggestions(self, keyphrases):
         suggestions = []

--- a/annif/backend/yake.py
+++ b/annif/backend/yake.py
@@ -17,7 +17,6 @@ from annif.exception import ConfigurationException, NotSupportedException
 class YakeBackend(backend.AnnifBackend):
     """Yake based backend for Annif"""
     name = "yake"
-    needs_subject_index = False
 
     # defaults for uninitialized instances
     _index = None

--- a/annif/cli.py
+++ b/annif/cli.py
@@ -258,10 +258,11 @@ def run_suggest(project_id, limit, threshold, backend_param):
     hit_filter = SuggestionFilter(project.subjects, limit, threshold)
     hits = hit_filter(project.suggest(text, backend_params))
     for hit in hits.as_list(project.subjects):
+        subj = project.subjects[hit.subject_id]
         click.echo(
             "<{}>\t{}\t{}".format(
-                hit.uri,
-                '\t'.join(filter(None, (hit.label, hit.notation))),
+                subj.uri,
+                '\t'.join(filter(None, (subj.label, subj.notation))),
                 hit.score))
 
 
@@ -302,9 +303,10 @@ def run_index(project_id, directory, suffix, force,
         with open(subjectfilename, 'w', encoding='utf-8') as subjfile:
             results = project.suggest(text, backend_params)
             for hit in hit_filter(results).as_list(project.subjects):
+                subj = project.subjects[hit.subject_id]
                 line = "<{}>\t{}\t{}".format(
-                    hit.uri,
-                    '\t'.join(filter(None, (hit.label, hit.notation))),
+                    subj.uri,
+                    '\t'.join(filter(None, (subj.label, subj.notation))),
                     hit.score)
                 click.echo(line, file=subjfile)
 

--- a/annif/cli.py
+++ b/annif/cli.py
@@ -257,7 +257,7 @@ def run_suggest(project_id, limit, threshold, backend_param):
     backend_params = parse_backend_params(backend_param, project)
     hit_filter = SuggestionFilter(project.subjects, limit, threshold)
     hits = hit_filter(project.suggest(text, backend_params))
-    for hit in hits.as_list(project.subjects):
+    for hit in hits.as_list():
         subj = project.subjects[hit.subject_id]
         click.echo(
             "<{}>\t{}\t{}".format(
@@ -302,7 +302,7 @@ def run_index(project_id, directory, suffix, force,
             continue
         with open(subjectfilename, 'w', encoding='utf-8') as subjfile:
             results = project.suggest(text, backend_params)
-            for hit in hit_filter(results).as_list(project.subjects):
+            for hit in hit_filter(results).as_list():
                 subj = project.subjects[hit.subject_id]
                 line = "<{}>\t{}\t{}".format(
                     subj.uri,

--- a/annif/corpus/skos.py
+++ b/annif/corpus/skos.py
@@ -65,8 +65,7 @@ class SubjectFileSKOS(SubjectCorpus):
             if notation is not None:
                 notation = str(notation)
 
-            yield Subject(uri=str(concept), label=label, notation=notation,
-                          text=None)
+            yield Subject(uri=str(concept), label=label, notation=notation)
 
     @property
     def concepts(self):

--- a/annif/corpus/subject.py
+++ b/annif/corpus/subject.py
@@ -18,7 +18,7 @@ class SubjectFileTSV:
         clean_uri = annif.util.cleanup_uri(vals[0])
         label = vals[1] if len(vals) >= 2 else None
         notation = vals[2] if len(vals) >= 3 else None
-        yield Subject(uri=clean_uri, label=label, notation=notation, text=None)
+        yield Subject(uri=clean_uri, label=label, notation=notation)
 
     @property
     def languages(self):

--- a/annif/corpus/subject.py
+++ b/annif/corpus/subject.py
@@ -59,8 +59,9 @@ class SubjectIndex:
         return len(self._uris)
 
     def __getitem__(self, subject_id):
-        return (self._uris[subject_id], self._labels[subject_id],
-                self._notations[subject_id])
+        return Subject(uri=self._uris[subject_id],
+                       label=self._labels[subject_id],
+                       notation=self._notations[subject_id])
 
     def _append(self, subject_id, uri, label, notation):
         self._uris.append(uri)

--- a/annif/corpus/subject.py
+++ b/annif/corpus/subject.py
@@ -52,8 +52,7 @@ class SubjectIndex:
         in the given language."""
 
         for subject_id, subject in enumerate(corpus.subjects(language)):
-            self._append(subject_id, subject.uri, subject.label,
-                         subject.notation)
+            self._append(subject_id, subject)
 
     def __len__(self):
         return len(self._uris)
@@ -63,16 +62,16 @@ class SubjectIndex:
                        label=self._labels[subject_id],
                        notation=self._notations[subject_id])
 
-    def _append(self, subject_id, uri, label, notation):
-        self._uris.append(uri)
-        self._labels.append(label)
-        self._notations.append(notation)
-        self._uri_idx[uri] = subject_id
-        self._label_idx[label] = subject_id
+    def _append(self, subject_id, subject):
+        self._uris.append(subject.uri)
+        self._labels.append(subject.label)
+        self._notations.append(subject.notation)
+        self._uri_idx[subject.uri] = subject_id
+        self._label_idx[subject.label] = subject_id
 
-    def append(self, uri, label, notation):
+    def append(self, subject):
         subject_id = len(self._uris)
-        self._append(subject_id, uri, label, notation)
+        self._append(subject_id, subject)
 
     def contains_uri(self, uri):
         return uri in self._uri_idx

--- a/annif/corpus/subject.py
+++ b/annif/corpus/subject.py
@@ -99,7 +99,7 @@ class SubjectIndex:
         """return a list of labels corresponding to the given URIs; unknown
         URIs are ignored"""
 
-        return [self[subject_id][1]
+        return [self._labels[subject_id]
                 for subject_id in (self.by_uri(uri) for uri in uris)
                 if subject_id is not None]
 
@@ -107,7 +107,7 @@ class SubjectIndex:
         """return a list of URIs corresponding to the given labels; unknown
         labels are ignored"""
 
-        return [self[subject_id][0]
+        return [self._uris[subject_id]
                 for subject_id in (self.by_label(label) for label in labels)
                 if subject_id is not None]
 

--- a/annif/corpus/types.py
+++ b/annif/corpus/types.py
@@ -46,7 +46,7 @@ class DocumentCorpus(metaclass=abc.ABCMeta):
             return True
 
 
-Subject = collections.namedtuple('Subject', 'uri label notation text')
+Subject = collections.namedtuple('Subject', 'uri label notation')
 
 
 class SubjectCorpus(metaclass=abc.ABCMeta):

--- a/annif/eval.py
+++ b/annif/eval.py
@@ -218,7 +218,7 @@ class EvaluationBatch:
             gold_subjects.as_vector(self._subject_index,
                                     destination=y_true[idx],
                                     warnings=warnings)
-            hits.as_vector(self._subject_index, destination=y_pred[idx])
+            hits.as_vector(len(self._subject_index), destination=y_pred[idx])
 
         results = self._evaluate_samples(y_true, y_pred, metrics)
         results['Documents evaluated'] = int(y_true.shape[0])

--- a/annif/rest.py
+++ b/annif/rest.py
@@ -73,7 +73,7 @@ def suggest(project_id, text, limit, threshold):
         result = project.suggest(text)
     except AnnifException as err:
         return server_error(err)
-    hits = hit_filter(result).as_list(project.subjects)
+    hits = hit_filter(result).as_list()
     return {'results': [_suggestion_to_dict(hit, project.subjects)
                         for hit in hits]}
 

--- a/annif/rest.py
+++ b/annif/rest.py
@@ -48,6 +48,16 @@ def show_project(project_id):
     return project.dump()
 
 
+def _suggestion_to_dict(suggestion, subject_index):
+    subject = subject_index[suggestion.subject_id]
+    return {
+        'uri': subject.uri,
+        'label': subject.label,
+        'notation': subject.notation,
+        'score': suggestion.score
+    }
+
+
 def suggest(project_id, text, limit, threshold):
     """suggest subjects for the given text and return a dict with results
     formatted according to Swagger spec"""
@@ -64,7 +74,8 @@ def suggest(project_id, text, limit, threshold):
     except AnnifException as err:
         return server_error(err)
     hits = hit_filter(result).as_list(project.subjects)
-    return {'results': [hit._asdict() for hit in hits]}
+    return {'results': [_suggestion_to_dict(hit, project.subjects)
+                        for hit in hits]}
 
 
 def _documents_to_corpus(documents):

--- a/annif/suggestion.py
+++ b/annif/suggestion.py
@@ -165,18 +165,6 @@ class ListSuggestionResult(SuggestionResult):
             return hit._replace(score=1.0)
         return hit
 
-    @classmethod
-    def create_from_index(cls, hits, subject_index):
-        subject_suggestions = []
-        for hit in hits:
-            subject_id = subject_index.by_uri(hit.uri)
-            if subject_id is None:
-                continue
-            subject_suggestions.append(
-                SubjectSuggestion(subject_id=subject_id,
-                                  score=hit.score))
-        return ListSuggestionResult(subject_suggestions)
-
     def _list_to_vector(self, subject_index, destination):
         if destination is None:
             destination = np.zeros(len(subject_index), dtype=np.float32)

--- a/annif/suggestion.py
+++ b/annif/suggestion.py
@@ -38,11 +38,10 @@ class SuggestionResult(metaclass=abc.ABCMeta):
         pass  # pragma: no cover
 
     @abc.abstractmethod
-    def as_vector(self, subject_index, destination=None):
-        """Return the hits as a one-dimensional score vector
-        where the indexes match the given subject index. If destination array
-        is given (not None) it will be used, otherwise a new array will
-        be created."""
+    def as_vector(self, size, destination=None):
+        """Return the hits as a one-dimensional score vector of given size.
+        If destination array is given (not None) it will be used, otherwise a
+        new array will be created."""
         pass  # pragma: no cover
 
     @abc.abstractmethod
@@ -76,9 +75,9 @@ class LazySuggestionResult(SuggestionResult):
         self._initialize()
         return self._object.as_list()
 
-    def as_vector(self, subject_index, destination=None):
+    def as_vector(self, size, destination=None):
         self._initialize()
-        return self._object.as_vector(subject_index, destination)
+        return self._object.as_vector(size, destination)
 
     def filter(self, subject_index, limit=None, threshold=0.0):
         self._initialize()
@@ -122,7 +121,7 @@ class VectorSuggestionResult(SuggestionResult):
             self._lsr = self._vector_to_list_suggestion()
         return self._lsr.as_list()
 
-    def as_vector(self, subject_index, destination=None):
+    def as_vector(self, size, destination=None):
         if destination is not None:
             np.copyto(destination, self._vector)
             return destination
@@ -165,9 +164,9 @@ class ListSuggestionResult(SuggestionResult):
             return hit._replace(score=1.0)
         return hit
 
-    def _list_to_vector(self, subject_index, destination):
+    def _list_to_vector(self, size, destination):
         if destination is None:
-            destination = np.zeros(len(subject_index), dtype=np.float32)
+            destination = np.zeros(size, dtype=np.float32)
 
         for hit in self._list:
             if hit.subject_id is not None:
@@ -177,9 +176,9 @@ class ListSuggestionResult(SuggestionResult):
     def as_list(self):
         return self._list
 
-    def as_vector(self, subject_index, destination=None):
+    def as_vector(self, size, destination=None):
         if self._vector is None:
-            self._vector = self._list_to_vector(subject_index, destination)
+            self._vector = self._list_to_vector(size, destination)
         return self._vector
 
     def filter(self, subject_index, limit=None, threshold=0.0):

--- a/annif/suggestion.py
+++ b/annif/suggestion.py
@@ -7,7 +7,7 @@ import numpy as np
 
 
 SubjectSuggestion = collections.namedtuple(
-    'SubjectSuggestion', 'uri label notation score')
+    'SubjectSuggestion', 'subject_id score')
 WeightedSuggestion = collections.namedtuple(
     'WeightedSuggestion', 'hits weight subjects')
 
@@ -105,12 +105,9 @@ class VectorSuggestionResult(SuggestionResult):
             score = self._vector[subject_id]
             if score <= 0.0:
                 break  # we can skip the remaining ones
-            subject = subject_index[subject_id]
             hits.append(
                 SubjectSuggestion(
-                    uri=subject[0],
-                    label=subject[1],
-                    notation=subject[2],
+                    subject_id=subject_id,
                     score=float(score)))
         return ListSuggestionResult(hits)
 
@@ -175,11 +172,8 @@ class ListSuggestionResult(SuggestionResult):
             subject_id = subject_index.by_uri(hit.uri)
             if subject_id is None:
                 continue
-            subject = subject_index[subject_id]
             subject_suggestions.append(
-                SubjectSuggestion(uri=hit.uri,
-                                  label=subject[1],
-                                  notation=subject[2],
+                SubjectSuggestion(subject_id=subject_id,
                                   score=hit.score))
         return ListSuggestionResult(subject_suggestions)
 
@@ -188,9 +182,8 @@ class ListSuggestionResult(SuggestionResult):
             destination = np.zeros(len(subject_index), dtype=np.float32)
 
         for hit in self._list:
-            subject_id = subject_index.by_uri(hit.uri)
-            if subject_id is not None:
-                destination[subject_id] = hit.score
+            if hit.subject_id is not None:
+                destination[hit.subject_id] = hit.score
         return destination
 
     def as_list(self, subject_index):
@@ -205,7 +198,7 @@ class ListSuggestionResult(SuggestionResult):
         hits = sorted(self._list, key=lambda hit: hit.score, reverse=True)
         filtered_hits = [hit for hit in hits
                          if hit.score >= threshold and hit.score > 0.0 and
-                         hit.label is not None]
+                         hit.subject_id is not None]
         if limit is not None:
             filtered_hits = filtered_hits[:limit]
         return ListSuggestionResult(filtered_hits)

--- a/annif/suggestion.py
+++ b/annif/suggestion.py
@@ -32,7 +32,7 @@ class SuggestionResult(metaclass=abc.ABCMeta):
     operation."""
 
     @abc.abstractmethod
-    def as_list(self, subject_index):
+    def as_list(self):
         """Return the hits as an ordered sequence of SubjectSuggestion objects,
         highest scores first."""
         pass  # pragma: no cover
@@ -72,9 +72,9 @@ class LazySuggestionResult(SuggestionResult):
         if self._object is None:
             self._object = self._construct()
 
-    def as_list(self, subject_index):
+    def as_list(self):
         self._initialize()
-        return self._object.as_list(subject_index)
+        return self._object.as_list()
 
     def as_vector(self, subject_index, destination=None):
         self._initialize()
@@ -99,7 +99,7 @@ class VectorSuggestionResult(SuggestionResult):
         self._subject_order = None
         self._lsr = None
 
-    def _vector_to_list_suggestion(self, subject_index):
+    def _vector_to_list_suggestion(self):
         hits = []
         for subject_id in self.subject_order:
             score = self._vector[subject_id]
@@ -117,10 +117,10 @@ class VectorSuggestionResult(SuggestionResult):
             self._subject_order = np.argsort(self._vector)[::-1]
         return self._subject_order
 
-    def as_list(self, subject_index):
+    def as_list(self):
         if self._lsr is None:
-            self._lsr = self._vector_to_list_suggestion(subject_index)
-        return self._lsr.as_list(subject_index)
+            self._lsr = self._vector_to_list_suggestion()
+        return self._lsr.as_list()
 
     def as_vector(self, subject_index, destination=None):
         if destination is not None:
@@ -144,7 +144,7 @@ class VectorSuggestionResult(SuggestionResult):
             deprecated_mask[deprecated_ids] = False
             mask = mask & deprecated_mask
         vsr = VectorSuggestionResult(self._vector * mask)
-        return ListSuggestionResult(vsr.as_list(subject_index))
+        return ListSuggestionResult(vsr.as_list())
 
     def __len__(self):
         return (self._vector > 0.0).sum()
@@ -174,7 +174,7 @@ class ListSuggestionResult(SuggestionResult):
                 destination[hit.subject_id] = hit.score
         return destination
 
-    def as_list(self, subject_index):
+    def as_list(self):
         return self._list
 
     def as_vector(self, subject_index, destination=None):

--- a/annif/util.py
+++ b/annif/util.py
@@ -37,13 +37,13 @@ def cleanup_uri(uri):
     return uri
 
 
-def merge_hits(weighted_hits, subject_index):
+def merge_hits(weighted_hits, size):
     """Merge hits from multiple sources. Input is a sequence of WeightedSuggestion
-    objects. A SubjectIndex is needed to convert between subject IDs and URIs.
+    objects. The size parameter determines the length of the subject vector.
     Returns an SuggestionResult object."""
 
     weights = [whit.weight for whit in weighted_hits]
-    scores = [whit.hits.as_vector(subject_index) for whit in weighted_hits]
+    scores = [whit.hits.as_vector(size) for whit in weighted_hits]
     result = np.average(scores, axis=0, weights=weights)
     return VectorSuggestionResult(result)
 

--- a/annif/vocab.py
+++ b/annif/vocab.py
@@ -53,15 +53,18 @@ class AnnifVocabulary(DatadirMixin):
         new_subjects.load_subjects(subject_corpus, language)
         updated_subjects = annif.corpus.SubjectIndex()
 
-        for uri, label, notation in old_subjects:
-            if new_subjects.contains_uri(uri):
-                label, notation = new_subjects[new_subjects.by_uri(uri)][1:3]
+        for old_subject in old_subjects:
+            if new_subjects.contains_uri(old_subject.uri):
+                new_subject = new_subjects[new_subjects.by_uri(
+                    old_subject.uri)]
             else:  # subject removed from new corpus
-                label, notation = None, None
-            updated_subjects.append(uri, label, notation)
-        for uri, label, notation in new_subjects:
-            if not old_subjects.contains_uri(uri):
-                updated_subjects.append(uri, label, notation)
+                new_subject = annif.corpus.Subject(uri=old_subject.uri,
+                                                   label=None,
+                                                   notation=None)
+            updated_subjects.append(new_subject)
+        for new_subject in new_subjects:
+            if not old_subjects.contains_uri(new_subject.uri):
+                updated_subjects.append(new_subject)
         annif.util.atomic_save(updated_subjects, self.datadir,
                                self._index_filename(language))
         return updated_subjects

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -75,6 +75,13 @@ def subject_file():
 
 
 @pytest.fixture(scope='module')
+def dummy_subject_index(testdatadir):
+    """a fixture to access the subject index of the dummy vocabulary"""
+    vocab = annif.vocab.AnnifVocabulary('dummy', testdatadir, 'en')
+    return vocab.subjects
+
+
+@pytest.fixture(scope='module')
 def vocabulary(datadir):
     vocab = annif.vocab.AnnifVocabulary('my-vocab', datadir, 'fi')
     subjfile = os.path.join(

--- a/tests/corpora/dummy-subjects.tsv
+++ b/tests/corpora/dummy-subjects.tsv
@@ -1,2 +1,2 @@
 <http://example.org/dummy>	dummy
-<http://example.org/none>	none
+<http://example.org/none>	none	42.42

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -12,15 +12,15 @@ def test_get_backend_nonexistent():
         annif.backend.get_backend("nonexistent")
 
 
-def test_get_backend_dummy(project):
+def test_get_backend_dummy(project, dummy_subject_index):
     dummy_type = annif.backend.get_backend("dummy")
     dummy = dummy_type(backend_id='dummy', config_params={},
                        project=project)
     result = dummy.suggest(text='this is some text')
     assert len(result) == 1
     hits = result.as_list(project.subjects)
-    assert hits[0].uri == 'http://example.org/dummy'
-    assert hits[0].label == 'dummy'
+    assert hits[0].subject_id == dummy_subject_index.by_uri(
+        'http://example.org/dummy')
     assert hits[0].score == 1.0
 
 
@@ -30,9 +30,10 @@ def test_learn_dummy(project, tmpdir):
                        project=project)
 
     tmpdir.join('doc1.txt').write('doc1')
-    tmpdir.join('doc1.tsv').write('<http://example.org/key1>\tkey1')
+    tmpdir.join('doc1.tsv').write(
+        '<http://www.yso.fi/onto/yso/p10849>\tarchaeologists')
     tmpdir.join('doc2.txt').write('doc2')
-    tmpdir.join('doc2.tsv').write('<http://example.org/key2>\tkey2')
+    tmpdir.join('doc2.tsv').write('<http://example.org/dummy>\tdummy')
     docdir = annif.corpus.DocumentDirectory(str(tmpdir))
 
     dummy.learn(docdir)
@@ -40,8 +41,9 @@ def test_learn_dummy(project, tmpdir):
     result = dummy.suggest(text='this is some text')
     assert len(result) == 1
     hits = result.as_list(project.subjects)
-    assert hits[0].uri == 'http://example.org/key1'
-    assert hits[0].label == 'key1'
+    assert hits[0].subject_id is not None
+    assert hits[0].subject_id == project.subjects.by_uri(
+        'http://www.yso.fi/onto/yso/p10849')
     assert hits[0].score == 1.0
 
 

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -18,7 +18,7 @@ def test_get_backend_dummy(project, dummy_subject_index):
                        project=project)
     result = dummy.suggest(text='this is some text')
     assert len(result) == 1
-    hits = result.as_list(project.subjects)
+    hits = result.as_list()
     assert hits[0].subject_id == dummy_subject_index.by_uri(
         'http://example.org/dummy')
     assert hits[0].score == 1.0
@@ -40,7 +40,7 @@ def test_learn_dummy(project, tmpdir):
 
     result = dummy.suggest(text='this is some text')
     assert len(result) == 1
-    hits = result.as_list(project.subjects)
+    hits = result.as_list()
     assert hits[0].subject_id is not None
     assert hits[0].subject_id == project.subjects.by_uri(
         'http://www.yso.fi/onto/yso/p10849')

--- a/tests/test_backend_fasttext.py
+++ b/tests/test_backend_fasttext.py
@@ -200,6 +200,6 @@ def test_fasttext_suggest(project):
         pohjaan.""")
 
     assert len(results) > 0
-    hits = results.as_list(project.subjects)
+    hits = results.as_list()
     archaeology = project.subjects.by_uri('http://www.yso.fi/onto/yso/p1265')
     assert archaeology in [result.subject_id for result in hits]

--- a/tests/test_backend_fasttext.py
+++ b/tests/test_backend_fasttext.py
@@ -201,6 +201,5 @@ def test_fasttext_suggest(project):
 
     assert len(results) > 0
     hits = results.as_list(project.subjects)
-    assert 'http://www.yso.fi/onto/yso/p1265' in [
-        result.uri for result in hits]
-    assert 'arkeologia' in [result.label for result in hits]
+    archaeology = project.subjects.by_uri('http://www.yso.fi/onto/yso/p1265')
+    assert archaeology in [result.subject_id for result in hits]

--- a/tests/test_backend_http.py
+++ b/tests/test_backend_http.py
@@ -27,7 +27,7 @@ def test_http_suggest(app_project):
             project=app_project)
         result = http.suggest('this is some text')
         assert len(result) == 1
-        hits = result.as_list(app_project.subjects)
+        hits = result.as_list()
         assert hits[0].subject_id is not None
         assert hits[0].subject_id == app_project.subjects.by_uri(
             'http://example.org/dummy')
@@ -56,7 +56,7 @@ def test_http_suggest_with_results(app_project):
 
         result = http.suggest('this is some text')
         assert len(result) == 1
-        hits = result.as_list(app_project.subjects)
+        hits = result.as_list()
         assert hits[0].subject_id is not None
         assert hits[0].subject_id == http.project.subjects.by_uri(
             'http://example.org/dummy-with-notation')

--- a/tests/test_backend_http.py
+++ b/tests/test_backend_http.py
@@ -28,10 +28,10 @@ def test_http_suggest(app_project):
         result = http.suggest('this is some text')
         assert len(result) == 1
         hits = result.as_list(app_project.subjects)
-        assert hits[0].uri == 'http://example.org/dummy'
-        assert hits[0].label == 'dummy'
+        assert hits[0].subject_id is not None
+        assert hits[0].subject_id == app_project.subjects.by_uri(
+            'http://example.org/dummy')
         assert hits[0].score == 1.0
-        assert hits[0].notation is None
 
 
 def test_http_suggest_with_results(app_project):
@@ -57,10 +57,10 @@ def test_http_suggest_with_results(app_project):
         result = http.suggest('this is some text')
         assert len(result) == 1
         hits = result.as_list(app_project.subjects)
-        assert hits[0].uri == 'http://example.org/dummy-with-notation'
-        assert hits[0].label == 'dummy'
+        assert hits[0].subject_id is not None
+        assert hits[0].subject_id == http.project.subjects.by_uri(
+            'http://example.org/dummy-with-notation')
         assert hits[0].score == 1.0
-        assert hits[0].notation == '42.42'
 
 
 def test_http_suggest_zero_score(project):

--- a/tests/test_backend_http.py
+++ b/tests/test_backend_http.py
@@ -6,6 +6,7 @@ import requests.exceptions
 import unittest.mock
 import annif.backend.http
 from annif.exception import OperationFailedException
+from annif.corpus import Subject
 
 
 def test_http_suggest(app_project):
@@ -51,8 +52,10 @@ def test_http_suggest_with_results(app_project):
                 'endpoint': 'http://api.example.org/dummy/analyze',
             },
             project=app_project)
-        http.project.subjects.append(
-            'http://example.org/dummy-with-notation', 'dummy', '42.42')
+        http.project.subjects.append(Subject(
+            uri='http://example.org/dummy-with-notation',
+            label='dummy',
+            notation='42.42'))
 
         result = http.suggest('this is some text')
         assert len(result) == 1

--- a/tests/test_backend_mllm.py
+++ b/tests/test_backend_mllm.py
@@ -89,9 +89,8 @@ def test_mllm_suggest(project):
     assert len(results) > 0
     assert len(results) <= 8
     hits = results.as_list(project.subjects)
-    assert 'http://www.yso.fi/onto/yso/p1265' in [
-        result.uri for result in hits]
-    assert 'arkeologia' in [result.label for result in hits]
+    archaeology = project.subjects.by_uri('http://www.yso.fi/onto/yso/p1265')
+    assert archaeology in [result.subject_id for result in hits]
 
 
 def test_mllm_suggest_no_matches(project):

--- a/tests/test_backend_mllm.py
+++ b/tests/test_backend_mllm.py
@@ -88,7 +88,7 @@ def test_mllm_suggest(project):
 
     assert len(results) > 0
     assert len(results) <= 8
-    hits = results.as_list(project.subjects)
+    hits = results.as_list()
     archaeology = project.subjects.by_uri('http://www.yso.fi/onto/yso/p1265')
     assert archaeology in [result.subject_id for result in hits]
 

--- a/tests/test_backend_omikuji.py
+++ b/tests/test_backend_omikuji.py
@@ -151,7 +151,7 @@ def test_omikuji_suggest(project):
 
     assert len(results) > 0
     assert len(results) <= 8
-    hits = results.as_list(project.subjects)
+    hits = results.as_list()
     archaeology = project.subjects.by_uri('http://www.yso.fi/onto/yso/p1265')
     assert archaeology in [result.subject_id for result in hits]
 

--- a/tests/test_backend_omikuji.py
+++ b/tests/test_backend_omikuji.py
@@ -152,9 +152,8 @@ def test_omikuji_suggest(project):
     assert len(results) > 0
     assert len(results) <= 8
     hits = results.as_list(project.subjects)
-    assert 'http://www.yso.fi/onto/yso/p1265' in [
-        result.uri for result in hits]
-    assert 'arkeologia' in [result.label for result in hits]
+    archaeology = project.subjects.by_uri('http://www.yso.fi/onto/yso/p1265')
+    assert archaeology in [result.subject_id for result in hits]
 
 
 def test_omikuji_suggest_no_input(project):

--- a/tests/test_backend_stwfsa.py
+++ b/tests/test_backend_stwfsa.py
@@ -119,6 +119,5 @@ def test_stwfsa_suggest(project, datadir):
     termoluminesenssi random random random""")
     assert len(results) == 10
     hits = results.as_list(project.subjects)
-    assert 'http://www.yso.fi/onto/yso/p14174' in [
-        result.uri for result in hits]
-    assert 'labyrintit' in [result.label for result in hits]
+    labyrinths = project.subjects.by_uri('http://www.yso.fi/onto/yso/p14174')
+    assert labyrinths in [result.subject_id for result in hits]

--- a/tests/test_backend_stwfsa.py
+++ b/tests/test_backend_stwfsa.py
@@ -118,6 +118,6 @@ def test_stwfsa_suggest(project, datadir):
     zikkuratit random random
     termoluminesenssi random random random""")
     assert len(results) == 10
-    hits = results.as_list(project.subjects)
+    hits = results.as_list()
     labyrinths = project.subjects.by_uri('http://www.yso.fi/onto/yso/p14174')
     assert labyrinths in [result.subject_id for result in hits]

--- a/tests/test_backend_svc.py
+++ b/tests/test_backend_svc.py
@@ -94,9 +94,9 @@ def test_svc_suggest(project):
     assert len(results) > 0
     assert len(results) <= 20
     hits = results.as_list(project.subjects)
-    assert 'http://www.yso.fi/onto/yso/p10849' in [
-        result.uri for result in hits]
-    assert 'arkeologit' in [result.label for result in hits]
+    archaeologists = project.subjects.by_uri(
+        'http://www.yso.fi/onto/yso/p10849')
+    assert archaeologists in [result.subject_id for result in hits]
 
 
 def test_svc_suggest_no_input(project):

--- a/tests/test_backend_svc.py
+++ b/tests/test_backend_svc.py
@@ -93,7 +93,7 @@ def test_svc_suggest(project):
 
     assert len(results) > 0
     assert len(results) <= 20
-    hits = results.as_list(project.subjects)
+    hits = results.as_list()
     archaeologists = project.subjects.by_uri(
         'http://www.yso.fi/onto/yso/p10849')
     assert archaeologists in [result.subject_id for result in hits]

--- a/tests/test_backend_tfidf.py
+++ b/tests/test_backend_tfidf.py
@@ -48,7 +48,7 @@ def test_tfidf_suggest(project):
         pohjaan.""")
 
     assert len(results) == 10
-    hits = results.as_list(project.subjects)
+    hits = results.as_list()
     archaeology = project.subjects.by_uri('http://www.yso.fi/onto/yso/p1265')
     assert archaeology in [result.subject_id for result in hits]
 

--- a/tests/test_backend_tfidf.py
+++ b/tests/test_backend_tfidf.py
@@ -49,9 +49,8 @@ def test_tfidf_suggest(project):
 
     assert len(results) == 10
     hits = results.as_list(project.subjects)
-    assert 'http://www.yso.fi/onto/yso/p1265' in [
-        result.uri for result in hits]
-    assert 'arkeologia' in [result.label for result in hits]
+    archaeology = project.subjects.by_uri('http://www.yso.fi/onto/yso/p1265')
+    assert archaeology in [result.subject_id for result in hits]
 
 
 def test_suggest_params(project):

--- a/tests/test_backend_yake.py
+++ b/tests/test_backend_yake.py
@@ -35,9 +35,8 @@ def test_yake_suggest(project):
     assert len(results) > 0
     assert len(results) <= 8
     hits = results.as_list()
-    assert 'http://www.yso.fi/onto/yso/p1265' in [
-        result.uri for result in hits]
-    assert 'arkeologia' in [result.label for result in hits]
+    archaeology = project.subjects.by_uri('http://www.yso.fi/onto/yso/p1265')
+    assert archaeology in [result.subject_id for result in hits]
 
 
 def test_yake_suggest_no_input(project):

--- a/tests/test_backend_yake.py
+++ b/tests/test_backend_yake.py
@@ -34,7 +34,7 @@ def test_yake_suggest(project):
 
     assert len(results) > 0
     assert len(results) <= 8
-    hits = results.as_list(project.subjects)
+    hits = results.as_list()
     assert 'http://www.yso.fi/onto/yso/p1265' in [
         result.uri for result in hits]
     assert 'arkeologia' in [result.label for result in hits]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -341,10 +341,11 @@ def test_suggest():
 def test_suggest_with_notations():
     result = runner.invoke(
         annif.cli.cli,
-        ['suggest', '--backend-param', 'dummy.notation=42.42', 'dummy-fi'],
+        ['suggest',
+         '--backend-param', 'dummy.uri=http://example.org/none', 'dummy-fi'],
         input='kissa')
     assert not result.exception
-    assert result.output == "<http://example.org/dummy>\tdummy\t42.42\t1.0\n"
+    assert result.output == "<http://example.org/none>\tnone\t42.42\t1.0\n"
     assert result.exit_code == 0
 
 

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -99,17 +99,17 @@ def test_evaluation_batch(subject_index):
     gold_set = annif.corpus.SubjectSet.from_string(
         '<http://www.yso.fi/onto/yso/p10849>\tarkeologit')
     hits1 = annif.suggestion.ListSuggestionResult([
+        # subject: archaeologists (yso:p10849)
         annif.suggestion.SubjectSuggestion(
-            uri='http://www.yso.fi/onto/yso/p10849',
-            label='arkeologit',
-            notation=None,
+            subject_id=subject_index.by_uri(
+                'http://www.yso.fi/onto/yso/p10849'),
             score=1.0)])
     batch.evaluate(hits1, gold_set)
     hits2 = annif.suggestion.ListSuggestionResult([
+        # subject: egyptologists (yso:p1747)
         annif.suggestion.SubjectSuggestion(
-            uri='http://www.yso.fi/onto/yso/p1747',
-            label='egyptologit',
-            notation=None,
+            subject_id=subject_index.by_uri(
+                'http://www.yso.fi/onto/yso/p1747'),
             score=1.0)])
     batch.evaluate(hits2, gold_set)
     results = batch.results()

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -165,9 +165,9 @@ def test_project_train_tfidf_nodocuments(registry, empty_corpus):
 
 def test_project_learn(registry, tmpdir):
     tmpdir.join('doc1.txt').write('doc1')
-    tmpdir.join('doc1.tsv').write('<http://example.org/key1>\tkey1')
+    tmpdir.join('doc1.tsv').write('<http://example.org/none>\tnone')
     tmpdir.join('doc2.txt').write('doc2')
-    tmpdir.join('doc2.tsv').write('<http://example.org/key2>\tkey2')
+    tmpdir.join('doc2.tsv').write('<http://example.org/dummy>\tdummy')
     docdir = annif.corpus.DocumentDirectory(str(tmpdir))
 
     project = registry.get_project('dummy-fi')
@@ -175,8 +175,8 @@ def test_project_learn(registry, tmpdir):
     result = project.suggest('this is some text')
     assert len(result) == 1
     hits = result.as_list(project.subjects)
-    assert hits[0].uri == 'http://example.org/key1'
-    assert hits[0].label == 'key1'
+    assert hits[0].subject_id == project.subjects.by_uri(
+        'http://example.org/none')
     assert hits[0].score == 1.0
 
 
@@ -213,8 +213,8 @@ def test_project_suggest(registry):
     result = project.suggest('this is some text')
     assert len(result) == 1
     hits = result.as_list(project.subjects)
-    assert hits[0].uri == 'http://example.org/dummy'
-    assert hits[0].label == 'dummy'
+    assert hits[0].subject_id == project.subjects.by_uri(
+        'http://example.org/dummy')
     assert hits[0].score == 1.0
 
 
@@ -223,8 +223,8 @@ def test_project_suggest_combine(registry):
     result = project.suggest('this is some text')
     assert len(result) == 1
     hits = result.as_list(project.subjects)
-    assert hits[0].uri == 'http://example.org/dummy'
-    assert hits[0].label == 'dummy'
+    assert hits[0].subject_id == project.subjects.by_uri(
+        'http://example.org/dummy')
     assert hits[0].score == 1.0
 
 
@@ -236,8 +236,8 @@ def test_project_train_state_not_available(registry, caplog):
     assert project.is_trained is None
     assert len(result) == 1
     hits = result.as_list(project.subjects)
-    assert hits[0].uri == 'http://example.org/dummy'
-    assert hits[0].label == 'dummy'
+    assert hits[0].subject_id == project.subjects.by_uri(
+        'http://example.org/dummy')
     assert hits[0].score == 1.0
     assert 'Could not get train state information' in caplog.text
 

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -174,7 +174,7 @@ def test_project_learn(registry, tmpdir):
     project.learn(docdir)
     result = project.suggest('this is some text')
     assert len(result) == 1
-    hits = result.as_list(project.subjects)
+    hits = result.as_list()
     assert hits[0].subject_id == project.subjects.by_uri(
         'http://example.org/none')
     assert hits[0].score == 1.0
@@ -212,7 +212,7 @@ def test_project_suggest(registry):
     project = registry.get_project('dummy-en')
     result = project.suggest('this is some text')
     assert len(result) == 1
-    hits = result.as_list(project.subjects)
+    hits = result.as_list()
     assert hits[0].subject_id == project.subjects.by_uri(
         'http://example.org/dummy')
     assert hits[0].score == 1.0
@@ -222,7 +222,7 @@ def test_project_suggest_combine(registry):
     project = registry.get_project('dummydummy')
     result = project.suggest('this is some text')
     assert len(result) == 1
-    hits = result.as_list(project.subjects)
+    hits = result.as_list()
     assert hits[0].subject_id == project.subjects.by_uri(
         'http://example.org/dummy')
     assert hits[0].score == 1.0
@@ -235,7 +235,7 @@ def test_project_train_state_not_available(registry, caplog):
         result = project.suggest('this is some text')
     assert project.is_trained is None
     assert len(result) == 1
-    hits = result.as_list(project.subjects)
+    hits = result.as_list()
     assert hits[0].subject_id == project.subjects.by_uri(
         'http://example.org/dummy')
     assert hits[0].score == 1.0

--- a/tests/test_rest.py
+++ b/tests/test_rest.py
@@ -115,8 +115,8 @@ def test_rest_learn_empty(app):
 
 def test_rest_learn(app):
     documents = [{'text': 'the quick brown fox',
-                  'subjects': [{'uri': 'http://example.org/fox',
-                                'label': 'fox'}]}]
+                  'subjects': [{'uri': 'http://example.org/none',
+                                'label': 'none'}]}]
     with app.app_context():
         response = annif.rest.learn('dummy-en', documents)
         assert response == (None, 204)  # success, no output
@@ -127,8 +127,8 @@ def test_rest_learn(app):
             limit=10,
             threshold=0.0)
         assert 'results' in result
-        assert result['results'][0]['uri'] == 'http://example.org/fox'
-        assert result['results'][0]['label'] == 'fox'
+        assert result['results'][0]['uri'] == 'http://example.org/none'
+        assert result['results'][0]['label'] == 'none'
 
 
 def test_rest_learn_novocab(app):

--- a/tests/test_suggestion.py
+++ b/tests/test_suggestion.py
@@ -91,7 +91,7 @@ def test_lazy_suggestion_result(subject_index):
     assert lsr._object is None
     assert len(lsr) == 10
     assert len(lsr.as_list()) == 10
-    assert lsr.as_vector(subject_index) is not None
+    assert lsr.as_vector(len(subject_index)) is not None
     assert lsr.as_list()[0] is not None
     filtered = lsr.filter(subject_index, limit=5, threshold=0.0)
     assert len(filtered) == 5
@@ -111,7 +111,7 @@ def test_list_suggestion_result_vector(subject_index):
                 subject_id=subject_index.by_uri(
                     'http://www.yso.fi/onto/yso/p6479'),
                 score=0.5)])
-    vector = suggestions.as_vector(subject_index)
+    vector = suggestions.as_vector(len(subject_index))
     assert isinstance(vector, np.ndarray)
     assert len(vector) == len(subject_index)
     assert vector.sum() == 1.5
@@ -152,7 +152,7 @@ def test_list_suggestions_vector_enforce_score_range(subject_index):
                 subject_id=subject_index.by_uri(
                     'http://www.yso.fi/onto/yso/p12738'),
                 score=-0.5)])
-    vector = suggestions.as_vector(subject_index)
+    vector = suggestions.as_vector(len(subject_index))
     assert vector.sum() == 2.5
     for subject_id, score in enumerate(vector):
         if subject_index[subject_id][1] == 'sinetit':
@@ -177,7 +177,8 @@ def test_list_suggestion_result_vector_destination(subject_index):
                     'http://www.yso.fi/onto/yso/p6479'),
                 score=0.5)])
     destination = np.zeros(len(subject_index), dtype=np.float32)
-    vector = suggestions.as_vector(subject_index, destination=destination)
+    vector = suggestions.as_vector(len(subject_index),
+                                   destination=destination)
     assert vector is destination
 
 
@@ -188,20 +189,20 @@ def test_list_suggestion_result_vector_notfound(subject_index):
                 subject_id=subject_index.by_uri(
                     'http://example.com/notfound'),
                 score=1.0)])
-    assert suggestions.as_vector(subject_index).sum() == 0
+    assert suggestions.as_vector(len(subject_index)).sum() == 0
 
 
 def test_vector_suggestion_result_as_vector(subject_index):
     orig_vector = np.ones(len(subject_index), dtype=np.float32)
     suggestions = VectorSuggestionResult(orig_vector)
-    vector = suggestions.as_vector(subject_index)
+    vector = suggestions.as_vector(len(subject_index))
     assert (vector == orig_vector).all()
 
 
 def test_vector_suggestions_enforce_score_range(subject_index):
     orig_vector = np.array([-0.1, 0.0, 0.5, 1.0, 1.5], dtype=np.float32)
     suggestions = VectorSuggestionResult(orig_vector)
-    vector = suggestions.as_vector(subject_index)
+    vector = suggestions.as_vector(len(subject_index))
     expected = np.array([0.0, 0.0, 0.5, 1.0, 1.0], dtype=np.float32)
     assert (vector == expected).all()
 
@@ -212,6 +213,7 @@ def test_vector_suggestion_result_as_vector_destination(subject_index):
     destination = np.zeros(len(subject_index), dtype=np.float32)
     assert not (destination == orig_vector).all()  # destination is all zeros
 
-    vector = suggestions.as_vector(subject_index, destination=destination)
+    vector = suggestions.as_vector(len(subject_index),
+                                   destination=destination)
     assert vector is destination
     assert (destination == orig_vector).all()      # destination now all ones

--- a/tests/test_suggestion.py
+++ b/tests/test_suggestion.py
@@ -60,10 +60,8 @@ def test_hitfilter_list_suggestion_results_with_deprecated_subjects(
     filtered_suggestions = SuggestionFilter(subject_index)(suggestions)
     assert isinstance(filtered_suggestions, SuggestionResult)
     assert len(filtered_suggestions) == 2
-    assert filtered_suggestions.as_list(
-        subject_index)[0] == suggestions.as_list(subject_index)[0]
-    assert filtered_suggestions.as_list(
-        subject_index)[1] == suggestions.as_list(subject_index)[1]
+    assert filtered_suggestions.as_list()[0] == suggestions.as_list()[0]
+    assert filtered_suggestions.as_list()[1] == suggestions.as_list()[1]
 
 
 def test_hitfilter_vector_suggestion_results_with_deprecated_subjects(
@@ -79,17 +77,17 @@ def test_hitfilter_vector_suggestion_results_with_deprecated_subjects(
     deprecated_id = subject_index.by_uri('http://example.org/deprecated')
     deprecated = SubjectSuggestion(subject_id=deprecated_id, score=1.0)
 
-    assert deprecated in suggestions.as_list(subject_index)
-    assert deprecated not in filtered_suggestions.as_list(subject_index)
+    assert deprecated in suggestions.as_list()
+    assert deprecated not in filtered_suggestions.as_list()
 
 
 def test_lazy_suggestion_result(subject_index):
     lsr = LazySuggestionResult(lambda: generate_suggestions(10, subject_index))
     assert lsr._object is None
     assert len(lsr) == 10
-    assert len(lsr.as_list(subject_index)) == 10
+    assert len(lsr.as_list()) == 10
     assert lsr.as_vector(subject_index) is not None
-    assert lsr.as_list(subject_index)[0] is not None
+    assert lsr.as_list()[0] is not None
     filtered = lsr.filter(subject_index, limit=5, threshold=0.0)
     assert len(filtered) == 5
     assert lsr._object is not None

--- a/tests/test_suggestion.py
+++ b/tests/test_suggestion.py
@@ -3,6 +3,7 @@
 from annif.suggestion import SubjectSuggestion, SuggestionResult, \
     LazySuggestionResult, ListSuggestionResult, VectorSuggestionResult, \
     SuggestionFilter
+from annif.corpus import Subject
 import numpy as np
 
 
@@ -40,7 +41,9 @@ def test_hitfilter_zero_score(subject_index):
 
 def test_hitfilter_list_suggestion_results_with_deprecated_subjects(
         subject_index):
-    subject_index.append('http://example.org/deprecated', None, None)
+    subject_index.append(Subject(uri='http://example.org/deprecated',
+                                 label=None,
+                                 notation=None))
     suggestions = ListSuggestionResult(
         [
             # subject: seals (labels)
@@ -66,7 +69,9 @@ def test_hitfilter_list_suggestion_results_with_deprecated_subjects(
 
 def test_hitfilter_vector_suggestion_results_with_deprecated_subjects(
         subject_index):
-    subject_index.append('http://example.org/deprecated', None, None)
+    subject_index.append(Subject(uri='http://example.org/deprecated',
+                                 label=None,
+                                 notation=None))
     vector = np.ones(len(subject_index))
     suggestions = VectorSuggestionResult(vector)
     filtered_suggestions = SuggestionFilter(subject_index)(suggestions)

--- a/tests/test_suggestion.py
+++ b/tests/test_suggestion.py
@@ -9,10 +9,7 @@ import numpy as np
 def generate_suggestions(n, subject_index):
     suggestions = []
     for i in range(n):
-        uri = 'http://example.org/{}'.format(i)
-        suggestions.append(SubjectSuggestion(uri=uri,
-                                             label='hit {}'.format(i),
-                                             notation=None,
+        suggestions.append(SubjectSuggestion(subject_id=i,
                                              score=1.0 / (i + 1)))
     return ListSuggestionResult(suggestions)
 
@@ -34,7 +31,7 @@ def test_hitfilter_threshold(subject_index):
 
 def test_hitfilter_zero_score(subject_index):
     origsuggestions = ListSuggestionResult(
-        [SubjectSuggestion(uri='uri', label='label', notation=None,
+        [SubjectSuggestion(subject_id=0,
                            score=0.0)])
     suggestions = SuggestionFilter(subject_index)(origsuggestions)
     assert isinstance(suggestions, SuggestionResult)
@@ -46,20 +43,19 @@ def test_hitfilter_list_suggestion_results_with_deprecated_subjects(
     subject_index.append('http://example.org/deprecated', None, None)
     suggestions = ListSuggestionResult(
         [
+            # subject: seals (labels)
             SubjectSuggestion(
-                uri='http://www.yso.fi/onto/yso/p7141',
-                label='sinetit',
-                notation=None,
+                subject_id=subject_index.by_uri(
+                    'http://www.yso.fi/onto/yso/p7141'),
                 score=1.0),
+            # subject: Vikings
             SubjectSuggestion(
-                uri='http://www.yso.fi/onto/yso/p6479',
-                label='viikingit',
-                notation=None,
+                subject_id=subject_index.by_uri(
+                    'http://www.yso.fi/onto/yso/p6479'),
                 score=0.5),
+            # a deprecated subject
             SubjectSuggestion(
-                uri='http://example.org/deprecated',
-                label=None,
-                notation=None,
+                subject_id=None,
                 score=0.5)])
     filtered_suggestions = SuggestionFilter(subject_index)(suggestions)
     assert isinstance(filtered_suggestions, SuggestionResult)
@@ -80,11 +76,9 @@ def test_hitfilter_vector_suggestion_results_with_deprecated_subjects(
     assert len(suggestions) == len(filtered_suggestions) \
         + len(subject_index.deprecated_ids())
 
-    deprecated = SubjectSuggestion(
-        uri='http://example.org/deprecated',
-        label=None,
-        notation=None,
-        score=1.0)
+    deprecated_id = subject_index.by_uri('http://example.org/deprecated')
+    deprecated = SubjectSuggestion(subject_id=deprecated_id, score=1.0)
+
     assert deprecated in suggestions.as_list(subject_index)
     assert deprecated not in filtered_suggestions.as_list(subject_index)
 
@@ -104,15 +98,15 @@ def test_lazy_suggestion_result(subject_index):
 def test_list_suggestion_result_vector(subject_index):
     suggestions = ListSuggestionResult(
         [
+            # subject: seals (labels)
             SubjectSuggestion(
-                uri='http://www.yso.fi/onto/yso/p7141',
-                label='sinetit',
-                notation=None,
+                subject_id=subject_index.by_uri(
+                    'http://www.yso.fi/onto/yso/p7141'),
                 score=1.0),
+            # subject: Vikings
             SubjectSuggestion(
-                uri='http://www.yso.fi/onto/yso/p6479',
-                label='viikingit',
-                notation=None,
+                subject_id=subject_index.by_uri(
+                    'http://www.yso.fi/onto/yso/p6479'),
                 score=0.5)])
     vector = suggestions.as_vector(subject_index)
     assert isinstance(vector, np.ndarray)
@@ -130,30 +124,30 @@ def test_list_suggestion_result_vector(subject_index):
 def test_list_suggestions_vector_enforce_score_range(subject_index):
     suggestions = ListSuggestionResult(
         [
+            # subject: seals (labels)
             SubjectSuggestion(
-                uri='http://www.yso.fi/onto/yso/p7141',
-                label='sinetit',
-                notation=None,
+                subject_id=subject_index.by_uri(
+                    'http://www.yso.fi/onto/yso/p7141'),
                 score=1.5),
+            # subject: Vikings
             SubjectSuggestion(
-                uri='http://www.yso.fi/onto/yso/p6479',
-                label='viikingit',
-                notation=None,
+                subject_id=subject_index.by_uri(
+                    'http://www.yso.fi/onto/yso/p6479'),
                 score=1.0),
+            # subject: excavations
             SubjectSuggestion(
-                uri='http://www.yso.fi/onto/yso/p14173',
-                label='kaivaukset',
-                notation=None,
+                subject_id=subject_index.by_uri(
+                    'http://www.yso.fi/onto/yso/p14173'),
                 score=0.5),
+            # subject: runestones
             SubjectSuggestion(
-                uri='http://www.yso.fi/onto/yso/p14588',
-                label='riimukivet',
-                notation=None,
+                subject_id=subject_index.by_uri(
+                    'http://www.yso.fi/onto/yso/p14588'),
                 score=0.0),
+            # subject: Viking Age
             SubjectSuggestion(
-                uri='http://www.yso.fi/onto/yso/p12738',
-                label='viikinkiaika',
-                notation=None,
+                subject_id=subject_index.by_uri(
+                    'http://www.yso.fi/onto/yso/p12738'),
                 score=-0.5)])
     vector = suggestions.as_vector(subject_index)
     assert vector.sum() == 2.5
@@ -169,15 +163,15 @@ def test_list_suggestions_vector_enforce_score_range(subject_index):
 def test_list_suggestion_result_vector_destination(subject_index):
     suggestions = ListSuggestionResult(
         [
+            # subject: seals (labels)
             SubjectSuggestion(
-                uri='http://www.yso.fi/onto/yso/p7141',
-                label='sinetit',
-                notation=None,
+                subject_id=subject_index.by_uri(
+                    'http://www.yso.fi/onto/yso/p7141'),
                 score=1.0),
+            # subject: Vikings
             SubjectSuggestion(
-                uri='http://www.yso.fi/onto/yso/p6479',
-                label='viikingit',
-                notation=None,
+                subject_id=subject_index.by_uri(
+                    'http://www.yso.fi/onto/yso/p6479'),
                 score=0.5)])
     destination = np.zeros(len(subject_index), dtype=np.float32)
     vector = suggestions.as_vector(subject_index, destination=destination)
@@ -188,9 +182,8 @@ def test_list_suggestion_result_vector_notfound(subject_index):
     suggestions = ListSuggestionResult(
         [
             SubjectSuggestion(
-                uri='http://example.com/notfound',
-                label='not found',
-                notation=None,
+                subject_id=subject_index.by_uri(
+                    'http://example.com/notfound'),
                 score=1.0)])
     assert suggestions.as_vector(subject_index).sum() == 0
 

--- a/tests/test_vocab.py
+++ b/tests/test_vocab.py
@@ -39,7 +39,7 @@ def test_update_subject_index_with_no_changes(tmpdir):
     assert vocab.subjects.by_uri('http://example.org/dummy') == 0
     assert vocab.subjects[0] == ('http://example.org/dummy', 'dummy', None)
     assert vocab.subjects.by_uri('http://example.org/none') == 1
-    assert vocab.subjects[1] == ('http://example.org/none', 'none', None)
+    assert vocab.subjects[1] == ('http://example.org/none', 'none', '42.42')
 
 
 def test_update_subject_index_with_removed_subject(tmpdir):


### PR DESCRIPTION
This PR is a pretty major refactoring and simplification (hopefully!) of how subject suggestions are represented internally in Annif. There are two main representations, VectorSuggestionResult and ListSuggestionResult. The latter consists of SubjectSuggestion objects, which is a named tuple that has until now contained the URI, label and notation of the suggested subject as well as its suggestion score.

This PR simplifies SubjectSuggestion so that apart from the score, it only contains a numeric subject ID instead of all the subject attributes (uri, label, notation). The subject ID can be looked up from the SubjectIndex when more information about the subject is needed for example in the CLI and REST API. Since subject IDs are already used in many backends as well as other functionality, this usually makes the code simpler. It is also now easier to convert between vector and list representations of suggestions, since both now use numeric subject IDs and there is no need to rely on a SubjectIndex for the conversions.

There are also related changes in the AnnifVocabulary and SubjectIndex classes, for example the SubjectIndex now makes use of the Subject namedtuple instead of plain tuples, which makes its API a bit cleaner.

I have not yet tested this extensively but instead I've relied on the unit tests, which have of course been modified accordingly. I would expect this to bring small improvements in efficiency.