### PR TITLE
Refactor SubjectSet and Document to store subject IDs instead of URIs and labels

### DIFF
--- a/annif/backend/dummy.py
+++ b/annif/backend/dummy.py
@@ -36,7 +36,6 @@ class DummyBackend(backend.AnnifLearningBackend):
         # of the first subject of the first document in the learning set
         # and using that in subsequent analysis results
         for doc in corpus.documents:
-            if doc.uris:
-                first_uri = list(doc.uris)[0]
-                self.subject_id = self.project.subjects.by_uri(first_uri)
+            if doc.subject_set:
+                self.subject_id = doc.subject_set[0]
             break

--- a/annif/backend/ensemble.py
+++ b/annif/backend/ensemble.py
@@ -88,10 +88,9 @@ class EnsembleOptimizer(hyperopt.HyperparameterOptimizer):
         jobs, pool_class = annif.parallel.get_pool(n_jobs)
 
         with pool_class(jobs) as pool:
-            for hits, uris, labels in pool.imap_unordered(
+            for hits, subject_set in pool.imap_unordered(
                     psmap.suggest, self._corpus.documents):
-                self._gold_subjects.append(
-                    annif.corpus.SubjectSet((uris, labels)))
+                self._gold_subjects.append(subject_set)
                 self._source_hits.append(hits)
 
     def _normalize(self, hps):

--- a/annif/backend/fasttext.py
+++ b/annif/backend/fasttext.py
@@ -90,10 +90,7 @@ class FastTextBackend(mixins.ChunkingBackend, backend.AnnifBackend):
                 text = self._normalize_text(doc.text)
                 if text == '':
                     continue
-                subject_ids = [self.project.subjects.by_uri(uri)
-                               for uri in doc.uris]
-                labels = [self._id_to_label(sid) for sid in subject_ids
-                          if sid is not None]
+                labels = [self._id_to_label(sid) for sid in doc.subject_set]
                 if labels:
                     print(' '.join(labels), text, file=trainfile)
                 else:

--- a/annif/backend/mllm.py
+++ b/annif/backend/mllm.py
@@ -26,8 +26,7 @@ class MLLMOptimizer(hyperopt.HyperparameterOptimizer):
         for doc in self._corpus.documents:
             candidates = self._backend._generate_candidates(doc.text)
             self._candidates.append(candidates)
-            self._gold_subjects.append(
-                annif.corpus.SubjectSet((doc.uris, doc.labels)))
+            self._gold_subjects.append(doc.subject_set)
 
     def _objective(self, trial):
         params = {

--- a/annif/backend/nn_ensemble.py
+++ b/annif/backend/nn_ensemble.py
@@ -201,7 +201,7 @@ class NNEnsembleBackend(
 
         self.info("Processing training documents...")
         with pool_class(jobs) as pool:
-            for hits, uris, labels in pool.imap_unordered(
+            for hits, subject_set in pool.imap_unordered(
                     psmap.suggest, corpus.documents):
                 doc_scores = []
                 for project_id, p_hits in hits.items():
@@ -211,8 +211,8 @@ class NNEnsembleBackend(
                                       * len(sources))
                 score_vector = np.array(doc_scores,
                                         dtype=np.float32).transpose()
-                subjects = annif.corpus.SubjectSet((uris, labels))
-                true_vector = subjects.as_vector(self.project.subjects)
+                true_vector = subject_set.as_vector(
+                    len(self.project.subjects))
                 seq.add_sample(score_vector, true_vector)
 
     def _open_lmdb(self, cached, lmdb_map_size):

--- a/annif/backend/omikuji.py
+++ b/annif/backend/omikuji.py
@@ -55,13 +55,6 @@ class OmikujiBackend(mixins.TfidfVectorizerMixin, backend.AnnifBackend):
         self.initialize_vectorizer()
         self._initialize_model()
 
-    def _uris_to_subj_ids(self, uris):
-        subject_ids = [self.project.subjects.by_uri(uri)
-                       for uri in uris]
-        return [str(subj_id)
-                for subj_id in subject_ids
-                if subj_id is not None]
-
     def _create_train_file(self, veccorpus, corpus):
         self.info('creating train file')
         path = os.path.join(self.datadir, self.TRAIN_FILE)

--- a/annif/backend/omikuji.py
+++ b/annif/backend/omikuji.py
@@ -74,7 +74,8 @@ class OmikujiBackend(mixins.TfidfVectorizerMixin, backend.AnnifBackend):
                   file=trainfile)
             n_samples = 0
             for doc, vector in zip(corpus.documents, veccorpus):
-                subject_ids = self._uris_to_subj_ids(doc.uris)
+                subject_ids = [str(subject_id)
+                               for subject_id in doc.subject_set]
                 feature_values = ['{}:{}'.format(col, vector[row, col])
                                   for row, col in zip(*vector.nonzero())]
                 if not subject_ids or not feature_values:

--- a/annif/backend/pav.py
+++ b/annif/backend/pav.py
@@ -83,9 +83,8 @@ class PAVBackend(ensemble.BaseEnsembleBackend):
                 data.append(vector[cid])
                 row.append(docid)
                 col.append(cid)
-            subjects = annif.corpus.SubjectSet((doc.uris, doc.labels))
             for cid in np.flatnonzero(
-                    subjects.as_vector(source_project.subjects)):
+                    doc.subject_set.as_vector(len(source_project.subjects))):
 
                 trow.append(docid)
                 tcol.append(cid)

--- a/annif/backend/stwfsa.py
+++ b/annif/backend/stwfsa.py
@@ -86,7 +86,8 @@ class StwfsaBackend(backend.AnnifBackend):
         y = []
         for doc in corpus.documents:
             X.append(doc.text)
-            y.append(doc.uris)
+            y.append([self.project.subjects[subject_id].uri
+                      for subject_id in doc.subject_set])
         return X, y
 
     def _train(self, corpus, params, jobs=0):

--- a/annif/backend/tfidf.py
+++ b/annif/backend/tfidf.py
@@ -68,10 +68,7 @@ class TFIDFBackend(mixins.TfidfVectorizerMixin, backend.AnnifBackend):
 
             for doc in corpus.documents:
                 tokens = self.project.analyzer.tokenize_words(doc.text)
-                for uri in doc.uris:
-                    subject_id = self.project.subjects.by_uri(uri)
-                    if subject_id is None:
-                        continue
+                for subject_id in doc.subject_set:
                     subject_buffer[subject_id].write(" ".join(tokens))
 
             for sid in range(len(self.project.subjects)):

--- a/annif/corpus/combine.py
+++ b/annif/corpus/combine.py
@@ -15,11 +15,3 @@ class CombinedCorpus(DocumentCorpus):
     def documents(self):
         return itertools.chain.from_iterable(
             [corpus.documents for corpus in self._corpora])
-
-    def set_subject_index(self, subject_index):
-        """Set a subject index for looking up labels that are necessary for
-        conversion"""
-
-        for corpus in self._corpora:
-            if hasattr(corpus, 'set_subject_index'):
-                corpus.set_subject_index(subject_index)

--- a/annif/corpus/types.py
+++ b/annif/corpus/types.py
@@ -4,38 +4,17 @@ import abc
 import collections
 
 
-Document = collections.namedtuple('Document', 'text uris labels')
+Document = collections.namedtuple('Document', 'text subject_set')
 
 
 class DocumentCorpus(metaclass=abc.ABCMeta):
     """Abstract base class for document corpora"""
-
-    _subject_index = None
 
     @property
     @abc.abstractmethod
     def documents(self):
         """Iterate through the document corpus, yielding Document objects."""
         pass  # pragma: no cover
-
-    def set_subject_index(self, subject_index):
-        """Set a subject index for looking up labels that are necessary for
-        conversion"""
-
-        self._subject_index = subject_index
-
-    def _create_document(self, text, uris, labels):
-        """Create a new Document instance from possibly incomplete
-        information. URIs for labels and vice versa are looked up from the
-        subject index, if available."""
-
-        if self._subject_index:
-            if not uris and labels:
-                uris = set((self._subject_index.labels_to_uris(labels)))
-            if not labels and uris:
-                labels = set((self._subject_index.uris_to_labels(uris)))
-
-        return Document(text=text, uris=uris, labels=labels)
 
     def is_empty(self):
         """Check if there are no documents to iterate."""

--- a/annif/eval.py
+++ b/annif/eval.py
@@ -202,7 +202,7 @@ class EvaluationBatch:
         self._result_per_subject_header(results_file)
         self._result_per_subject_body(zipped, results_file)
 
-    def results(self, metrics=[], results_file=None, warnings=False):
+    def results(self, metrics=[], results_file=None):
         """evaluate a set of selected subjects against a gold standard using
         different metrics. If metrics is empty, use all available metrics.
         If results_file (file object) given, write results per subject to it"""
@@ -215,9 +215,7 @@ class EvaluationBatch:
         y_pred = np.zeros(shape, dtype=np.float32)
 
         for idx, (hits, gold_subjects) in enumerate(self._samples):
-            gold_subjects.as_vector(self._subject_index,
-                                    destination=y_true[idx],
-                                    warnings=warnings)
+            gold_subjects.as_vector(destination=y_true[idx])
             hits.as_vector(len(self._subject_index), destination=y_pred[idx])
 
         results = self._evaluate_samples(y_true, y_pred, metrics)

--- a/annif/lexical/mllm.py
+++ b/annif/lexical/mllm.py
@@ -212,7 +212,7 @@ class MLLMModel:
 
         return subject_ids
 
-    def _prepare_train_data(self, corpus, vocab, analyzer, n_jobs):
+    def _prepare_train_data(self, corpus, analyzer, n_jobs):
         # frequency of subjects (by id) in the generated candidates
         self._doc_freq = collections.Counter()
         # frequency of manually assigned subjects ("domain keyphraseness")
@@ -271,7 +271,7 @@ class MLLMModel:
 
         # convert the corpus into train data
         train_x, train_y = self._prepare_train_data(
-            corpus, vocab, analyzer, n_jobs)
+            corpus, analyzer, n_jobs)
 
         # precalculate idf values for all candidate subjects
         self._idf = self._calculate_idf(subject_ids, len(train_x))

--- a/annif/lexical/mllm.py
+++ b/annif/lexical/mllm.py
@@ -112,9 +112,9 @@ def candidates_to_features(candidates, mdata):
 class MLLMCandidateGenerator(annif.parallel.BaseWorker):
 
     @classmethod
-    def generate_candidates(cls, doc_subject_ids, text):
+    def generate_candidates(cls, doc_subject_set, text):
         candidates = generate_candidates(text, **cls.args)  # pragma: no cover
-        return doc_subject_ids, candidates  # pragma: no cover
+        return doc_subject_set, candidates  # pragma: no cover
 
 
 class MLLMFeatureConverter(annif.parallel.BaseWorker):
@@ -231,7 +231,7 @@ class MLLMModel:
         with pool_class(jobs,
                         initializer=MLLMCandidateGenerator.init,
                         initargs=(cg_args,)) as pool:
-            params = (([vocab.subjects.by_uri(uri) for uri in doc.uris],
+            params = ((doc.subject_set,
                        doc.text)
                       for doc in corpus.documents)
             for doc_subject_ids, candidates in pool.starmap(

--- a/annif/parallel.py
+++ b/annif/parallel.py
@@ -46,7 +46,7 @@ class ProjectSuggestMap:
             hits = project.suggest(doc.text, self.backend_params)
             filtered_hits[project_id] = hits.filter(
                 project.subjects, self.limit, self.threshold)
-        return (filtered_hits, doc.uris, doc.labels)
+        return (filtered_hits, doc.subject_set)
 
 
 def get_pool(n_jobs):

--- a/annif/project.py
+++ b/annif/project.py
@@ -200,7 +200,6 @@ class AnnifProject(DatadirMixin):
     def train(self, corpus, backend_params=None, jobs=0):
         """train the project using documents from a metadata source"""
         if corpus != 'cached':
-            corpus.set_subject_index(self.subjects)
             corpus = self.transform.transform_corpus(corpus)
         if backend_params is None:
             backend_params = {}
@@ -209,7 +208,6 @@ class AnnifProject(DatadirMixin):
 
     def learn(self, corpus, backend_params=None):
         """further train the project using documents from a metadata source"""
-        corpus.set_subject_index(self.subjects)
         if backend_params is None:
             backend_params = {}
         beparams = backend_params.get(self.backend.backend_id, {})

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -106,8 +106,7 @@ def document_corpus(subject_index):
         'corpora',
         'archaeology',
         'documents.tsv')
-    doc_corpus = annif.corpus.DocumentFile(docfile)
-    doc_corpus.set_subject_index(subject_index)
+    doc_corpus = annif.corpus.DocumentFile(docfile, subject_index)
     return doc_corpus
 
 
@@ -118,8 +117,7 @@ def fulltext_corpus(subject_index):
         'corpora',
         'archaeology',
         'fulltext')
-    ft_corpus = annif.corpus.DocumentDirectory(ftdir)
-    ft_corpus.set_subject_index(subject_index)
+    ft_corpus = annif.corpus.DocumentDirectory(ftdir, subject_index)
     return ft_corpus
 
 
@@ -153,6 +151,6 @@ def app_project(app):
 
 
 @pytest.fixture(scope='function')
-def empty_corpus(tmpdir):
+def empty_corpus(tmpdir, subject_index):
     empty_file = tmpdir.ensure('empty.tsv')
-    return annif.corpus.DocumentFile(str(empty_file))
+    return annif.corpus.DocumentFile(str(empty_file), subject_index)

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -34,7 +34,7 @@ def test_learn_dummy(project, tmpdir):
         '<http://www.yso.fi/onto/yso/p10849>\tarchaeologists')
     tmpdir.join('doc2.txt').write('doc2')
     tmpdir.join('doc2.tsv').write('<http://example.org/dummy>\tdummy')
-    docdir = annif.corpus.DocumentDirectory(str(tmpdir))
+    docdir = annif.corpus.DocumentDirectory(str(tmpdir), project.subjects)
 
     dummy.learn(docdir)
 

--- a/tests/test_backend_fasttext.py
+++ b/tests/test_backend_fasttext.py
@@ -82,7 +82,8 @@ def test_fasttext_train_unknown_subject(tmpdir, datadir, project):
     tmpfile = tmpdir.join('document.tsv')
     tmpfile.write("nonexistent\thttp://example.com/nonexistent\n" +
                   "arkeologia\thttp://www.yso.fi/onto/yso/p1265")
-    document_corpus = annif.corpus.DocumentFile(str(tmpfile))
+    document_corpus = annif.corpus.DocumentFile(str(tmpfile),
+                                                project.subjects)
 
     fasttext.train(document_corpus)
     assert fasttext._model is not None

--- a/tests/test_backend_nn_ensemble.py
+++ b/tests/test_backend_nn_ensemble.py
@@ -71,7 +71,8 @@ def test_set_lmdb_map_size(registry, tmpdir):
     tmpfile.write("dummy\thttp://example.org/dummy\n" +
                   "another\thttp://example.org/dummy\n" +
                   "none\thttp://example.org/none\n" * 40)
-    document_corpus = annif.corpus.DocumentFile(str(tmpfile))
+    document_corpus = annif.corpus.DocumentFile(str(tmpfile),
+                                                project.subjects)
 
     with pytest.raises(lmdb.MapFullError):
         nn_ensemble.train(document_corpus)
@@ -89,7 +90,8 @@ def test_nn_ensemble_train_and_learn(registry, tmpdir):
     tmpfile.write("dummy\thttp://example.org/dummy\n" +
                   "another\thttp://example.org/dummy\n" +
                   "none\thttp://example.org/none\n" * 40)
-    document_corpus = annif.corpus.DocumentFile(str(tmpfile))
+    document_corpus = annif.corpus.DocumentFile(str(tmpfile),
+                                                project.subjects)
 
     nn_ensemble.train(document_corpus)
 
@@ -148,7 +150,8 @@ def test_nn_ensemble_train_and_learn_params(registry, tmpdir, capfd):
     tmpfile.write("dummy\thttp://example.org/dummy\n" +
                   "another\thttp://example.org/dummy\n" +
                   "none\thttp://example.org/none")
-    document_corpus = annif.corpus.DocumentFile(str(tmpfile))
+    document_corpus = annif.corpus.DocumentFile(str(tmpfile),
+                                                project.subjects)
 
     train_params = {'epochs': 3}
     nn_ensemble.train(document_corpus, train_params)

--- a/tests/test_backend_omikuji.py
+++ b/tests/test_backend_omikuji.py
@@ -41,7 +41,7 @@ def test_omikuji_create_train_file(tmpdir, project, datadir):
     tmpfile.write("nonexistent\thttp://example.com/nonexistent\n" +
                   "arkeologia\thttp://www.yso.fi/onto/yso/p1265\n" +
                   "...\thttp://example.com/none")
-    corpus = annif.corpus.DocumentFile(str(tmpfile))
+    corpus = annif.corpus.DocumentFile(str(tmpfile), project.subjects)
     omikuji_type = annif.backend.get_backend('omikuji')
     omikuji = omikuji_type(
         backend_id='omikuji',

--- a/tests/test_backend_pav.py
+++ b/tests/test_backend_pav.py
@@ -45,7 +45,8 @@ def test_pav_train(tmpdir, app_project):
     tmpfile.write("dummy\thttp://example.org/dummy\n" +
                   "another\thttp://example.org/dummy\n" +
                   "none\thttp://example.org/none")
-    document_corpus = annif.corpus.DocumentFile(str(tmpfile))
+    document_corpus = annif.corpus.DocumentFile(str(tmpfile),
+                                                app_project.subjects)
 
     pav.train(document_corpus)
     datadir = py.path.local(app_project.datadir)
@@ -122,7 +123,8 @@ def test_pav_train_params(tmpdir, app_project, caplog):
     tmpfile.write("dummy\thttp://example.org/dummy\n" +
                   "another\thttp://example.org/dummy\n" +
                   "none\thttp://example.org/none")
-    document_corpus = annif.corpus.DocumentFile(str(tmpfile))
+    document_corpus = annif.corpus.DocumentFile(str(tmpfile),
+                                                app_project.subjects)
     params = {'min-docs': 5}
 
     with caplog.at_level(logging.DEBUG):

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -2,71 +2,89 @@
 
 import gzip
 import numpy as np
+import pytest
 import annif.corpus
 from annif.corpus import TransformingDocumentCorpus
 
 
-def test_subjectset_uris():
-    data = """<http://example.org/dummy>\tdummy
-    <http://example.org/another>\tanother
+def test_subjectset_uris(subject_index):
+    data = """<http://www.yso.fi/onto/yso/p2558>\trautakausi
+    <http://www.yso.fi/onto/yso/p12738>\tviikinkiaika
     """
 
-    sset = annif.corpus.SubjectSet.from_string(data)
-    assert sset.has_uris()
-    assert len(sset.subject_uris) == 2
-    assert "http://example.org/dummy" in sset.subject_uris
-    assert "http://example.org/another" in sset.subject_uris
+    sset = annif.corpus.SubjectSet.from_string(data, subject_index)
+    assert len(sset) == 2
+    assert subject_index.by_uri("http://www.yso.fi/onto/yso/p2558") in sset
+    assert subject_index.by_uri("http://www.yso.fi/onto/yso/p12738") in sset
 
 
-def test_subjectset_labels():
-    data = """dummy
-    another
+def test_subjectset_labels(subject_index):
+    data = """rautakausi
+    viikinkiaika
     """
 
-    sset = annif.corpus.SubjectSet.from_string(data)
-    assert not sset.has_uris()
-    assert len(sset.subject_labels) == 2
-    assert "dummy" in sset.subject_labels
-    assert "another" in sset.subject_labels
+    sset = annif.corpus.SubjectSet.from_string(data, subject_index)
+    assert len(sset) == 2
+    assert subject_index.by_label("rautakausi") in sset
+    assert subject_index.by_label("viikinkiaika") in sset
 
 
-def test_subjectset_from_tuple():
+def test_subjectset_from_list(subject_index):
     uris = ['http://www.yso.fi/onto/yso/p10849',
             'http://www.yso.fi/onto/yso/p19740']
-    labels = ['arkeologit', 'obeliskit']
-    sset = annif.corpus.SubjectSet((uris, labels))
-    assert sset.has_uris()
-    assert len(sset.subject_uris) == 2
-    assert 'http://www.yso.fi/onto/yso/p10849' in sset.subject_uris
-    assert 'http://www.yso.fi/onto/yso/p19740' in sset.subject_uris
+    subject_ids = [subject_index.by_uri(uri) for uri in uris]
+    sset = annif.corpus.SubjectSet(subject_ids)
+    assert len(sset) == 2
+    assert subject_index.by_uri("http://www.yso.fi/onto/yso/p10849") in sset
+    assert subject_index.by_uri("http://www.yso.fi/onto/yso/p19740") in sset
+
+
+def test_subjectset_empty():
+    sset = annif.corpus.SubjectSet()
+    assert len(sset) == 0
+    assert not sset
+    with pytest.raises(IndexError):
+        sset[0]
+
+
+def test_subjectset_equal():
+    sset = annif.corpus.SubjectSet([1, 3, 5])
+    sset2 = annif.corpus.SubjectSet([3, 5, 1])
+    assert sset == sset2
+
+
+def test_subjectset_nonequal():
+    sset = annif.corpus.SubjectSet([1, 3, 5])
+    sset2 = annif.corpus.SubjectSet([3, 5])
+    assert sset != sset2
 
 
 def test_subjectset_as_vector(subject_index):
     uris = ['http://www.yso.fi/onto/yso/p10849', 'http://example.org/unknown']
-    labels = ['arkeologit', 'unknown-subject']
-    sset = annif.corpus.SubjectSet((uris, labels))
-    vector = sset.as_vector(subject_index)
+    subject_ids = [subject_index.by_uri(uri) for uri in uris]
+    sset = annif.corpus.SubjectSet(subject_ids)
+    vector = sset.as_vector(len(subject_index))
     assert vector.sum() == 1  # only one known subject
 
 
 def test_subjectset_as_vector_destination(subject_index):
     uris = ['http://www.yso.fi/onto/yso/p10849', 'http://example.org/unknown']
-    labels = ['arkeologit', 'unknown-subject']
-    sset = annif.corpus.SubjectSet((uris, labels))
+    subject_ids = [subject_index.by_uri(uri) for uri in uris]
+    sset = annif.corpus.SubjectSet(subject_ids)
     destination = np.zeros(len(subject_index), dtype=np.float32)
-    vector = sset.as_vector(subject_index, destination=destination)
+    vector = sset.as_vector(destination=destination)
     assert vector.sum() == 1  # only one known subject
     assert vector is destination
 
 
-def test_docdir_key(tmpdir):
+def test_docdir_key(tmpdir, subject_index):
     tmpdir.join('doc1.txt').write('doc1')
     tmpdir.join('doc1.key').write('key1')
     tmpdir.join('doc2.txt').write('doc2')
     tmpdir.join('doc2.key').write('key2')
     tmpdir.join('doc3.txt').write('doc3')
 
-    docdir = annif.corpus.DocumentDirectory(str(tmpdir))
+    docdir = annif.corpus.DocumentDirectory(str(tmpdir), subject_index)
     files = sorted(list(docdir))
     assert len(files) == 3
     assert files[0][0] == str(tmpdir.join('doc1.txt'))
@@ -77,14 +95,14 @@ def test_docdir_key(tmpdir):
     assert files[2][1] is None
 
 
-def test_docdir_tsv(tmpdir):
+def test_docdir_tsv(tmpdir, subject_index):
     tmpdir.join('doc1.txt').write('doc1')
     tmpdir.join('doc1.tsv').write('<http://example.org/key1>\tkey1')
     tmpdir.join('doc2.txt').write('doc2')
     tmpdir.join('doc2.tsv').write('<http://example.org/key2>\tkey2')
     tmpdir.join('doc3.txt').write('doc3')
 
-    docdir = annif.corpus.DocumentDirectory(str(tmpdir))
+    docdir = annif.corpus.DocumentDirectory(str(tmpdir), subject_index)
     files = sorted(list(docdir))
     assert len(files) == 3
     assert files[0][0] == str(tmpdir.join('doc1.txt'))
@@ -95,32 +113,35 @@ def test_docdir_tsv(tmpdir):
     assert files[2][1] is None
 
 
-def test_docdir_tsv_bom(tmpdir):
+def test_docdir_tsv_bom(tmpdir, subject_index):
     tmpdir.join('doc1.txt').write('doc1'.encode('utf-8-sig'))
     tmpdir.join('doc1.tsv').write(
-        '<http://example.org/key1>\tkey1'.encode('utf-8-sig'))
+        '<http://www.yso.fi/onto/yso/p4622>\tesihistoria'.encode('utf-8-sig'))
     tmpdir.join('doc2.txt').write('doc2'.encode('utf-8-sig'))
     tmpdir.join('doc2.tsv').write(
-        '<http://example.org/key2>\tkey2'.encode('utf-8-sig'))
+        '<http://www.yso.fi/onto/yso/p2558>\trautakausi'.encode('utf-8-sig'))
 
