### PR TITLE
multilingual SubjectIndex backed by CSV file

### DIFF
--- a/annif/backend/yake.py
+++ b/annif/backend/yake.py
@@ -87,9 +87,9 @@ class YakeBackend(backend.AnnifBackend):
         skos_vocab = self.project.vocab.skos
         for concept in skos_vocab.concepts:
             uri = str(concept)
-            labels = skos_vocab.get_concept_labels(
-                concept, self.label_types, self.params['language'])
-            for label in labels:
+            labels_by_lang = skos_vocab.get_concept_labels(concept,
+                                                           self.label_types)
+            for label in labels_by_lang[self.params['language']]:
                 label = self._normalize_label(label)
                 index[label].add(uri)
         index.pop('', None)  # Remove possible empty string entry

--- a/annif/cli.py
+++ b/annif/cli.py
@@ -190,6 +190,9 @@ def run_loadvoc(project_id, force, subjectfile):
     if annif.corpus.SubjectFileSKOS.is_rdf_file(subjectfile):
         # SKOS/RDF file supported by rdflib
         subjects = annif.corpus.SubjectFileSKOS(subjectfile)
+    elif annif.corpus.SubjectFileCSV.is_csv_file(subjectfile):
+        # CSV file
+        subjects = annif.corpus.SubjectFileCSV(subjectfile)
     else:
         # probably a TSV file
         subjects = annif.corpus.SubjectFileTSV(subjectfile, proj.language)

--- a/annif/corpus/__init__.py
+++ b/annif/corpus/__init__.py
@@ -3,13 +3,13 @@
 
 from .document import DocumentDirectory, DocumentFile, DocumentList, \
     TransformingDocumentCorpus, LimitingDocumentCorpus
-from .subject import Subject, SubjectFileTSV
+from .subject import Subject, SubjectFileTSV, SubjectFileCSV
 from .subject import SubjectIndex, SubjectSet
 from .skos import SubjectFileSKOS
 from .types import Document
 from .combine import CombinedCorpus
 
 __all__ = ["DocumentDirectory", "DocumentFile", "DocumentList", "Subject",
-           "SubjectFileTSV", "SubjectIndex", "SubjectSet", "SubjectFileSKOS",
-           "Document", "CombinedCorpus", "TransformingDocumentCorpus",
-           "LimitingDocumentCorpus"]
+           "SubjectFileTSV", "SubjectFileCSV", "SubjectIndex", "SubjectSet",
+           "SubjectFileSKOS", "Document", "CombinedCorpus",
+           "TransformingDocumentCorpus", "LimitingDocumentCorpus"]

--- a/annif/corpus/document.py
+++ b/annif/corpus/document.py
@@ -15,9 +15,10 @@ logger = annif.logger
 class DocumentDirectory(DocumentCorpus):
     """A directory of files as a full text document corpus"""
 
-    def __init__(self, path, subject_index, require_subjects=False):
+    def __init__(self, path, subject_index, language, require_subjects=False):
         self.path = path
         self.subject_index = subject_index
+        self.language = language
         self.require_subjects = require_subjects
 
     def __iter__(self):
@@ -45,7 +46,8 @@ class DocumentDirectory(DocumentCorpus):
                 text = docfile.read()
             with open(keyfilename, encoding='utf-8-sig') as keyfile:
                 subjects = SubjectSet.from_string(keyfile.read(),
-                                                  self.subject_index)
+                                                  self.subject_index,
+                                                  self.language)
             yield Document(text=text, subject_set=subjects)
 
 

--- a/annif/corpus/skos.py
+++ b/annif/corpus/skos.py
@@ -1,5 +1,6 @@
 """Support for subjects loaded from a SKOS/RDF file"""
 
+import collections
 import os.path
 import shutil
 import joblib
@@ -10,7 +11,7 @@ import annif.util
 from .types import Subject, SubjectCorpus
 
 
-def serialize_subjects_to_skos(subjects, language, path):
+def serialize_subjects_to_skos(subjects, path):
     """Create a SKOS representation of the given subjects and serialize it
     into a SKOS/Turtle file with the given path name."""
 
@@ -18,9 +19,10 @@ def serialize_subjects_to_skos(subjects, language, path):
     graph.namespace_manager.bind('skos', SKOS)
     for subject in subjects:
         graph.add((rdflib.URIRef(subject.uri), RDF.type, SKOS.Concept))
-        graph.add((rdflib.URIRef(subject.uri),
-                   SKOS.prefLabel,
-                   rdflib.Literal(subject.label, language)))
+        for lang, label in subject.labels.items():
+            graph.add((rdflib.URIRef(subject.uri),
+                       SKOS.prefLabel,
+                       rdflib.Literal(label, lang)))
         graph.add((rdflib.URIRef(subject.uri),
                    SKOS.notation,
                    rdflib.Literal(subject.notation)))
@@ -36,6 +38,8 @@ class SubjectFileSKOS(SubjectCorpus):
 
     PREF_LABEL_PROPERTIES = (SKOS.prefLabel, RDFS.label)
 
+    _languages = None
+
     def __init__(self, path):
         self.path = path
         if path.endswith('.dump.gz'):
@@ -47,25 +51,30 @@ class SubjectFileSKOS(SubjectCorpus):
 
     @property
     def languages(self):
-        return {label.language
-                for concept in self.concepts
-                for label_type in self.PREF_LABEL_PROPERTIES
-                for label in self.graph.objects(concept, label_type)
-                if label.language is not None}
+        if self._languages is None:
+            self._languages = {label.language
+                               for concept in self.concepts
+                               for label_type in self.PREF_LABEL_PROPERTIES
+                               for label in self.graph.objects(concept,
+                                                               label_type)
+                               if label.language is not None}
+        return self._languages
 
-    def subjects(self, language):
+    @property
+    def subjects(self):
         for concept in self.concepts:
-            labels = self.get_concept_labels(
-                concept, self.PREF_LABEL_PROPERTIES, language)
-            # Use first label if available, else use qualified name (from URI)
-            label = (labels[0] if labels
-                     else self.graph.namespace_manager.qname(concept))
+            by_lang = self.get_concept_labels(concept,
+                                              self.PREF_LABEL_PROPERTIES)
+            labels = {lang: by_lang[lang][0] if by_lang[lang]  # correct lang
+                      else by_lang[None][0] if by_lang[None]  # no language
+                      else self.graph.namespace_manager.qname(concept)
+                      for lang in self.languages}
 
             notation = self.graph.value(concept, SKOS.notation, None, any=True)
             if notation is not None:
                 notation = str(notation)
 
-            yield Subject(uri=str(concept), label=label, notation=notation)
+            yield Subject(uri=str(concept), labels=labels, notation=notation)
 
     @property
     def concepts(self):
@@ -74,23 +83,17 @@ class SubjectFileSKOS(SubjectCorpus):
                 continue
             yield concept
 
-    def get_concept_labels(self, concept, label_types, language):
-        all_labels = [label
-                      for label_type in label_types
-                      for label in self.graph.objects(concept, label_type)]
+    def get_concept_labels(self, concept, label_types):
+        """return all the labels of the given concept with the given label
+        properties as a dict-like object where the keys are language codes
+        and the values are lists of labels in that language"""
+        labels_by_lang = collections.defaultdict(list)
 
-        # 1. Labels with the correct language tag
-        same_lang_labels = [str(label)
-                            for label in all_labels
-                            if label.language == language]
+        for label_type in label_types:
+            for label in self.graph.objects(concept, label_type):
+                labels_by_lang[label.language].append(str(label))
 
-        # 2. Labels without a language tag
-        no_lang_labels = [str(label)
-                          for label in all_labels
-                          if label.language is None]
-
-        # Return both kinds, but better ones (with the right language) first
-        return same_lang_labels + no_lang_labels
+        return labels_by_lang
 
     @staticmethod
     def is_rdf_file(path):
@@ -100,7 +103,7 @@ class SubjectFileSKOS(SubjectCorpus):
         fmt = rdflib.util.guess_format(path)
         return fmt is not None
 
-    def save_skos(self, path, language):
+    def save_skos(self, path):
         """Save the contents of the subject vocabulary into a SKOS/Turtle
         file with the given path name."""
 

--- a/annif/corpus/skos.py
+++ b/annif/corpus/skos.py
@@ -60,15 +60,18 @@ class SubjectFileSKOS(SubjectCorpus):
                                if label.language is not None}
         return self._languages
 
+    def _concept_labels(self, concept):
+        by_lang = self.get_concept_labels(concept,
+                                          self.PREF_LABEL_PROPERTIES)
+        return {lang: by_lang[lang][0] if by_lang[lang]  # correct lang
+                else by_lang[None][0] if by_lang[None]  # no language
+                else self.graph.namespace_manager.qname(concept)
+                for lang in self.languages}
+
     @property
     def subjects(self):
         for concept in self.concepts:
-            by_lang = self.get_concept_labels(concept,
-                                              self.PREF_LABEL_PROPERTIES)
-            labels = {lang: by_lang[lang][0] if by_lang[lang]  # correct lang
-                      else by_lang[None][0] if by_lang[None]  # no language
-                      else self.graph.namespace_manager.qname(concept)
-                      for lang in self.languages}
+            labels = self._concept_labels(concept)
 
             notation = self.graph.value(concept, SKOS.notation, None, any=True)
             if notation is not None:

--- a/annif/corpus/subject.py
+++ b/annif/corpus/subject.py
@@ -1,39 +1,88 @@
 """Classes for supporting subject corpora expressed as directories or files"""
 
-import annif.util
+import csv
 import numpy as np
+import annif.util
 from annif import logger
-from .types import Subject
+from .types import Subject, SubjectCorpus
 from .skos import serialize_subjects_to_skos
 
 
-class SubjectFileTSV:
-    """A subject vocabulary stored in a TSV file."""
+class SubjectFileTSV(SubjectCorpus):
+    """A monolingual subject vocabulary stored in a TSV file."""
 
-    def __init__(self, path):
+    def __init__(self, path, language):
+        """initialize the SubjectFileTSV given a path to a TSV file and the
+        language of the vocabulary"""
+
         self.path = path
