### PR TITLE
Store vocabs in AnnifRegistry so they are shared between projects

### DIFF
--- a/annif/project.py
+++ b/annif/project.py
@@ -9,7 +9,6 @@ import annif.analyzer
 import annif.corpus
 import annif.suggestion
 import annif.backend
-import annif.vocab
 from annif.datadir import DatadirMixin
 from annif.exception import AnnifException, ConfigurationException, \
     NotSupportedException, NotInitializedException
@@ -155,9 +154,8 @@ class AnnifProject(DatadirMixin):
             if self.vocab_spec is None:
                 raise ConfigurationException("vocab setting is missing",
                                              project_id=self.project_id)
-            self._vocab = annif.vocab.get_vocab(self.vocab_spec,
-                                                self._base_datadir,
-                                                self.language)
+            self._vocab = self.registry.get_vocab(self.vocab_spec,
+                                                  self.language)
 
         return self._vocab
 

--- a/annif/registry.py
+++ b/annif/registry.py
@@ -1,35 +1,41 @@
 """Registry that keeps track of Annif projects"""
 
 import collections
+import re
 from flask import current_app
 import annif
 from annif.config import parse_config
 from annif.project import Access, AnnifProject
+from annif.vocab import AnnifVocabulary
+from annif.util import parse_args
 
 logger = annif.logger
 
 
 class AnnifRegistry:
-    """Class that keeps track of the Annif projects"""
+    """Class that keeps track of the Annif projects and vocabularies"""
 
-    # Note: The individual projects are stored in a shared static variable,
-    # keyed by the "registry ID" which is unique to the registry instance.
-    # This is done to make it possible to serialize AnnifRegistry instances
-    # without including the potentially huge project objects (which contain
-    # backends with large models, vocabularies with lots of concepts etc).
-    # Serialized AnnifRegistry instances can then be passed between
-    # processes when using the multiprocessing module.
+    # Note: The individual projects and vocabularies are stored in shared
+    # static variables, keyed by the "registry ID" which is unique to the
+    # registry instance. This is done to make it possible to serialize
+    # AnnifRegistry instances without including the potentially huge objects
+    # (which contain backends with large models, vocabularies with lots of
+    # concepts etc). Serialized AnnifRegistry instances can then be passed
+    # between processes when using the multiprocessing module.
     _projects = {}
+    _vocabs = {}
 
     def __init__(self, projects_config_path, datadir, init_projects):
         self._rid = id(self)
+        self._datadir = datadir
         self._projects[self._rid] = \
-            self._create_projects(projects_config_path, datadir)
+            self._create_projects(projects_config_path)
+        self._vocabs[self._rid] = {}
         if init_projects:
             for project in self._projects[self._rid].values():
                 project.initialize()
 
-    def _create_projects(self, projects_config_path, datadir):
+    def _create_projects(self, projects_config_path):
         # parse the configuration
         config = parse_config(projects_config_path)
 
@@ -42,7 +48,7 @@ class AnnifRegistry:
         for project_id in config.project_ids:
             projects[project_id] = AnnifProject(project_id,
                                                 config[project_id],
-                                                datadir,
+                                                self._datadir,
                                                 self)
         return projects
 
@@ -63,6 +69,23 @@ class AnnifRegistry:
             return projects[project_id]
         except KeyError:
             raise ValueError("No such project {}".format(project_id))
+
+    def get_vocab(self, vocab_spec, default_language):
+        """Return an AnnifVocabulary corresponding to the vocab_spec. If no
+        language information is specified, use the given default language."""
+        match = re.match(r'(\w+)(\((.*)\))?', vocab_spec)
+        if match is None:
+            raise ValueError(
+                f"Invalid vocabulary specification: {vocab_spec}")
+        vocab_id = match.group(1)
+        posargs, kwargs = parse_args(match.group(3))
+        language = posargs[0] if posargs else default_language
+        vocab_key = (vocab_id, language)
+
+        if vocab_key not in self._vocabs[self._rid]:
+            self._vocabs[self._rid][vocab_key] = AnnifVocabulary(
+                vocab_id, self._datadir, language)
+        return self._vocabs[self._rid][vocab_key]
 
 
 def initialize_projects(app):

--- a/annif/vocab.py
+++ b/annif/vocab.py
@@ -1,26 +1,13 @@
 """Vocabulary management functionality for Annif"""
 
 import os.path
-import re
 import annif
 import annif.corpus
 import annif.util
 from annif.datadir import DatadirMixin
 from annif.exception import NotInitializedException
-from annif.util import parse_args
 
 logger = annif.logger
-
-
-def get_vocab(vocab_spec, datadir, default_language):
-    match = re.match(r'(\w+)(\((.*)\))?', vocab_spec)
-    if match is None:
-        raise ValueError(f"Invalid vocabulary specification: {vocab_spec}")
-    vocab_id = match.group(1)
-    posargs, kwargs = parse_args(match.group(3))
-    language = posargs[0] if posargs else default_language
-
-    return AnnifVocabulary(vocab_id, datadir, language)
 
 
 class AnnifVocabulary(DatadirMixin):

--- a/tests/test_vocab.py
+++ b/tests/test_vocab.py
@@ -19,9 +19,9 @@ def load_dummy_vocab(tmpdir):
     return vocab
 
 
-def test_get_vocab_invalid():
+def test_get_vocab_invalid(registry):
     with pytest.raises(ValueError) as excinfo:
-        annif.vocab.get_vocab('', None, None)
+        registry.get_vocab('', None)
     assert 'Invalid vocabulary specification' in str(excinfo.value)
 
 


### PR DESCRIPTION
Fixes #603

This PR makes the handling of vocabularies more efficient by making it possible to use a single AnnifVocabulary instance shared by multiple projects. The vocabularies are now stored in AnnifRegistry, similar to how projects are stored.

I did a little benchmarking. I set up TFIDF, MLLM and Parabel projects with YSO as the vocabulary, as well as an ensemble using these three as sources. I trained them using the archaeology test corpora from the test suite. Then I measured the user time and maximum RSS of two commands targeting the ensemble project: a simple `annif suggest` and a parallelized `annif eval -j4` command against the fulltext documents in the test suite, before and after this PR:

|           | time before | time after | RSS before | RSS after |
|-----------|-------------|------------|------------|-----------|
| suggest   | 6.81        | 5.51       | 438072     | 305828    |
| eval -j 4 | 24.35       | 23.24      | 418492     | 304464    |

This PR avoids loading the YSO vocabulary four times (once per project) and instead loads it only once. The result is 1.1-1.3 second reduction in CPU time and 110-130MB reduction in RAM usage.