-    docdir = annif.corpus.DocumentDirectory(str(tmpdir))
+    docdir = annif.corpus.DocumentDirectory(str(tmpdir), subject_index)
     docs = list(docdir.documents)
     assert docs[0].text == 'doc1'
-    assert list(docs[0].uris)[0] == 'http://example.org/key1'
-    assert list(docs[0].labels)[0] == 'key1'
+    assert subject_index.by_uri(
+        'http://www.yso.fi/onto/yso/p4622') in docs[0].subject_set
+    assert len(docs[0].subject_set) == 1
     assert docs[1].text == 'doc2'
-    assert list(docs[1].uris)[0] == 'http://example.org/key2'
-    assert list(docs[1].labels)[0] == 'key2'
+    assert subject_index.by_uri(
+        'http://www.yso.fi/onto/yso/p2558') in docs[1].subject_set
+    assert len(docs[1].subject_set) == 1
 
 
-def test_docdir_key_require_subjects(tmpdir):
+def test_docdir_key_require_subjects(tmpdir, subject_index):
     tmpdir.join('doc1.txt').write('doc1')
     tmpdir.join('doc1.key').write('<http://example.org/key1>\tkey1')
     tmpdir.join('doc2.txt').write('doc2')
     tmpdir.join('doc2.key').write('<http://example.org/key2>\tkey2')
     tmpdir.join('doc3.txt').write('doc3')
 