+        self.language = language
 
     def _parse_line(self, line):
         vals = line.strip().split('\t', 2)
         clean_uri = annif.util.cleanup_uri(vals[0])
         label = vals[1] if len(vals) >= 2 else None
+        labels = {self.language: label} if label else None
         notation = vals[2] if len(vals) >= 3 else None
-        yield Subject(uri=clean_uri, label=label, notation=notation)
+        yield Subject(uri=clean_uri,
+                      labels=labels,
+                      notation=notation)
 
     @property
     def languages(self):
-        # we don't have information about the language(s) of labels
-        return None
+        return [self.language]
 
-    def subjects(self, language):
+    @property
+    def subjects(self):
         with open(self.path, encoding='utf-8-sig') as subjfile:
             for line in subjfile:
                 yield from self._parse_line(line)
 
-    def save_skos(self, path, language):
+    def save_skos(self, path):
         """Save the contents of the subject vocabulary into a SKOS/Turtle
         file with the given path name."""
-        serialize_subjects_to_skos(self.subjects(language), language, path)
+        serialize_subjects_to_skos(self.subjects, path)
+
+
+class SubjectFileCSV(SubjectCorpus):
+    """A multilingual subject vocabulary stored in a CSV file."""
+
+    def __init__(self, path):
+        """initialize the SubjectFileCSV given a path to a CSV file"""
+        self.path = path
+
+    def _parse_row(self, row):
+        labels = {
+            fname.replace('label_', ''): value or None
+            for fname, value in row.items()
+            if fname.startswith('label_')
+        }
+        yield Subject(uri=annif.util.cleanup_uri(row['uri']),
+                      labels=labels,
+                      notation=row.get('notation', None) or None)
+
+    @property
+    def languages(self):
+        # infer the supported languages from the CSV column names
+        with open(self.path, encoding='utf-8-sig') as csvfile:
+            reader = csv.reader(csvfile)
+            fieldnames = next(reader, None)
+
+        return [fname.replace('label_', '')
+                for fname in fieldnames
+                if fname.startswith('label_')]
+
+    @property
+    def subjects(self):
+        with open(self.path, encoding='utf-8-sig') as csvfile:
+            reader = csv.DictReader(csvfile)
+            for row in reader:
+                yield from self._parse_row(row)
+
+    def save_skos(self, path):
+        """Save the contents of the subject vocabulary into a SKOS/Turtle
+        file with the given path name."""
+        serialize_subjects_to_skos(self.subjects, path)
 
 
 class SubjectIndex:
@@ -41,43 +90,40 @@ class SubjectIndex:
     and their URIs and labels."""
 
     def __init__(self):
-        self._uris = []
-        self._labels = []
-        self._notations = []
+        self._subjects = []
         self._uri_idx = {}
         self._label_idx = {}
+        self._languages = None
 
-    def load_subjects(self, corpus, language):
-        """Initialize the subject index from a subject corpus using labels
-        in the given language."""
+    def load_subjects(self, corpus):
+        """Initialize the subject index from a subject corpus"""
 
-        for subject_id, subject in enumerate(corpus.subjects(language)):
-            self._append(subject_id, subject)
+        self._languages = corpus.languages
+        for subject in corpus.subjects:
+            self.append(subject)
 
     def __len__(self):
-        return len(self._uris)
+        return len(self._subjects)
 
     def __getitem__(self, subject_id):
-        return Subject(uri=self._uris[subject_id],
-                       label=self._labels[subject_id],
-                       notation=self._notations[subject_id])
-
-    def _append(self, subject_id, subject):
-        self._uris.append(subject.uri)
-        self._labels.append(subject.label)
-        self._notations.append(subject.notation)
-        self._uri_idx[subject.uri] = subject_id
-        self._label_idx[subject.label] = subject_id
+        return self._subjects[subject_id]
 
     def append(self, subject):
-        subject_id = len(self._uris)
-        self._append(subject_id, subject)
+        if self._languages is None:
+            self._languages = list(subject.labels.keys())
+
+        subject_id = len(self._subjects)
+        self._uri_idx[subject.uri] = subject_id
+        if subject.labels:
+            for lang, label in subject.labels.items():
+                self._label_idx[(label, lang)] = subject_id
+        self._subjects.append(subject)
 
     def contains_uri(self, uri):
         return uri in self._uri_idx
 
     def by_uri(self, uri, warnings=True):
-        """return the subject index of a subject by its URI, or None if not found.
+        """return the subject ID of a subject by its URI, or None if not found.
         If warnings=True, log a warning message if the URI cannot be found."""
         try:
             return self._uri_idx[uri]
@@ -86,49 +132,56 @@ class SubjectIndex:
                 logger.warning('Unknown subject URI <%s>', uri)
             return None
 
-    def by_label(self, label):
-        """return the subject index of a subject by its label"""
+    def by_label(self, label, language):
+        """return the subject ID of a subject by its label in a given
+        language"""
         try:
-            return self._label_idx[label]
+            return self._label_idx[(label, language)]
         except KeyError:
-            logger.warning('Unknown subject label "%s"', label)
+            logger.warning('Unknown subject label "%s"@%s', label, language)
             return None
 
     def deprecated_ids(self):
         """return indices of deprecated subjects"""
 
-        return [subject_id for subject_id, label in enumerate(self._labels)
-                if label is None]
+        return [subject_id for subject_id, subject in enumerate(self._subjects)
+                if subject.labels is None]
 
     @property
     def active(self):
-        """return a list of (subject_id, uri, label, notation) tuples of all
-        subjects that are not deprecated"""
+        """return a list of (subject_id, subject) tuples of all subjects that
+        are not deprecated"""
 
-        return [(subj_id, uri, label, notation)
-                for subj_id, (uri, label, notation)
-                in enumerate(zip(self._uris, self._labels, self._notations))
-                if label is not None]
+        return [(subj_id, subject)
+                for subj_id, subject
+                in enumerate(self._subjects)
+                if subject.labels is not None]
 
     def save(self, path):
-        """Save this subject index into a file."""
+        """Save this subject index into a file with the given path name."""
 
-        with open(path, 'w', encoding='utf-8') as subjfile:
-            for uri, label, notation in self:
-                line = "<{}>".format(uri)
-                if label is not None:
-                    line += ('\t' + label)
-                    if notation is not None:
-                        line += ('\t' + notation)
-                print(line, file=subjfile)
+        fieldnames = ['uri', 'notation']
+        for lang in self._languages:
+            fieldnames.append(f'label_{lang}')
+
+        with open(path, 'w', encoding='utf-8', newline='') as csvfile:
+            writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
+            writer.writeheader()
+            for subject in self:
+                row = {'uri': subject.uri,
+                       'notation': subject.notation or ''}
+                if subject.labels:
+                    for lang, label in subject.labels.items():
+                        row[f'label_{lang}'] = label
+                writer.writerow(row)
 
     @classmethod
     def load(cls, path):
-        """Load a subject index from a TSV file and return it."""
+        """Load a subject index from a CSV file and return it."""
 
-        corpus = SubjectFileTSV(path)
+        corpus = SubjectFileCSV(path)
         subject_index = cls()
-        subject_index.load_subjects(corpus, None)
+        subject_index.load_subjects(corpus)
         return subject_index
 
 
@@ -163,14 +216,14 @@ class SubjectSet:
         return False
 
     @classmethod
-    def from_string(cls, subj_data, subject_index):
+    def from_string(cls, subj_data, subject_index, language):
         subject_ids = set()
         for line in subj_data.splitlines():
             uri, label = cls._parse_line(line)
             if uri is not None:
                 subject_ids.add(subject_index.by_uri(uri))
             else:
-                subject_ids.add(subject_index.by_label(label))
+                subject_ids.add(subject_index.by_label(label, language))
         return cls(subject_ids)
 
     @staticmethod

--- a/annif/corpus/subject.py
+++ b/annif/corpus/subject.py
@@ -160,9 +160,8 @@ class SubjectIndex:
     def save(self, path):
         """Save this subject index into a file with the given path name."""
 
-        fieldnames = ['uri', 'notation']
-        for lang in self._languages:
-            fieldnames.append(f'label_{lang}')
+        fieldnames = ['uri', 'notation'] + \
+            [f'label_{lang}' for lang in self._languages]
 
         with open(path, 'w', encoding='utf-8', newline='') as csvfile:
             writer = csv.DictWriter(csvfile, fieldnames=fieldnames)

--- a/annif/corpus/types.py
+++ b/annif/corpus/types.py
@@ -25,7 +25,7 @@ class DocumentCorpus(metaclass=abc.ABCMeta):
             return True
 
 
-Subject = collections.namedtuple('Subject', 'uri label notation')
+Subject = collections.namedtuple('Subject', 'uri labels notation')
 
 
 class SubjectCorpus(metaclass=abc.ABCMeta):
@@ -35,4 +35,17 @@ class SubjectCorpus(metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def subjects(self):
         """Iterate through the subject corpus, yielding Subject objects."""
+        pass  # pragma: no cover
+
+    @property
+    @abc.abstractmethod
+    def languages(self):
+        """Provide a list of language codes supported by this subject
+        corpus."""
+        pass  # pragma: no cover
+
+    @abc.abstractmethod
+    def save_skos(self, path):
+        """Save the contents of the subject corpus into a SKOS/Turtle
+        file with the given path name."""
         pass  # pragma: no cover

--- a/annif/eval.py
+++ b/annif/eval.py
@@ -174,9 +174,10 @@ class EvaluationBatch:
         for row in zipped_results:
             print('\t'.join((str(e) for e in row)), file=results_file)
 
-    def output_result_per_subject(self, y_true, y_pred, results_file):
+    def output_result_per_subject(self, y_true, y_pred,
+                                  results_file, language):
         """Write results per subject (non-aggregated)
-        to outputfile results_file"""
+        to outputfile results_file, using labels in the given language"""
 
         y_pred = y_pred.T > 0.0
         y_true = y_true.T > 0.0
@@ -187,8 +188,10 @@ class EvaluationBatch:
 
         r = len(y_true)
 
-        zipped = zip(self._subject_index._uris,               # URI
-                     self._subject_index._labels,             # Label
+        zipped = zip([subj.uri
+                      for subj in self._subject_index],       # URI
+                     [subj.labels[language]
+                      for subj in self._subject_index],	      # Label
                      np.sum((true_pos + false_neg), axis=1),  # Support
                      np.sum(true_pos, axis=1),                # True_positives
                      np.sum(false_pos, axis=1),               # False_positives
@@ -202,10 +205,11 @@ class EvaluationBatch:
         self._result_per_subject_header(results_file)
         self._result_per_subject_body(zipped, results_file)
 
-    def results(self, metrics=[], results_file=None):
+    def results(self, metrics=[], results_file=None, language=None):
         """evaluate a set of selected subjects against a gold standard using
         different metrics. If metrics is empty, use all available metrics.
-        If results_file (file object) given, write results per subject to it"""
+        If results_file (file object) given, write results per subject to it
+        with labels expressed in the given language."""
 
         if not self._samples:
             raise NotSupportedException("cannot evaluate empty corpus")
@@ -222,5 +226,6 @@ class EvaluationBatch:
         results['Documents evaluated'] = int(y_true.shape[0])
 
         if results_file:
-            self.output_result_per_subject(y_true, y_pred, results_file)
+            self.output_result_per_subject(y_true, y_pred,
+                                           results_file, language)
         return results

--- a/annif/lexical/mllm.py
+++ b/annif/lexical/mllm.py
@@ -161,16 +161,18 @@ class MLLMModel:
 
         terms = []
         subject_ids = []
-        for subj_id, uri, _, _ in vocab.subjects.active:
+        for subj_id, subject in vocab.subjects.active:
             subject_ids.append(subj_id)
 
-            for label in get_subject_labels(graph, uri, pref_label_props,
+            for label in get_subject_labels(graph, subject.uri,
+                                            pref_label_props,
                                             params['language']):
                 terms.append(Term(subject_id=subj_id,
                                   label=label,
                                   is_pref=True))
 
-            for label in get_subject_labels(graph, uri, nonpref_label_props,
+            for label in get_subject_labels(graph, subject.uri,
+                                            nonpref_label_props,
                                             params['language']):
                 terms.append(Term(subject_id=subj_id,
                                   label=label,

--- a/annif/rest.py
+++ b/annif/rest.py
@@ -48,11 +48,11 @@ def show_project(project_id):
     return project.dump()
 
 
-def _suggestion_to_dict(suggestion, subject_index):
+def _suggestion_to_dict(suggestion, subject_index, language):
     subject = subject_index[suggestion.subject_id]
     return {
         'uri': subject.uri,
-        'label': subject.label,
+        'label': subject.labels[language],
         'notation': subject.notation,
         'score': suggestion.score
     }
@@ -74,7 +74,8 @@ def suggest(project_id, text, limit, threshold):
     except AnnifException as err:
         return server_error(err)
     hits = hit_filter(result).as_list()
-    return {'results': [_suggestion_to_dict(hit, project.subjects)
+    return {'results': [_suggestion_to_dict(hit, project.subjects,
+                                            project.language)
                         for hit in hits]}
 
 

--- a/annif/vocab.py
+++ b/annif/vocab.py
@@ -30,27 +30,28 @@ class AnnifVocabulary(DatadirMixin):
     # defaults for uninitialized instances
     _subjects = None
 
+    # constants
+    INDEX_FILENAME_DUMP = "subjects.dump.gz"
+    INDEX_FILENAME_TTL = "subjects.ttl"
+    INDEX_FILENAME_CSV = "subjects.csv"
+
     def __init__(self, vocab_id, datadir, language):
         DatadirMixin.__init__(self, datadir, 'vocabs', vocab_id)
         self.vocab_id = vocab_id
         self.language = language
         self._skos_vocab = None
 
-    @staticmethod
-    def _index_filename(language):
-        return f"subjects.{language}.tsv"
-
-    def _create_subject_index(self, subject_corpus, language):
+    def _create_subject_index(self, subject_corpus):
         subjects = annif.corpus.SubjectIndex()
-        subjects.load_subjects(subject_corpus, language)
+        subjects.load_subjects(subject_corpus)
         annif.util.atomic_save(subjects, self.datadir,
-                               self._index_filename(language))
+                               self.INDEX_FILENAME_CSV)
         return subjects
 
-    def _update_subject_index(self, subject_corpus, language):
+    def _update_subject_index(self, subject_corpus):
         old_subjects = self.subjects
         new_subjects = annif.corpus.SubjectIndex()
-        new_subjects.load_subjects(subject_corpus, language)
+        new_subjects.load_subjects(subject_corpus)
         updated_subjects = annif.corpus.SubjectIndex()
 
         for old_subject in old_subjects:
@@ -59,21 +60,20 @@ class AnnifVocabulary(DatadirMixin):
                     old_subject.uri)]
             else:  # subject removed from new corpus
                 new_subject = annif.corpus.Subject(uri=old_subject.uri,
-                                                   label=None,
+                                                   labels=None,
                                                    notation=None)
             updated_subjects.append(new_subject)
         for new_subject in new_subjects:
             if not old_subjects.contains_uri(new_subject.uri):
                 updated_subjects.append(new_subject)
         annif.util.atomic_save(updated_subjects, self.datadir,
-                               self._index_filename(language))
+                               self.INDEX_FILENAME_CSV)
         return updated_subjects
 
     @property
     def subjects(self):
         if self._subjects is None:
-            path = os.path.join(self.datadir,
-                                self._index_filename(self.language))
+            path = os.path.join(self.datadir, self.INDEX_FILENAME_CSV)
             if os.path.exists(path):
                 logger.debug('loading subjects from %s', path)
                 self._subjects = annif.corpus.SubjectIndex.load(path)
@@ -89,7 +89,7 @@ class AnnifVocabulary(DatadirMixin):
             return self._skos_vocab
 
         # attempt to load graph from dump file
-        dumppath = os.path.join(self.datadir, 'subjects.dump.gz')
+        dumppath = os.path.join(self.datadir, self.INDEX_FILENAME_DUMP)
         if os.path.exists(dumppath):
             logger.debug(f'loading graph dump from {dumppath}')
             try:
@@ -101,43 +101,34 @@ class AnnifVocabulary(DatadirMixin):
                 return self._skos_vocab
 
         # graph dump file not found - parse ttl file instead
-        path = os.path.join(self.datadir, 'subjects.ttl')
+        path = os.path.join(self.datadir, self.INDEX_FILENAME_TTL)
         if os.path.exists(path):
             logger.debug(f'loading graph from {path}')
             self._skos_vocab = annif.corpus.SubjectFileSKOS(path)
             # store the dump file so we can use it next time
-            self._skos_vocab.save_skos(path, self.language)
+            self._skos_vocab.save_skos(path)
             return self._skos_vocab
 
         raise NotInitializedException(f'graph file {path} not found')
 
-    def load_vocabulary(self, subject_corpus, default_language, force=False):
+    def load_vocabulary(self, subject_corpus, force=False):
         """Load subjects from a subject corpus and save them into one
         or more subject index files as well as a SKOS/Turtle file for later
         use. If force=True, replace the existing subject index completely."""
 
-        # default to language from project config if subject corpus isn't
-        # language-aware or can't detect languages
-        languages = subject_corpus.languages or [default_language]
+        if not force and os.path.exists(
+                os.path.join(self.datadir, self.INDEX_FILENAME_CSV)):
+            logger.info('updating existing vocabulary')
+            self._subjects = self._update_subject_index(subject_corpus)
+        else:
+            self._subjects = self._create_subject_index(subject_corpus)
 
-        for language in languages:
-            if not force and os.path.exists(
-                    os.path.join(self.datadir,
-                                 self._index_filename(language))):
-                logger.info('updating existing vocabulary')
-                subjects = self._update_subject_index(subject_corpus, language)
-            else:
-                subjects = self._create_subject_index(subject_corpus, language)
-
-            if language == default_language:
-                self._subjects = subjects
-
-        subject_corpus.save_skos(os.path.join(self.datadir, 'subjects.ttl'),
-                                 default_language)
+        subject_corpus.save_skos(
+            os.path.join(self.datadir, self.INDEX_FILENAME_TTL))
 
     def as_skos_file(self):
         """return the vocabulary as a file object, in SKOS/Turtle syntax"""
-        return open(os.path.join(self.datadir, 'subjects.ttl'), 'rb')
+        return open(os.path.join(self.datadir, self.INDEX_FILENAME_TTL), 'rb')
 
     def as_graph(self):
         """return the vocabulary as an rdflib graph"""

--- a/annif/vocab.py
+++ b/annif/vocab.py
@@ -126,10 +126,6 @@ class AnnifVocabulary(DatadirMixin):
         subject_corpus.save_skos(
             os.path.join(self.datadir, self.INDEX_FILENAME_TTL))
 
-    def as_skos_file(self):
-        """return the vocabulary as a file object, in SKOS/Turtle syntax"""
-        return open(os.path.join(self.datadir, self.INDEX_FILENAME_TTL), 'rb')
-
     def as_graph(self):
         """return the vocabulary as an rdflib graph"""
         return self.skos.graph

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,14 +18,13 @@ def app():
     subjfile = os.path.join(
         os.path.dirname(__file__),
         'corpora',
-        'dummy-subjects.tsv')
-    vocab = annif.corpus.SubjectFileTSV(subjfile)
+        'dummy-subjects.csv')
     app = annif.create_app(config_name='annif.default_config.TestingConfig')
     with app.app_context():
         project = annif.registry.get_project('dummy-en')
         # the vocab is needed for both English and Finnish language projects
-        project.vocab.load_vocabulary(vocab, 'en')
-        project.vocab.load_vocabulary(vocab, 'fi')
+        vocab = annif.corpus.SubjectFileCSV(subjfile)
+        project.vocab.load_vocabulary(vocab)
     return app
 
 
@@ -71,7 +70,7 @@ def subject_file():
         'corpora',
         'archaeology',
         'subjects.tsv')
-    return annif.corpus.SubjectFileTSV(docfile)
+    return annif.corpus.SubjectFileTSV(docfile, 'fi')
 
 
 @pytest.fixture(scope='module')
@@ -90,7 +89,7 @@ def vocabulary(datadir):
         'archaeology',
         'yso-archaeology.ttl')
     subjects = annif.corpus.SubjectFileSKOS(subjfile)