-    docdir = annif.corpus.DocumentDirectory(str(tmpdir), require_subjects=True)
+    docdir = annif.corpus.DocumentDirectory(str(tmpdir), subject_index,
+                                            require_subjects=True)
     files = sorted(list(docdir))
     assert len(files) == 2
     assert files[0][0] == str(tmpdir.join('doc1.txt'))
@@ -129,14 +150,15 @@ def test_docdir_key_require_subjects(tmpdir):
     assert files[1][1] == str(tmpdir.join('doc2.key'))
 
 
-def test_docdir_tsv_require_subjects(tmpdir):
+def test_docdir_tsv_require_subjects(tmpdir, subject_index):
     tmpdir.join('doc1.txt').write('doc1')
     tmpdir.join('doc1.tsv').write('key1')
     tmpdir.join('doc2.txt').write('doc2')
     tmpdir.join('doc2.tsv').write('key2')
     tmpdir.join('doc3.txt').write('doc3')
 
-    docdir = annif.corpus.DocumentDirectory(str(tmpdir), require_subjects=True)
+    docdir = annif.corpus.DocumentDirectory(str(tmpdir), subject_index,
+                                            require_subjects=True)
     files = sorted(list(docdir))
     assert len(files) == 2
     assert files[0][0] == str(tmpdir.join('doc1.txt'))
@@ -145,20 +167,27 @@ def test_docdir_tsv_require_subjects(tmpdir):
     assert files[1][1] == str(tmpdir.join('doc2.tsv'))
 
 
-def test_docdir_tsv_as_doccorpus(tmpdir):
+def test_docdir_tsv_as_doccorpus(tmpdir, subject_index):
     tmpdir.join('doc1.txt').write('doc1')
-    tmpdir.join('doc1.tsv').write('<http://example.org/subj1>\tsubj1')
+    tmpdir.join('doc1.tsv').write(
+        '<http://www.yso.fi/onto/yso/p4622>\tesihistoria')
     tmpdir.join('doc2.txt').write('doc2')
-    tmpdir.join('doc2.tsv').write('<http://example.org/subj2>\tsubj2')
+    tmpdir.join('doc2.tsv').write(
+        '<http://www.yso.fi/onto/yso/p2558>\trautakausi')
     tmpdir.join('doc3.txt').write('doc3')
 
-    docdir = annif.corpus.DocumentDirectory(str(tmpdir), require_subjects=True)
+    docdir = annif.corpus.DocumentDirectory(str(tmpdir), subject_index,
+                                            require_subjects=True)
     docs = list(docdir.documents)
     assert len(docs) == 2
     assert docs[0].text == 'doc1'