-    vocab.load_vocabulary(subjects, 'fi')
+    vocab.load_vocabulary(subjects)
     return vocab
 
 
@@ -117,7 +116,7 @@ def fulltext_corpus(subject_index):
         'corpora',
         'archaeology',
         'fulltext')
-    ft_corpus = annif.corpus.DocumentDirectory(ftdir, subject_index)
+    ft_corpus = annif.corpus.DocumentDirectory(ftdir, subject_index, 'fi')
     return ft_corpus
 
 

--- a/tests/corpora/archaeology/subjects.csv
+++ b/tests/corpora/archaeology/subjects.csv
@@ -1,0 +1,126 @@
+uri,notation,label_fi
+http://www.yso.fi/onto/yso/p10073,,mykeneläinen kulttuuri
+http://www.yso.fi/onto/yso/p10174,,fosfaattianalyysi
+http://www.yso.fi/onto/yso/p10295,,kykladinen kulttuuri
+http://www.yso.fi/onto/yso/p10415,,rahalöydöt
+http://www.yso.fi/onto/yso/p10416,,aarrelöydöt
+http://www.yso.fi/onto/yso/p10417,,muinaisesineet
+http://www.yso.fi/onto/yso/p10826,,Askolan kulttuuri
+http://www.yso.fi/onto/yso/p10849,,arkeologit
+http://www.yso.fi/onto/yso/p10986,,piirtokirjoitukset
+http://www.yso.fi/onto/yso/p11052,,rannansiirtyminen
+http://www.yso.fi/onto/yso/p11111,,kuoppakeraaminen kulttuuri
+http://www.yso.fi/onto/yso/p11348,,klassinen arkeologia
+http://www.yso.fi/onto/yso/p1209,,kauppatiet
+http://www.yso.fi/onto/yso/p12179,,palsamointi
+http://www.yso.fi/onto/yso/p12463,,esihistoriallinen taide
+http://www.yso.fi/onto/yso/p12484,,paleoliittinen kausi
+http://www.yso.fi/onto/yso/p12627,,merovingiaika
+http://www.yso.fi/onto/yso/p1264,,kaupunkiarkeologia
+http://www.yso.fi/onto/yso/p1265,,arkeologia
+http://www.yso.fi/onto/yso/p12651,,Kundan kulttuuri
+http://www.yso.fi/onto/yso/p12738,,viikinkiaika
+http://www.yso.fi/onto/yso/p12897,,muinaismuistoalueet
+http://www.yso.fi/onto/yso/p13027,,kalliotaide
+http://www.yso.fi/onto/yso/p13489,,nuorakeraaminen kulttuuri
+http://www.yso.fi/onto/yso/p13564,,termoluminesenssi
+http://www.yso.fi/onto/yso/p13721,,etruskologia
+http://www.yso.fi/onto/yso/p14173,,kaivaukset
+http://www.yso.fi/onto/yso/p14174,,labyrintit
+http://www.yso.fi/onto/yso/p1419,,asbestikeramiikka
+http://www.yso.fi/onto/yso/p1421,,tekstiilikeramiikka
+http://www.yso.fi/onto/yso/p14303,,asuinpaikat
+http://www.yso.fi/onto/yso/p14374,,epigrammit
+http://www.yso.fi/onto/yso/p14588,,riimukivet
+http://www.yso.fi/onto/yso/p14800,,megaliittikulttuuri
+http://www.yso.fi/onto/yso/p15031,,viikinkiretket
+http://www.yso.fi/onto/yso/p16323,,asutushistoria
+http://www.yso.fi/onto/yso/p16476,,historiallinen arkeologia
+http://www.yso.fi/onto/yso/p1747,,egyptologit
+http://www.yso.fi/onto/yso/p17863,,polttohaudat
+http://www.yso.fi/onto/yso/p18211,,molekyyliarkeologia
+http://www.yso.fi/onto/yso/p18569,,pyramidit
+http://www.yso.fi/onto/yso/p18838,,teollisuusarkeologia
+http://www.yso.fi/onto/yso/p1894,,kansainvaellukset
+http://www.yso.fi/onto/yso/p19077,,radiohiiliajoitus
+http://www.yso.fi/onto/yso/p19180,,Mesa Verde
+http://www.yso.fi/onto/yso/p19258,,Suomusjärven kulttuuri
+http://www.yso.fi/onto/yso/p19353,,kraniologia
+http://www.yso.fi/onto/yso/p19740,,obeliskit
+http://www.yso.fi/onto/yso/p20096,,kansainvaellusaika
+http://www.yso.fi/onto/yso/p20280,,normannit
+http://www.yso.fi/onto/yso/p20339,,kokeellinen arkeologia
+http://www.yso.fi/onto/yso/p20471,,mesoliittinen kausi
+http://www.yso.fi/onto/yso/p20619,,siitepölyanalyysi
+http://www.yso.fi/onto/yso/p21084,,hautakirjoitukset
+http://www.yso.fi/onto/yso/p21412,,makrofossiilit
+http://www.yso.fi/onto/yso/p21482,,hautakammiot
+http://www.yso.fi/onto/yso/p21820,,papyrukset
+http://www.yso.fi/onto/yso/p2192,,egyptologia
+http://www.yso.fi/onto/yso/p2193,,muumiot
+http://www.yso.fi/onto/yso/p2194,,hieroglyfit
+http://www.yso.fi/onto/yso/p2195,,assyriologia
+http://www.yso.fi/onto/yso/p22768,,Kiinan muuri
+http://www.yso.fi/onto/yso/p23386,,joukkohaudat
+http://www.yso.fi/onto/yso/p23677,,Eurooppalainen yleissopimus arkeologisen perinnön suojelusta
+http://www.yso.fi/onto/yso/p24443,,assyriologit
+http://www.yso.fi/onto/yso/p2557,,ristiretkiaika
+http://www.yso.fi/onto/yso/p25576,,muinaisrannat
+http://www.yso.fi/onto/yso/p2558,,rautakausi
+http://www.yso.fi/onto/yso/p26858,,zikkuratit
+http://www.yso.fi/onto/yso/p2714,,stratigrafia
+http://www.yso.fi/onto/yso/p27358,,muinaismuistolaki
+http://www.yso.fi/onto/yso/p27547,,jatulintarhat
+http://www.yso.fi/onto/yso/p27963,,kalliopiirrokset
+http://www.yso.fi/onto/yso/p27964,,kalliomaalaukset
+http://www.yso.fi/onto/yso/p28252,,yhteisöarkeologia
+http://www.yso.fi/onto/yso/p28955,,pronssipeilit
+http://www.yso.fi/onto/yso/p2932,,muinaispuvut
+http://www.yso.fi/onto/yso/p29406,,runologia
+http://www.yso.fi/onto/yso/p29433,,ympäristöarkeologia
+http://www.yso.fi/onto/yso/p3973,,antiikki
+http://www.yso.fi/onto/yso/p4622,,esihistoria
+http://www.yso.fi/onto/yso/p4624,,kivikausi
+http://www.yso.fi/onto/yso/p4625,,pronssikausi
+http://www.yso.fi/onto/yso/p4626,,varhaismetallikausi
+http://www.yso.fi/onto/yso/p4739,,Komsan kulttuuri
+http://www.yso.fi/onto/yso/p4740,,kivikautiset kulttuurit
+http://www.yso.fi/onto/yso/p4791,,uhrikivet
+http://www.yso.fi/onto/yso/p4831,,roomalainen rautakausi
+http://www.yso.fi/onto/yso/p5337,,luulöydöt
+http://www.yso.fi/onto/yso/p5338,,osteologia
+http://www.yso.fi/onto/yso/p5340,,muinaisjäännökset
+http://www.yso.fi/onto/yso/p5713,,hautalöydöt
+http://www.yso.fi/onto/yso/p5714,,muinaishaudat
+http://www.yso.fi/onto/yso/p580,,uhripaikat
+http://www.yso.fi/onto/yso/p5842,,hiidenkiukaat
+http://www.yso.fi/onto/yso/p6074,,suolöydöt
+http://www.yso.fi/onto/yso/p6218,,riimukirjoitus
+http://www.yso.fi/onto/yso/p6289,,saviastiat
+http://www.yso.fi/onto/yso/p6436,,esiroomalainen rautakausi
+http://www.yso.fi/onto/yso/p6477,,ruumishaudat
+http://www.yso.fi/onto/yso/p6479,,viikingit
+http://www.yso.fi/onto/yso/p6780,,Indus-kulttuuri
+http://www.yso.fi/onto/yso/p7141,,sinetit
+http://www.yso.fi/onto/yso/p7148,,Kiukaisten kulttuuri
+http://www.yso.fi/onto/yso/p7346,,linnavuoret
+http://www.yso.fi/onto/yso/p7347,,muinaislinnat
+http://www.yso.fi/onto/yso/p7428,,minolainen kulttuuri
+http://www.yso.fi/onto/yso/p7429,,aigeialainen kulttuuri
+http://www.yso.fi/onto/yso/p7751,,kampakeraaminen kulttuuri
+http://www.yso.fi/onto/yso/p7784,,dendrokronologia
+http://www.yso.fi/onto/yso/p7785,,kronologia
+http://www.yso.fi/onto/yso/p7804,,iänmääritys
+http://www.yso.fi/onto/yso/p8307,,sfinksit
+http://www.yso.fi/onto/yso/p8506,,haudat
+http://www.yso.fi/onto/yso/p8508,,kalmistot
+http://www.yso.fi/onto/yso/p8712,,paleografia
+http://www.yso.fi/onto/yso/p8713,,papyrologia
+http://www.yso.fi/onto/yso/p8714,,epigrafia
+http://www.yso.fi/onto/yso/p8810,,sinettitiede
+http://www.yso.fi/onto/yso/p8867,,meriarkeologia
+http://www.yso.fi/onto/yso/p8868,,vedenalainen arkeologia
+http://www.yso.fi/onto/yso/p8869,,laivalöydöt
+http://www.yso.fi/onto/yso/p8888,,foinikialainen kulttuuri
+http://www.yso.fi/onto/yso/p8993,,hylyt
+http://www.yso.fi/onto/yso/p9285,,neoliittinen kausi