-    assert docs[0].uris == {'http://example.org/subj1'}
+    assert len(docs[0].subject_set) == 1
+    assert subject_index.by_uri(
+        'http://www.yso.fi/onto/yso/p4622') in docs[0].subject_set
     assert docs[1].text == 'doc2'
-    assert docs[1].uris == {'http://example.org/subj2'}
+    assert subject_index.by_uri(
+        'http://www.yso.fi/onto/yso/p2558') in docs[1].subject_set
+    assert len(docs[1].subject_set) == 1
 
 
 def test_docdir_key_as_doccorpus(tmpdir, subject_index):
@@ -168,14 +197,18 @@ def test_docdir_key_as_doccorpus(tmpdir, subject_index):
     tmpdir.join('doc2.key').write('kalliotaide')
     tmpdir.join('doc3.txt').write('doc3')
 
-    docdir = annif.corpus.DocumentDirectory(str(tmpdir), require_subjects=True)
-    docdir.set_subject_index(subject_index)
+    docdir = annif.corpus.DocumentDirectory(str(tmpdir), subject_index,
+                                            require_subjects=True)
     docs = list(docdir.documents)
     assert len(docs) == 2
     assert docs[0].text == 'doc1'
-    assert docs[0].uris == {'http://www.yso.fi/onto/yso/p10849'}
+    assert len(docs[0].subject_set) == 1
+    assert subject_index.by_uri(
+        'http://www.yso.fi/onto/yso/p10849') in docs[0].subject_set
     assert docs[1].text == 'doc2'