--- a/tests/corpora/dummy-subjects.csv
+++ b/tests/corpora/dummy-subjects.csv
@@ -1,0 +1,3 @@
+uri,notation,label_fi,label_en
+http://example.org/dummy,,dummy,dummy
+http://example.org/none,42.42,none,none

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -34,7 +34,8 @@ def test_learn_dummy(project, tmpdir):
         '<http://www.yso.fi/onto/yso/p10849>\tarchaeologists')
     tmpdir.join('doc2.txt').write('doc2')
     tmpdir.join('doc2.tsv').write('<http://example.org/dummy>\tdummy')
-    docdir = annif.corpus.DocumentDirectory(str(tmpdir), project.subjects)
+    docdir = annif.corpus.DocumentDirectory(
+        str(tmpdir), project.subjects, 'en')
 
     dummy.learn(docdir)
 

--- a/tests/test_backend_http.py
+++ b/tests/test_backend_http.py
@@ -54,7 +54,7 @@ def test_http_suggest_with_results(app_project):
             project=app_project)
         http.project.subjects.append(Subject(
             uri='http://example.org/dummy-with-notation',
-            label='dummy',
+            labels={'en': 'dummy', 'fi': 'dummy'},
             notation='42.42'))
 
         result = http.suggest('this is some text')

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -112,6 +112,27 @@ def test_clear_project_nonexistent_data(testdatadir, caplog):
     assert expected_msg == caplog.records[0].message
 
 
+def test_loadvoc_csv(testdatadir):
+    with contextlib.suppress(FileNotFoundError):
+        os.remove(str(testdatadir.join('projects/tfidf-fi/subjects.csv')))
+    with contextlib.suppress(FileNotFoundError):
+        os.remove(str(testdatadir.join('projects/tfidf-fi/subjects.ttl')))
+    subjectfile = os.path.join(
+        os.path.dirname(__file__),
+        'corpora',
+        'archaeology',
+        'subjects.csv')
+    result = runner.invoke(annif.cli.cli, ['loadvoc', 'tfidf-fi', subjectfile])
+    assert not result.exception
+    assert result.exit_code == 0
+    assert testdatadir.join('vocabs/yso/subjects.csv').exists()
+    assert testdatadir.join('vocabs/yso/subjects.csv').size() > 0
+    assert testdatadir.join('vocabs/yso/subjects.ttl').exists()
+    assert testdatadir.join('vocabs/yso/subjects.ttl').size() > 0
+    assert testdatadir.join('vocabs/yso/subjects.dump.gz').exists()
+    assert testdatadir.join('vocabs/yso/subjects.dump.gz').size() > 0
+
+
 def test_loadvoc_tsv(testdatadir):
     with contextlib.suppress(FileNotFoundError):
         os.remove(str(testdatadir.join('projects/tfidf-fi/subjects.csv')))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -114,7 +114,7 @@ def test_clear_project_nonexistent_data(testdatadir, caplog):
 
 def test_loadvoc_tsv(testdatadir):
     with contextlib.suppress(FileNotFoundError):