-    assert docs[1].uris == {'http://www.yso.fi/onto/yso/p13027'}
+    assert len(docs[1].subject_set) == 1
+    assert subject_index.by_uri(
+        'http://www.yso.fi/onto/yso/p13027') in docs[1].subject_set
 
 
 def test_subject_by_uri(subject_index):
@@ -198,29 +231,29 @@ def test_subject_by_label_missing(subject_index):
     assert subj_id is None
 
 
-def test_docfile_plain(tmpdir):
+def test_docfile_plain(tmpdir, subject_index):
     docfile = tmpdir.join('documents.tsv')
     docfile.write("""Läntinen\t<http://www.yso.fi/onto/yso/p2557>
         Oulunlinnan\t<http://www.yso.fi/onto/yso/p7346>
         Harald Hirmuinen\t<http://www.yso.fi/onto/yso/p6479>""")
 
-    docs = annif.corpus.DocumentFile(str(docfile))
+    docs = annif.corpus.DocumentFile(str(docfile), subject_index)
     assert len(list(docs.documents)) == 3
 
 
-def test_docfile_bom(tmpdir):
+def test_docfile_bom(tmpdir, subject_index):
     docfile = tmpdir.join('documents_bom.tsv')
     data = """Läntinen\t<http://www.yso.fi/onto/yso/p2557>
         Oulunlinnan\t<http://www.yso.fi/onto/yso/p7346>
         Harald Hirmuinen\t<http://www.yso.fi/onto/yso/p6479>"""
     docfile.write(data.encode('utf-8-sig'))
 
-    docs = annif.corpus.DocumentFile(str(docfile))
+    docs = annif.corpus.DocumentFile(str(docfile), subject_index)
     firstdoc = next(docs.documents)
     assert firstdoc.text.startswith("Läntinen")
 
 
-def test_docfile_plain_invalid_lines(tmpdir, caplog):
+def test_docfile_plain_invalid_lines(tmpdir, caplog, subject_index):
     logger = annif.logger
     logger.propagate = True
     docfile = tmpdir.join('documents_invalid.tsv')
@@ -229,7 +262,7 @@ def test_docfile_plain_invalid_lines(tmpdir, caplog):
         Oulunlinnan\t<http://www.yso.fi/onto/yso/p7346>
         A line with no tabs
         Harald Hirmuinen\t<http://www.yso.fi/onto/yso/p6479>""")
-    docs = annif.corpus.DocumentFile(str(docfile))
+    docs = annif.corpus.DocumentFile(str(docfile), subject_index)
     assert len(list(docs.documents)) == 3
     assert len(caplog.records) == 2
     expected_msg = 'Skipping invalid line (missing tab):'
@@ -237,31 +270,31 @@ def test_docfile_plain_invalid_lines(tmpdir, caplog):
         assert expected_msg in record.message
 
 
-def test_docfile_gzipped(tmpdir):
+def test_docfile_gzipped(tmpdir, subject_index):
     docfile = tmpdir.join('documents.tsv.gz')
     with gzip.open(str(docfile), 'wt') as gzf:
         gzf.write("""Pohjoinen\t<http://www.yso.fi/onto/yso/p2557>
             Oulunlinnan\t<http://www.yso.fi/onto/yso/p7346>
             Harald Hirmuinen\t<http://www.yso.fi/onto/yso/p6479>""")
 
-    docs = annif.corpus.DocumentFile(str(docfile))
+    docs = annif.corpus.DocumentFile(str(docfile), subject_index)
     assert len(list(docs.documents)) == 3
 
 
-def test_docfile_is_empty(tmpdir):
+def test_docfile_is_empty(tmpdir, subject_index):
     empty_file = tmpdir.ensure('empty.tsv')
-    docs = annif.corpus.DocumentFile(str(empty_file))
+    docs = annif.corpus.DocumentFile(str(empty_file), subject_index)
     assert docs.is_empty()
 
 
-def test_combinedcorpus(tmpdir):
+def test_combinedcorpus(tmpdir, subject_index):
     docfile = tmpdir.join('documents.tsv')
     docfile.write("""Läntinen\t<http://www.yso.fi/onto/yso/p2557>
         Oulunlinnan\t<http://www.yso.fi/onto/yso/p7346>
         Harald Hirmuinen\t<http://www.yso.fi/onto/yso/p6479>""")
 
-    corpus1 = annif.corpus.DocumentFile(str(docfile))
-    corpus2 = annif.corpus.DocumentFile(str(docfile))
+    corpus1 = annif.corpus.DocumentFile(str(docfile), subject_index)
+    corpus2 = annif.corpus.DocumentFile(str(docfile), subject_index)
 
     combined = annif.corpus.CombinedCorpus([corpus1, corpus2])
 