-        os.remove(str(testdatadir.join('projects/tfidf-fi/subjects.fi.tsv')))
+        os.remove(str(testdatadir.join('projects/tfidf-fi/subjects.csv')))
     with contextlib.suppress(FileNotFoundError):
         os.remove(str(testdatadir.join('projects/tfidf-fi/subjects.ttl')))
     subjectfile = os.path.join(
@@ -125,8 +125,8 @@ def test_loadvoc_tsv(testdatadir):
     result = runner.invoke(annif.cli.cli, ['loadvoc', 'tfidf-fi', subjectfile])
     assert not result.exception
     assert result.exit_code == 0
-    assert testdatadir.join('vocabs/yso/subjects.fi.tsv').exists()
-    assert testdatadir.join('vocabs/yso/subjects.fi.tsv').size() > 0
+    assert testdatadir.join('vocabs/yso/subjects.csv').exists()
+    assert testdatadir.join('vocabs/yso/subjects.csv').size() > 0
     assert testdatadir.join('vocabs/yso/subjects.ttl').exists()
     assert testdatadir.join('vocabs/yso/subjects.ttl').size() > 0
     assert testdatadir.join('vocabs/yso/subjects.dump.gz').exists()
@@ -135,7 +135,7 @@ def test_loadvoc_tsv(testdatadir):
 
 def test_loadvoc_tsv_with_bom(testdatadir):
     with contextlib.suppress(FileNotFoundError):
-        os.remove(str(testdatadir.join('projects/tfidf-fi/subjects.fi.tsv')))
+        os.remove(str(testdatadir.join('projects/tfidf-fi/subjects.csv')))
     with contextlib.suppress(FileNotFoundError):
         os.remove(str(testdatadir.join('projects/tfidf-fi/subjects.ttl')))
     subjectfile = os.path.join(
@@ -146,8 +146,8 @@ def test_loadvoc_tsv_with_bom(testdatadir):
     result = runner.invoke(annif.cli.cli, ['loadvoc', 'tfidf-fi', subjectfile])
     assert not result.exception
     assert result.exit_code == 0
-    assert testdatadir.join('vocabs/yso/subjects.fi.tsv').exists()
-    assert testdatadir.join('vocabs/yso/subjects.fi.tsv').size() > 0
+    assert testdatadir.join('vocabs/yso/subjects.csv').exists()
+    assert testdatadir.join('vocabs/yso/subjects.csv').size() > 0
     assert testdatadir.join('vocabs/yso/subjects.ttl').exists()
     assert testdatadir.join('vocabs/yso/subjects.ttl').size() > 0
     assert testdatadir.join('vocabs/yso/subjects.dump.gz').exists()
@@ -156,7 +156,7 @@ def test_loadvoc_tsv_with_bom(testdatadir):
 
 def test_loadvoc_rdf(testdatadir):
     with contextlib.suppress(FileNotFoundError):
-        os.remove(str(testdatadir.join('projects/tfidf-fi/subjects.fi.tsv')))
+        os.remove(str(testdatadir.join('projects/tfidf-fi/subjects.csv')))
     with contextlib.suppress(FileNotFoundError):
         os.remove(str(testdatadir.join('projects/tfidf-fi/subjects.ttl')))
     subjectfile = os.path.join(
@@ -167,8 +167,8 @@ def test_loadvoc_rdf(testdatadir):
     result = runner.invoke(annif.cli.cli, ['loadvoc', 'tfidf-fi', subjectfile])
     assert not result.exception
     assert result.exit_code == 0
-    assert testdatadir.join('vocabs/yso/subjects.fi.tsv').exists()
-    assert testdatadir.join('vocabs/yso/subjects.fi.tsv').size() > 0
+    assert testdatadir.join('vocabs/yso/subjects.csv').exists()
+    assert testdatadir.join('vocabs/yso/subjects.csv').size() > 0
     assert testdatadir.join('vocabs/yso/subjects.ttl').exists()
     assert testdatadir.join('vocabs/yso/subjects.ttl').size() > 0
     assert testdatadir.join('vocabs/yso/subjects.dump.gz').exists()
@@ -177,7 +177,7 @@ def test_loadvoc_rdf(testdatadir):
 
 def test_loadvoc_ttl(testdatadir):
     with contextlib.suppress(FileNotFoundError):
-        os.remove(str(testdatadir.join('projects/tfidf-fi/subjects.fi.tsv')))
+        os.remove(str(testdatadir.join('projects/tfidf-fi/subjects.csv')))
     with contextlib.suppress(FileNotFoundError):
         os.remove(str(testdatadir.join('projects/tfidf-fi/subjects.ttl')))
     subjectfile = os.path.join(
@@ -188,8 +188,8 @@ def test_loadvoc_ttl(testdatadir):
     result = runner.invoke(annif.cli.cli, ['loadvoc', 'tfidf-fi', subjectfile])
     assert not result.exception
     assert result.exit_code == 0
-    assert testdatadir.join('vocabs/yso/subjects.fi.tsv').exists()
-    assert testdatadir.join('vocabs/yso/subjects.fi.tsv').size() > 0
+    assert testdatadir.join('vocabs/yso/subjects.csv').exists()
+    assert testdatadir.join('vocabs/yso/subjects.csv').size() > 0
     assert testdatadir.join('vocabs/yso/subjects.ttl').exists()
     assert testdatadir.join('vocabs/yso/subjects.ttl').size() > 0
     assert testdatadir.join('vocabs/yso/subjects.dump.gz').exists()

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -12,7 +12,7 @@ def test_subjectset_uris(subject_index):
     <http://www.yso.fi/onto/yso/p12738>\tviikinkiaika
     """
 
-    sset = annif.corpus.SubjectSet.from_string(data, subject_index)
+    sset = annif.corpus.SubjectSet.from_string(data, subject_index, 'fi')
     assert len(sset) == 2
     assert subject_index.by_uri("http://www.yso.fi/onto/yso/p2558") in sset
     assert subject_index.by_uri("http://www.yso.fi/onto/yso/p12738") in sset
@@ -23,10 +23,10 @@ def test_subjectset_labels(subject_index):
     viikinkiaika
     """
 
-    sset = annif.corpus.SubjectSet.from_string(data, subject_index)
+    sset = annif.corpus.SubjectSet.from_string(data, subject_index, 'fi')
     assert len(sset) == 2
-    assert subject_index.by_label("rautakausi") in sset
-    assert subject_index.by_label("viikinkiaika") in sset
+    assert subject_index.by_label("rautakausi", 'fi') in sset
+    assert subject_index.by_label("viikinkiaika", 'fi') in sset
 
 
 def test_subjectset_from_list(subject_index):
@@ -86,7 +86,7 @@ def test_docdir_key(tmpdir, subject_index):
     tmpdir.join('doc2.key').write('key2')
     tmpdir.join('doc3.txt').write('doc3')
 
-    docdir = annif.corpus.DocumentDirectory(str(tmpdir), subject_index)
+    docdir = annif.corpus.DocumentDirectory(str(tmpdir), subject_index, 'en')
     files = sorted(list(docdir))
     assert len(files) == 3
     assert files[0][0] == str(tmpdir.join('doc1.txt'))
@@ -104,7 +104,7 @@ def test_docdir_tsv(tmpdir, subject_index):
     tmpdir.join('doc2.tsv').write('<http://example.org/key2>\tkey2')
     tmpdir.join('doc3.txt').write('doc3')
 
-    docdir = annif.corpus.DocumentDirectory(str(tmpdir), subject_index)
+    docdir = annif.corpus.DocumentDirectory(str(tmpdir), subject_index, 'en')
     files = sorted(list(docdir))
     assert len(files) == 3
     assert files[0][0] == str(tmpdir.join('doc1.txt'))
@@ -123,7 +123,7 @@ def test_docdir_tsv_bom(tmpdir, subject_index):
     tmpdir.join('doc2.tsv').write(
         '<http://www.yso.fi/onto/yso/p2558>\trautakausi'.encode('utf-8-sig'))
 
-    docdir = annif.corpus.DocumentDirectory(str(tmpdir), subject_index)
+    docdir = annif.corpus.DocumentDirectory(str(tmpdir), subject_index, 'fi')
     docs = list(docdir.documents)
     assert docs[0].text == 'doc1'
     assert subject_index.by_uri(
@@ -143,7 +143,7 @@ def test_docdir_key_require_subjects(tmpdir, subject_index):
     tmpdir.join('doc3.txt').write('doc3')
 
     docdir = annif.corpus.DocumentDirectory(str(tmpdir), subject_index,
-                                            require_subjects=True)
+                                            'en', require_subjects=True)
     files = sorted(list(docdir))
     assert len(files) == 2
     assert files[0][0] == str(tmpdir.join('doc1.txt'))
@@ -160,7 +160,7 @@ def test_docdir_tsv_require_subjects(tmpdir, subject_index):
     tmpdir.join('doc3.txt').write('doc3')
 
     docdir = annif.corpus.DocumentDirectory(str(tmpdir), subject_index,
-                                            require_subjects=True)
+                                            'en', require_subjects=True)
     files = sorted(list(docdir))
     assert len(files) == 2
     assert files[0][0] == str(tmpdir.join('doc1.txt'))
@@ -179,7 +179,7 @@ def test_docdir_tsv_as_doccorpus(tmpdir, subject_index):
     tmpdir.join('doc3.txt').write('doc3')
 
     docdir = annif.corpus.DocumentDirectory(str(tmpdir), subject_index,
-                                            require_subjects=True)
+                                            'fi', require_subjects=True)
     docs = list(docdir.documents)
     assert len(docs) == 2
     assert docs[0].text == 'doc1'
@@ -200,7 +200,7 @@ def test_docdir_key_as_doccorpus(tmpdir, subject_index):
     tmpdir.join('doc3.txt').write('doc3')
 
     docdir = annif.corpus.DocumentDirectory(str(tmpdir), subject_index,
-                                            require_subjects=True)
+                                            'fi', require_subjects=True)
     docs = list(docdir.documents)
     assert len(docs) == 2
     assert docs[0].text == 'doc1'
@@ -215,7 +215,7 @@ def test_docdir_key_as_doccorpus(tmpdir, subject_index):
 
 def test_subject_by_uri(subject_index):
     subj_id = subject_index.by_uri('http://www.yso.fi/onto/yso/p7141')
-    assert subject_index[subj_id][1] == 'sinetit'
+    assert subject_index[subj_id].labels['fi'] == 'sinetit'
 
 
 def test_subject_by_uri_missing(subject_index):
@@ -224,12 +224,12 @@ def test_subject_by_uri_missing(subject_index):
 
 
 def test_subject_by_label(subject_index):
-    subj_id = subject_index.by_label('sinetit')
-    assert subject_index[subj_id][0] == 'http://www.yso.fi/onto/yso/p7141'
+    subj_id = subject_index.by_label('sinetit', 'fi')
+    assert subject_index[subj_id].uri == 'http://www.yso.fi/onto/yso/p7141'
 
 
 def test_subject_by_label_missing(subject_index):
-    subj_id = subject_index.by_label('nonexistent')
+    subj_id = subject_index.by_label('nonexistent', 'fi')
     assert subj_id is None
 
 

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -98,7 +98,7 @@ def test_evaluation_batch(subject_index):
 
     gold_set = annif.corpus.SubjectSet.from_string(
         '<http://www.yso.fi/onto/yso/p10849>\tarkeologit',
-        subject_index)
+        subject_index, 'fi')
     hits1 = annif.suggestion.ListSuggestionResult([
         # subject: archaeologists (yso:p10849)
         annif.suggestion.SubjectSuggestion(

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -128,9 +128,9 @@ def test_get_project_invalid_config_file():
 
 def test_project_load_vocabulary_tfidf(registry, subject_file, testdatadir):
     project = registry.get_project('tfidf-fi')
-    project.vocab.load_vocabulary(subject_file, 'fi')
-    assert testdatadir.join('vocabs/yso/subjects.fi.tsv').exists()
-    assert testdatadir.join('vocabs/yso/subjects.fi.tsv').size() > 0
+    project.vocab.load_vocabulary(subject_file)
+    assert testdatadir.join('vocabs/yso/subjects.csv').exists()
+    assert testdatadir.join('vocabs/yso/subjects.csv').size() > 0
 
 
 def test_project_tfidf_is_not_trained(registry):
@@ -170,7 +170,8 @@ def test_project_learn(registry, tmpdir):
     tmpdir.join('doc2.tsv').write('<http://example.org/dummy>\tdummy')
 
     project = registry.get_project('dummy-fi')
-    docdir = annif.corpus.DocumentDirectory(str(tmpdir), project.subjects)
+    docdir = annif.corpus.DocumentDirectory(
+        str(tmpdir), project.subjects, 'en')
     project.learn(docdir)
     result = project.suggest('this is some text')
     assert len(result) == 1
@@ -187,7 +188,8 @@ def test_project_learn_not_supported(registry, tmpdir):
     tmpdir.join('doc2.tsv').write('<http://example.org/key2>\tkey2')
 
     project = registry.get_project('tfidf-fi')
-    docdir = annif.corpus.DocumentDirectory(str(tmpdir), project.subjects)
+    docdir = annif.corpus.DocumentDirectory(
+        str(tmpdir), project.subjects, 'en')
     with pytest.raises(NotSupportedException):
         project.learn(docdir)
 
@@ -195,9 +197,9 @@ def test_project_learn_not_supported(registry, tmpdir):
 def test_project_load_vocabulary_fasttext(registry, subject_file, testdatadir):
     pytest.importorskip("annif.backend.fasttext")
     project = registry.get_project('fasttext-fi')
-    project.vocab.load_vocabulary(subject_file, 'fi')
-    assert testdatadir.join('vocabs/yso/subjects.fi.tsv').exists()
-    assert testdatadir.join('vocabs/yso/subjects.fi.tsv').size() > 0
+    project.vocab.load_vocabulary(subject_file)
+    assert testdatadir.join('vocabs/yso/subjects.csv').exists()
+    assert testdatadir.join('vocabs/yso/subjects.csv').size() > 0
 
 
 def test_project_train_fasttext(registry, document_corpus, testdatadir):

--- a/tests/test_suggestion.py
+++ b/tests/test_suggestion.py
@@ -156,13 +156,19 @@ def test_list_suggestions_vector_enforce_score_range(subject_index):
                 score=-0.5)])
     vector = suggestions.as_vector(len(subject_index))
     assert vector.sum() == 2.5
+    found = 0
     for subject_id, score in enumerate(vector):
-        if subject_index[subject_id][1] == 'sinetit':
+        if subject_index[subject_id].labels is None:
+            continue  # skip deprecated subjects
+        if subject_index[subject_id].labels['fi'] == 'sinetit':
             assert score == 1.0
-        elif subject_index[subject_id][1] == 'viikinkiaika':
+            found += 1
+        elif subject_index[subject_id].labels['fi'] == 'viikinkiaika':
             assert score == 0.0
+            found += 1
         else:
             assert score in (1.0, 0.5, 0.0)
+    assert found == 2
 
 
 def test_list_suggestion_result_vector_destination(subject_index):

--- a/tests/test_suggestion.py
+++ b/tests/test_suggestion.py
@@ -42,7 +42,7 @@ def test_hitfilter_zero_score(subject_index):
 def test_hitfilter_list_suggestion_results_with_deprecated_subjects(
         subject_index):
     subject_index.append(Subject(uri='http://example.org/deprecated',
-                                 label=None,
+                                 labels=None,
                                  notation=None))
     suggestions = ListSuggestionResult(
         [
@@ -70,7 +70,7 @@ def test_hitfilter_list_suggestion_results_with_deprecated_subjects(
 def test_hitfilter_vector_suggestion_results_with_deprecated_subjects(
         subject_index):
     subject_index.append(Subject(uri='http://example.org/deprecated',
-                                 label=None,
+                                 labels=None,
                                  notation=None))
     vector = np.ones(len(subject_index))
     suggestions = VectorSuggestionResult(vector)
@@ -116,9 +116,11 @@ def test_list_suggestion_result_vector(subject_index):
     assert len(vector) == len(subject_index)
     assert vector.sum() == 1.5
     for subject_id, score in enumerate(vector):
-        if subject_index[subject_id][1] == 'sinetit':
+        if subject_index[subject_id].labels is None:  # deprecated
+            assert score == 0.0
+        elif subject_index[subject_id].labels['fi'] == 'sinetit':
             assert score == 1.0
-        elif subject_index[subject_id][1] == 'viikingit':
+        elif subject_index[subject_id].labels['fi'] == 'viikingit':
             assert score == 0.5
         else:
             assert score == 0.0

--- a/tests/test_vocab.py
+++ b/tests/test_vocab.py
@@ -14,8 +14,8 @@ def load_dummy_vocab(tmpdir):
         os.path.dirname(__file__),
         'corpora',
         'dummy-subjects.tsv')
-    subjects = annif.corpus.SubjectFileTSV(subjfile)
-    vocab.load_vocabulary(subjects, 'en')
+    subjects = annif.corpus.SubjectFileTSV(subjfile, 'en')
+    vocab.load_vocabulary(subjects)
     return vocab
 
 
@@ -32,14 +32,18 @@ def test_update_subject_index_with_no_changes(tmpdir):
         os.path.dirname(__file__),
         'corpora',
         'dummy-subjects.tsv')
-    subjects = annif.corpus.SubjectFileTSV(subjfile)
+    subjects = annif.corpus.SubjectFileTSV(subjfile, 'en')
 
-    vocab.load_vocabulary(subjects, 'en')
+    vocab.load_vocabulary(subjects)
     assert len(vocab.subjects) == 2
     assert vocab.subjects.by_uri('http://example.org/dummy') == 0
-    assert vocab.subjects[0] == ('http://example.org/dummy', 'dummy', None)
+    assert vocab.subjects[0].uri == 'http://example.org/dummy'
+    assert vocab.subjects[0].labels['en'] == 'dummy'
+    assert vocab.subjects[0].notation is None
     assert vocab.subjects.by_uri('http://example.org/none') == 1
-    assert vocab.subjects[1] == ('http://example.org/none', 'none', '42.42')
+    assert vocab.subjects[1].uri == 'http://example.org/none'
+    assert vocab.subjects[1].labels['en'] == 'none'
+    assert vocab.subjects[1].notation == '42.42'
 
 
 def test_update_subject_index_with_removed_subject(tmpdir):
@@ -47,14 +51,18 @@ def test_update_subject_index_with_removed_subject(tmpdir):
 
     subjfile_new = tmpdir.join('subjects_new.tsv')
     subjfile_new.write("<http://example.org/dummy>\tdummy\n")
-    subjects_new = annif.corpus.SubjectFileTSV(str(subjfile_new))
+    subjects_new = annif.corpus.SubjectFileTSV(str(subjfile_new), 'en')
 
-    vocab.load_vocabulary(subjects_new, 'en')
+    vocab.load_vocabulary(subjects_new)
     assert len(vocab.subjects) == 2
     assert vocab.subjects.by_uri('http://example.org/dummy') == 0
-    assert vocab.subjects[0] == ('http://example.org/dummy', 'dummy', None)
+    assert vocab.subjects[0].uri == 'http://example.org/dummy'
+    assert vocab.subjects[0].labels['en'] == 'dummy'
+    assert vocab.subjects[0].notation is None
     assert vocab.subjects.by_uri('http://example.org/none') == 1
-    assert vocab.subjects[1] == ('http://example.org/none', None, None)
+    assert vocab.subjects[1].uri == 'http://example.org/none'
+    assert vocab.subjects[1].labels is None
+    assert vocab.subjects[1].notation is None
 
 
 def test_update_subject_index_with_renamed_label_and_added_notation(tmpdir):
@@ -63,15 +71,18 @@ def test_update_subject_index_with_renamed_label_and_added_notation(tmpdir):
     subjfile_new = tmpdir.join('subjects_new.tsv')
     subjfile_new.write("<http://example.org/dummy>\tdummy\n" +
                        "<http://example.org/none>\tnew none\t42.42\n")
-    subjects_new = annif.corpus.SubjectFileTSV(str(subjfile_new))
+    subjects_new = annif.corpus.SubjectFileTSV(str(subjfile_new), 'en')
 
-    vocab.load_vocabulary(subjects_new, 'en')
+    vocab.load_vocabulary(subjects_new)
     assert len(vocab.subjects) == 2
     assert vocab.subjects.by_uri('http://example.org/dummy') == 0
-    assert vocab.subjects[0] == ('http://example.org/dummy', 'dummy', None)
+    assert vocab.subjects[0].uri == 'http://example.org/dummy'
+    assert vocab.subjects[0].labels['en'] == 'dummy'
+    assert vocab.subjects[0].notation is None
     assert vocab.subjects.by_uri('http://example.org/none') == 1
-    assert vocab.subjects[1] == ('http://example.org/none', 'new none',
-                                 '42.42')
+    assert vocab.subjects[1].uri == 'http://example.org/none'
+    assert vocab.subjects[1].labels['en'] == 'new none'
+    assert vocab.subjects[1].notation == '42.42'
 
 
 def test_update_subject_index_with_added_subjects(tmpdir):
@@ -81,15 +92,18 @@ def test_update_subject_index_with_added_subjects(tmpdir):
                        "<http://example.org/none>\tnone\n" +
                        "<http://example.org/new-dummy>\tnew dummy\t42.42\n" +
                        "<http://example.org/new-none>\tnew none\n")
-    subjects_new = annif.corpus.SubjectFileTSV(str(subjfile_new))
+    subjects_new = annif.corpus.SubjectFileTSV(str(subjfile_new), 'en')
 
-    vocab.load_vocabulary(subjects_new, 'en')
+    vocab.load_vocabulary(subjects_new)
     assert len(vocab.subjects) == 4
     assert vocab.subjects.by_uri('http://example.org/dummy') == 0
-    assert vocab.subjects[0] == ('http://example.org/dummy', 'dummy', None)
+    assert vocab.subjects[0].uri == 'http://example.org/dummy'
+    assert vocab.subjects[0].labels['en'] == 'dummy'
+    assert vocab.subjects[0].notation is None
     assert vocab.subjects.by_uri('http://example.org/new-dummy') == 2
-    assert vocab.subjects[2] == ('http://example.org/new-dummy', 'new dummy',
-                                 '42.42')
+    assert vocab.subjects[2].uri == 'http://example.org/new-dummy'
+    assert vocab.subjects[2].labels['en'] == 'new dummy'
+    assert vocab.subjects[2].notation == '42.42'
 
 
 def test_update_subject_index_force(tmpdir):
@@ -98,15 +112,18 @@ def test_update_subject_index_force(tmpdir):
     subjfile_new.write("<http://example.org/dummy>\tdummy\n" +
                        "<http://example.org/new-dummy>\tnew dummy\t42.42\n" +
                        "<http://example.org/new-none>\tnew none\n")
-    subjects_new = annif.corpus.SubjectFileTSV(str(subjfile_new))
+    subjects_new = annif.corpus.SubjectFileTSV(str(subjfile_new), 'en')
 
-    vocab.load_vocabulary(subjects_new, 'en', force=True)
+    vocab.load_vocabulary(subjects_new, force=True)
     assert len(vocab.subjects) == 3
     assert vocab.subjects.by_uri('http://example.org/dummy') == 0
-    assert vocab.subjects[0] == ('http://example.org/dummy', 'dummy', None)
+    assert vocab.subjects[0].uri == 'http://example.org/dummy'
+    assert vocab.subjects[0].labels['en'] == 'dummy'
+    assert vocab.subjects[0].notation is None
     assert vocab.subjects.by_uri('http://example.org/new-dummy') == 1
-    assert vocab.subjects[1] == ('http://example.org/new-dummy', 'new dummy',
-                                 '42.42')
+    assert vocab.subjects[1].uri == 'http://example.org/new-dummy'
+    assert vocab.subjects[1].labels['en'] == 'new dummy'
+    assert vocab.subjects[1].notation == '42.42'
 
 
 def test_skos(tmpdir):

--- a/tests/test_vocab_csv.py
+++ b/tests/test_vocab_csv.py
@@ -1,0 +1,96 @@
+"""Unit tests for CSV vocabulary functionality in Annif"""
+
+
+from annif.corpus import SubjectFileCSV, SubjectIndex
+
+
+def test_recognize_csv_lowercase():
+    assert SubjectFileCSV.is_csv_file('subjects.csv')
+
+
+def test_recognize_csv_uppercase():
+    assert SubjectFileCSV.is_csv_file('SUBJECTS.CSV')
+
+
+def test_recognize_tsv():
+    assert not SubjectFileCSV.is_csv_file('subjects.tsv')
+
+
+def test_recognize_noext():
+    assert not SubjectFileCSV.is_csv_file('subjects')
+
+
+def test_load_csv_uri_brackets(tmpdir):
+    tmpfile = tmpdir.join('subjects.csv')
+    tmpfile.write("uri,label_fi\n" +
+                  "<http://www.yso.fi/onto/yso/p8993>,hylyt\n" +
+                  "<http://www.yso.fi/onto/yso/p9285>,neoliittinen kausi")
+
+    corpus = SubjectFileCSV(str(tmpfile))
+    subjects = list(corpus.subjects)
+    assert len(subjects) == 2
+    assert subjects[0].uri == 'http://www.yso.fi/onto/yso/p8993'
+    assert subjects[0].labels['fi'] == 'hylyt'
+    assert subjects[0].notation is None
+    assert subjects[1].uri == 'http://www.yso.fi/onto/yso/p9285'
+    assert subjects[1].labels['fi'] == 'neoliittinen kausi'
+    assert subjects[1].notation is None
+
+
+def test_load_tsv_uri_nobrackets(tmpdir):
+    tmpfile = tmpdir.join('subjects.csv')
+    tmpfile.write("uri,label_fi\n" +
+                  "http://www.yso.fi/onto/yso/p8993,hylyt\n" +
+                  "http://www.yso.fi/onto/yso/p9285,neoliittinen kausi")
+
+    corpus = SubjectFileCSV(str(tmpfile))
+    subjects = list(corpus.subjects)
+    assert len(subjects) == 2
+    assert subjects[0].uri == 'http://www.yso.fi/onto/yso/p8993'
+    assert subjects[0].labels['fi'] == 'hylyt'
+    assert subjects[0].notation is None
+    assert subjects[1].uri == 'http://www.yso.fi/onto/yso/p9285'
+    assert subjects[1].labels['fi'] == 'neoliittinen kausi'
+    assert subjects[1].notation is None
+
+
+def test_load_tsv_with_notations(tmpdir):
+    tmpfile = tmpdir.join('subjects-with-notations.csv')
+    tmpfile.write("uri,label_fi,notation\n" +
+                  "http://www.yso.fi/onto/yso/p8993,hylyt,42.42\n" +
+                  "http://www.yso.fi/onto/yso/p9285,neoliittinen kausi,42.0")
+
+    corpus = SubjectFileCSV(str(tmpfile))
+    subjects = list(corpus.subjects)
+    assert len(subjects) == 2
+    assert subjects[0].uri == 'http://www.yso.fi/onto/yso/p8993'
+    assert subjects[0].labels['fi'] == 'hylyt'
+    assert subjects[0].notation == '42.42'
+    assert subjects[1].uri == 'http://www.yso.fi/onto/yso/p9285'
+    assert subjects[1].labels['fi'] == 'neoliittinen kausi'
+    assert subjects[1].notation == '42.0'
+
+
+def test_load_tsv_with_deprecated(tmpdir):
+    tmpfile = tmpdir.join('subjects.csv')
+    tmpfile.write("uri,label_fi\n" +
+                  "<http://www.yso.fi/onto/yso/p8993>,hylyt\n" +
+                  "<http://example.org/deprecated>,\n" +
+                  "<http://www.yso.fi/onto/yso/p9285>,neoliittinen kausi")
+
+    corpus = SubjectFileCSV(str(tmpfile))
+    subjects = list(corpus.subjects)
+    assert len(list(corpus.subjects)) == 3
+    assert subjects[1].labels is None
+
+    index = SubjectIndex()
+    index.load_subjects(corpus)
+
+    active = list(index.active)
+    assert len(active) == 2
+    assert active[0][1].uri == 'http://www.yso.fi/onto/yso/p8993'
+    assert active[0][1].labels['fi'] == 'hylyt'
+    assert active[0][1].notation is None
+    assert active[1][1].uri == 'http://www.yso.fi/onto/yso/p9285'
+    assert active[1][1].labels['fi'] == 'neoliittinen kausi'
+    assert active[1][1].notation is None