@@ -275,14 +308,13 @@ def test_transformingcorpus(document_corpus):
     for transf_doc, doc in zip(transformed_corpus.documents,
                                document_corpus.documents):
         assert transf_doc.text == doc.text + doc.text
-        assert transf_doc.uris == doc.uris
-        assert transf_doc.labels == doc.labels
+        assert transf_doc.subject_set == doc.subject_set
     # Ensure docs are still available after iterating
     assert len(list(transformed_corpus.documents)) \
         == len(list(document_corpus.documents))
 
 
-def test_limitingcorpus(tmpdir):
+def test_limitingcorpus(tmpdir, subject_index):
     docfile = tmpdir.join('documents_invalid.tsv')
     docfile.write("""Läntinen\t<http://www.yso.fi/onto/yso/p2557>
 
@@ -290,7 +322,7 @@ def test_limitingcorpus(tmpdir):
         A line with no tabs
         Harald Hirmuinen\t<http://www.yso.fi/onto/yso/p6479>""")
 
-    document_corpus = annif.corpus.DocumentFile(str(docfile))
+    document_corpus = annif.corpus.DocumentFile(str(docfile), subject_index)
     limiting_corpus = annif.corpus.LimitingDocumentCorpus(document_corpus, 2)
 
     assert len(list(limiting_corpus.documents)) == 2

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -57,6 +57,8 @@ def test_subjectset_nonequal():
     sset = annif.corpus.SubjectSet([1, 3, 5])
     sset2 = annif.corpus.SubjectSet([3, 5])
     assert sset != sset2
+    assert sset != [1, 3, 5]
+    assert sset != set([1, 3, 5])
 
 
 def test_subjectset_as_vector(subject_index):

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -97,7 +97,8 @@ def test_evaluation_batch(subject_index):
     batch = annif.eval.EvaluationBatch(subject_index)
 
     gold_set = annif.corpus.SubjectSet.from_string(
-        '<http://www.yso.fi/onto/yso/p10849>\tarkeologit')
+        '<http://www.yso.fi/onto/yso/p10849>\tarkeologit',
+        subject_index)
     hits1 = annif.suggestion.ListSuggestionResult([
         # subject: archaeologists (yso:p10849)
         annif.suggestion.SubjectSuggestion(

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -168,9 +168,9 @@ def test_project_learn(registry, tmpdir):
     tmpdir.join('doc1.tsv').write('<http://example.org/none>\tnone')
     tmpdir.join('doc2.txt').write('doc2')
     tmpdir.join('doc2.tsv').write('<http://example.org/dummy>\tdummy')
-    docdir = annif.corpus.DocumentDirectory(str(tmpdir))
 
     project = registry.get_project('dummy-fi')
+    docdir = annif.corpus.DocumentDirectory(str(tmpdir), project.subjects)
     project.learn(docdir)
     result = project.suggest('this is some text')
     assert len(result) == 1
@@ -185,9 +185,9 @@ def test_project_learn_not_supported(registry, tmpdir):
     tmpdir.join('doc1.tsv').write('<http://example.org/key1>\tkey1')
     tmpdir.join('doc2.txt').write('doc2')
     tmpdir.join('doc2.tsv').write('<http://example.org/key2>\tkey2')
-    docdir = annif.corpus.DocumentDirectory(str(tmpdir))
 
     project = registry.get_project('tfidf-fi')
+    docdir = annif.corpus.DocumentDirectory(str(tmpdir), project.subjects)
     with pytest.raises(NotSupportedException):
         project.learn(docdir)
 

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -50,8 +50,7 @@ def test_chained_transforms_corpus(document_corpus):
     for transf_doc, doc in zip(transformed_corpus.documents,
                                document_corpus.documents):
         assert transf_doc.text == doc.text[:3]
-        assert transf_doc.uris == doc.uris
-        assert transf_doc.labels == doc.labels
+        assert transf_doc.subject_set == doc.subject_set
 
     # Check with a more arbitrary transform function
     reverser = annif.transform.transform.IdentityTransform(None)
@@ -60,5 +59,4 @@ def test_chained_transforms_corpus(document_corpus):
     for transf_doc, doc in zip(transformed_corpus.documents,
                                document_corpus.documents):
         assert transf_doc.text == doc.text[:3][::-1]
-        assert transf_doc.uris == doc.uris
-        assert transf_doc.labels == doc.labels
+        assert transf_doc.subject_set == doc.subject_set


### PR DESCRIPTION
This PR refactors the SubjectSet class, which are used to represent gold standard / manually indexed subjects for training and evaluation documents, so that the SubjectSet class only stores numeric subject IDs instead of subject URIs and labels. It also changes the Document class to contain a SubjectSet instead of separate fields for subject URIs and labels. The end result is that internally, numeric IDs are used much more than before and the conversion from concept URIs and/or labels to subject IDs is performed earlier than before. The changes should simplify things overall and also likely improve efficiency (both RAM and CPU), although I haven't measured the difference.

This PR is very similar to PR #604 which did the same kind of overhaul for the SubjectSuggestion class.