--- a/tests/test_vocab_skos.py
+++ b/tests/test_vocab_skos.py
@@ -47,10 +47,11 @@ yso:p9285
     """)
 
     corpus = SubjectFileSKOS(str(tmpfile))
-    subjects = list(corpus.subjects('fi'))
+    subjects = list(corpus.subjects)
     assert len(subjects) == 1  # one of the concepts was deprecated
     assert subjects[0].uri == 'http://www.yso.fi/onto/yso/p8993'
-    assert subjects[0].label == 'hylyt'
+    print(subjects[0].labels)
+    assert subjects[0].labels['fi'] == 'hylyt'
     assert subjects[0].notation is None
 
 
@@ -69,9 +70,9 @@ yso:p8993
     """)
 
     corpus = SubjectFileSKOS(str(tmpfile))
-    subjects = list(corpus.subjects('fi'))
+    subjects = list(corpus.subjects)
     assert subjects[0].uri == 'http://www.yso.fi/onto/yso/p8993'
-    assert subjects[0].label == 'hylyt'
+    assert subjects[0].labels['fi'] == 'hylyt'
     assert subjects[0].notation == '42.42'
 
 
@@ -94,14 +95,14 @@ ex:conc3 a skos:Concept .
     """)
 
     corpus = SubjectFileSKOS(str(tmpfile))
-    subjects = list(corpus.subjects('en'))
+    subjects = list(corpus.subjects)
     assert len(subjects) == 3
 
     # check that the vocabulary contains the expected labels
-    labels = {subj.label for subj in subjects}
-    assert 'Concept 1' in labels
-    assert 'Concept 2' in labels
-    assert 'ex:conc3' in labels
+    en_labels = {subj.labels['en'] for subj in subjects}
+    assert 'Concept 1' in en_labels
+    assert 'Concept 2' in en_labels
+    assert 'ex:conc3' in en_labels
 
 
 def test_load_turtle_get_languages(testdatadir):

--- a/tests/test_vocab_tsv.py
+++ b/tests/test_vocab_tsv.py
@@ -1,7 +1,7 @@
 """Unit tests for TSV vocabulary functionality in Annif"""
 
 
-from annif.corpus import SubjectIndex
+from annif.corpus import SubjectFileTSV, SubjectIndex
 
 
 def test_load_tsv_uri_brackets(tmpdir):
@@ -9,12 +9,15 @@ def test_load_tsv_uri_brackets(tmpdir):
     tmpfile.write("<http://www.yso.fi/onto/yso/p8993>\thylyt\n" +
                   "<http://www.yso.fi/onto/yso/p9285>\tneoliittinen kausi")
 
-    index = SubjectIndex.load(str(tmpfile))
-    assert len(index) == 2
-    assert index[0] == ('http://www.yso.fi/onto/yso/p8993', 'hylyt', None)
-    assert index[1] == (
-        'http://www.yso.fi/onto/yso/p9285',
-        'neoliittinen kausi', None)
+    corpus = SubjectFileTSV(str(tmpfile), 'fi')
+    subjects = list(corpus.subjects)
+    assert len(subjects) == 2
+    assert subjects[0].uri == 'http://www.yso.fi/onto/yso/p8993'
+    assert subjects[0].labels['fi'] == 'hylyt'
+    assert subjects[0].notation is None
+    assert subjects[1].uri == 'http://www.yso.fi/onto/yso/p9285'
+    assert subjects[1].labels['fi'] == 'neoliittinen kausi'
+    assert subjects[1].notation is None
 
 
 def test_load_tsv_uri_nobrackets(tmpdir):
@@ -22,12 +25,15 @@ def test_load_tsv_uri_nobrackets(tmpdir):
     tmpfile.write("http://www.yso.fi/onto/yso/p8993\thylyt\n" +
                   "http://www.yso.fi/onto/yso/p9285\tneoliittinen kausi")
 
-    index = SubjectIndex.load(str(tmpfile))
-    assert len(index) == 2
-    assert index[0] == ('http://www.yso.fi/onto/yso/p8993', 'hylyt', None)
-    assert index[1] == (
-        'http://www.yso.fi/onto/yso/p9285',
-        'neoliittinen kausi', None)
+    corpus = SubjectFileTSV(str(tmpfile), 'fi')
+    subjects = list(corpus.subjects)
+    assert len(subjects) == 2
+    assert subjects[0].uri == 'http://www.yso.fi/onto/yso/p8993'
+    assert subjects[0].labels['fi'] == 'hylyt'
+    assert subjects[0].notation is None
+    assert subjects[1].uri == 'http://www.yso.fi/onto/yso/p9285'
+    assert subjects[1].labels['fi'] == 'neoliittinen kausi'
+    assert subjects[1].notation is None
 
 
 def test_load_tsv_with_notations(tmpdir):
@@ -35,12 +41,15 @@ def test_load_tsv_with_notations(tmpdir):
     tmpfile.write("http://www.yso.fi/onto/yso/p8993\thylyt\t42.42\n" +
                   "http://www.yso.fi/onto/yso/p9285\tneoliittinen kausi\t42.0")
 
-    index = SubjectIndex.load(str(tmpfile))
-    assert len(index) == 2
-    assert index[0] == ('http://www.yso.fi/onto/yso/p8993', 'hylyt', '42.42')
-    assert index[1] == (
-        'http://www.yso.fi/onto/yso/p9285',
-        'neoliittinen kausi', '42.0')
+    corpus = SubjectFileTSV(str(tmpfile), 'fi')
+    subjects = list(corpus.subjects)
+    assert len(subjects) == 2
+    assert subjects[0].uri == 'http://www.yso.fi/onto/yso/p8993'
+    assert subjects[0].labels['fi'] == 'hylyt'
+    assert subjects[0].notation == '42.42'
+    assert subjects[1].uri == 'http://www.yso.fi/onto/yso/p9285'
+    assert subjects[1].labels['fi'] == 'neoliittinen kausi'
+    assert subjects[1].notation == '42.0'
 
 
 def test_load_tsv_with_deprecated(tmpdir):
@@ -49,10 +58,19 @@ def test_load_tsv_with_deprecated(tmpdir):
                   "<http://example.org/deprecated>\t\n" +
                   "<http://www.yso.fi/onto/yso/p9285>\tneoliittinen kausi")
 
-    index = SubjectIndex.load(str(tmpfile))
-    assert len(index) == 3
-    assert len(index.active) == 2
+    corpus = SubjectFileTSV(str(tmpfile), 'fi')
+    subjects = list(corpus.subjects)
+    assert len(list(corpus.subjects)) == 3
+    assert subjects[1].labels is None
+
+    index = SubjectIndex()
+    index.load_subjects(corpus)
+
     active = list(index.active)
-    assert active[0] == (0, 'http://www.yso.fi/onto/yso/p8993', 'hylyt', None)
-    assert active[1] == \
-        (2, 'http://www.yso.fi/onto/yso/p9285', 'neoliittinen kausi', None)
+    assert len(active) == 2
+    assert active[0][1].uri == 'http://www.yso.fi/onto/yso/p8993'
+    assert active[0][1].labels['fi'] == 'hylyt'
+    assert active[0][1].notation is None
+    assert active[1][1].uri == 'http://www.yso.fi/onto/yso/p9285'
+    assert active[1][1].labels['fi'] == 'neoliittinen kausi'
+    assert active[1][1].notation is None


### PR DESCRIPTION
This PR completes (hopefully) the switch to multilingual vocabularies (#559) started in PR #600 and continued in PRs #604 and #606. It changes the SubjectIndex so that it keeps track of labels in all available languages, not just one at a time. The index is stored on disk in a CSV file which stores the labels in different columns named e.g. `label_en`, `label_fi`, `label_sv` etc. It replaces the current short-lived format where separate TSV files for each language were used (`subjects.en.tsv`, `subjects.fi.tsv` etc.). It turned out to be easier and cleaner to have just a single file containing labels in all languages. CSV is a good format for this as the columns can be named in a header row, so there is some flexibility in which columns are used.

It is also possible to use this CSV format to represent multilingual vocabularies that can be loaded with the `annif loadvoc` command.
