### PR TITLE
Autogenerated CLI commands documentation on ReadTheDocs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -31,6 +31,6 @@ python:
         - pycld3
         - spacy
     - requirements: docs/requirements.txt
-    - method: setuptools
+    - method: pip
       path: .
   system_packages: true

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -26,6 +26,10 @@ python:
         - voikko
         - nn
         - omikuji
+        - fasttext
+        - yake
+        - pycld3
+        - spacy
     - requirements: docs/requirements.txt
     - method: setuptools
       path: .

--- a/annif/cli.py
+++ b/annif/cli.py
@@ -135,10 +135,6 @@ def run_list_projects():
     """
     List available projects.
     \f
-    REST equivalent::
-
-        GET /projects/
-
     Show a list of currently defined projects. Projects are defined in a
     configuration file, normally called ``projects.cfg``. See Project
     configuration for details
@@ -161,10 +157,6 @@ def run_list_projects():
 def run_show_project(project_id):
     """
     Show information about a project.
-    \f
-    REST equivalent::
-
-        GET /projects/<PROJECT_ID>
     """
 
     proj = get_project(project_id)
@@ -182,8 +174,6 @@ def run_show_project(project_id):
 def run_clear_project(project_id):
     """
     Initialize the project to its original, untrained state.
-    \f
-    REST equivalent: N/A
     """
     proj = get_project(project_id)
     proj.remove_model_data()
@@ -212,8 +202,6 @@ def run_loadvoc(project_id, force, subjectfile):
     Note that new subjects will not be suggested before the project is
     retrained with the updated vocabulary. The update behavior can be
     overridden with the ``--force`` option.
-
-    REST equivalent: N/A
     """
     proj = get_project(project_id)
     if annif.corpus.SubjectFileSKOS.is_rdf_file(subjectfile):
@@ -248,8 +236,6 @@ def run_train(project_id, paths, cached, docs_limit, jobs, backend_param):
     \f
     This will train the project using all the documents from the given
     directory or TSV file in a single batch operation.
-
-    REST equivalent: N/A
     """
     proj = get_project(project_id)
     backend_params = parse_backend_params(backend_param, proj)
@@ -279,10 +265,6 @@ def run_learn(project_id, paths, docs_limit, backend_param):
     This will continue training an already trained project using all the
     documents from the given directory or TSV file in a single batch operation.
     Not supported by all backends.
-
-    REST equivalent::
-
-         /projects/<PROJECT_ID>/learn
     """
     proj = get_project(project_id)
     backend_params = parse_backend_params(backend_param, proj)
@@ -303,10 +285,6 @@ def run_suggest(project_id, limit, threshold, backend_param):
     \f
     This will read a text document from standard input and suggest subjects for
     it.
-
-    REST equivalent::
-
-        POST /projects/<PROJECT_ID>/suggest
     """
     project = get_project(project_id)
     text = sys.stdin.read()
@@ -343,8 +321,6 @@ def run_index(project_id, directory, suffix, force,
     """
     Index a directory with documents, suggesting subjects for each document.
     Write the results in TSV files with the given suffix.
-    \f
-    REST equivalent: N/A
     """
     project = get_project(project_id)
     backend_params = parse_backend_params(backend_param, project)
@@ -431,8 +407,6 @@ def run_eval(
     case they will all be processed in the same run.
 
     The output is a list of statistical measures.
-
-    REST equivalent: N/A
     """
 
     project = get_project(project_id)
@@ -500,9 +474,6 @@ def run_optimize(project_id, paths, docs_limit, backend_param):
     The output is a list of parameter combinations and their scores. From the
     output, you can determine the optimum limit and threshold parameters
     depending on which measure you want to target.
-
-    REST equivalent: N/A
-
     """
     project = get_project(project_id)
     backend_params = parse_backend_params(backend_param, project)
@@ -589,8 +560,6 @@ def run_hyperopt(project_id, paths, docs_limit, trials, jobs, metric,
                  results_file):
     """
     Optimize the hyperparameters of a project using a validation corpus.
-    \f
-    REST equivalent: N/A
     """
     proj = get_project(project_id)
     documents = open_documents(paths, proj.subjects,

--- a/annif/cli.py
+++ b/annif/cli.py
@@ -236,10 +236,10 @@ def run_train(project_id, paths, cached, docs_limit, jobs, backend_param):
     """
     Train a project on a collection of documents.
     \f
-    This will train the project using the documents from all TSV files
-    (possibly gzipped) or directories given by ``PATHS`` in a single batch
-    operation, or if ``--cached`` is set, reuse preprocessed training data from
-    the previous run. See `Reusing preprocessed training data
+    This will train the project using the documents from ``PATHS`` (directories
+    or possibly gzipped TSV files) in a single batch operation. If ``--cached``
+    is set, preprocessed training data from the previous run is reused instead
+    of documents input; see `Reusing preprocessed training data
     <https://github.com/NatLibFi/Annif/wiki/
     Reusing-preprocessed-training-data>`_.
     """
@@ -268,9 +268,9 @@ def run_learn(project_id, paths, docs_limit, backend_param):
     """
     Further train an existing project on a collection of documents.
     \f
-    This will continue training an already trained project using the documents
-    from all TSV files (possibly gzipped) or directories given by ``PATHS`` in
-    a single batch operation. Not supported by all backends.
+    Similar to the ``train`` command. This will continue training an already
+    trained project using the documents given by ``PATHS`` in a single batch
+    operation. Not supported by all backends.
     """
     proj = get_project(project_id)
     backend_params = parse_backend_params(backend_param, proj)
@@ -326,7 +326,8 @@ def run_index(project_id, directory, suffix, force,
               limit, threshold, backend_param):
     """
     Index a directory with documents, suggesting subjects for each document.
-    Write the results in TSV files with the given suffix (default ``.annif``).
+    Write the results in TSV files with the given suffix (``.annif`` by
+    default).
     """
     project = get_project(project_id)
     backend_params = parse_backend_params(backend_param, project)
@@ -406,10 +407,10 @@ def run_eval(
     Suggest subjects for documents and evaluate the results by comparing
     against a gold standard.
     \f
-    With this command the documents from the TSV files (possibly gzipped) or
-    directories given by ``PATHS`` will be assigned subject suggestions and
-    then statistical measures are calculated that quantify how well the
-    suggested subjects match the gold-standard subjects in the documents.
+    With this command the documents from ``PATHS`` (directories or possibly
+    gzipped TSV files) will be assigned subject suggestions and then
+    statistical measures are calculated that quantify how well the suggested
+    subjects match the gold-standard subjects in the documents.
 
     Normally the output is the list of the metrics calculated across documents.
     If ``--results-file <FILENAME>`` option is given, the metrics are
@@ -560,8 +561,9 @@ def run_optimize(project_id, paths, docs_limit, backend_param):
 def run_hyperopt(project_id, paths, docs_limit, trials, jobs, metric,
                  results_file):
     """
-    Optimize the hyperparameters of a project using a validation corpus. Not
-    supported by all backends.
+    Optimize the hyperparameters of a project using validation documents from
+    ``PATHS``. Not supported by all backends. Output is a list of trial results
+    and a report of the best performing parameters.
     """
     proj = get_project(project_id)
     documents = open_documents(paths, proj.subjects,

--- a/annif/cli.py
+++ b/annif/cli.py
@@ -136,8 +136,10 @@ def run_list_projects():
     List available projects.
     \f
     Show a list of currently defined projects. Projects are defined in a
-    configuration file, normally called ``projects.cfg``. See Project
-    configuration for details
+    configuration file, normally called ``projects.cfg``. See `Project
+    configuration
+    <https://github.com/NatLibFi/Annif/wiki/Project-configuration>`_
+    for details.
     """
 
     template = "{0: <25}{1: <45}{2: <10}{3: <7}"
@@ -234,8 +236,12 @@ def run_train(project_id, paths, cached, docs_limit, jobs, backend_param):
     """
     Train a project on a collection of documents.
     \f
-    This will train the project using all the documents from the given
-    directory or TSV file in a single batch operation.
+    This will train the project using the documents from all TSV files
+    (possibly gzipped) or directories given by ``PATHS`` in a single batch
+    operation, or if ``--cached`` is set, reuse preprocessed training data from
+    the previous run. See `Reusing preprocessed training data
+    <https://github.com/NatLibFi/Annif/wiki/
+    Reusing-preprocessed-training-data>`_.
     """
     proj = get_project(project_id)
     backend_params = parse_backend_params(backend_param, proj)
@@ -262,9 +268,9 @@ def run_learn(project_id, paths, docs_limit, backend_param):
     """
     Further train an existing project on a collection of documents.
     \f
-    This will continue training an already trained project using all the
-    documents from the given directory or TSV file in a single batch operation.
-    Not supported by all backends.
+    This will continue training an already trained project using the documents
+    from all TSV files (possibly gzipped) or directories given by ``PATHS`` in
+    a single batch operation. Not supported by all backends.
     """
     proj = get_project(project_id)
     backend_params = parse_backend_params(backend_param, proj)
@@ -320,7 +326,7 @@ def run_index(project_id, directory, suffix, force,
               limit, threshold, backend_param):
     """
     Index a directory with documents, suggesting subjects for each document.
-    Write the results in TSV files with the given suffix.
+    Write the results in TSV files with the given suffix (default ``.annif``).
     """
     project = get_project(project_id)
     backend_params = parse_backend_params(backend_param, project)
@@ -397,16 +403,17 @@ def run_eval(
         jobs,
         backend_param):
     """
-    Analyze documents and evaluate the result.
+    Suggest subjects for documents and evaluate the results by comparing
+    against a gold standard.
     \f
-    Compare the results of automated indexing against a gold standard. The path
-    may be either a TSV file with short documents or a directory with documents
-    in separate files. You need to supply the documents in one of the supported
-    Document corpus formats, i.e. either as a directory or as a TSV file. It is
-    possible to give multiple corpora (even mixing corpus formats), in which
-    case they will all be processed in the same run.
+    With this command the documents from the TSV files (possibly gzipped) or
+    directories given by ``PATHS`` will be assigned subject suggestions and
+    then statistical measures are calculated that quantify how well the
+    suggested subjects match the gold-standard subjects in the documents.
 
-    The output is a list of statistical measures.
+    Normally the output is the list of the metrics calculated across documents.
+    If ``--results-file <FILENAME>`` option is given, the metrics are
+    calculated separately for each subject, and written to the given file.
     """
 
     project = get_project(project_id)
@@ -460,20 +467,14 @@ def run_eval(
 @common_options
 def run_optimize(project_id, paths, docs_limit, backend_param):
     """
-    Analyze documents, testing multiple limits and thresholds.
-
-    Evaluate the analysis results for a directory with documents against a gold
-    standard given in subject files. Test different limit/threshold values and
-    report the precision, recall and F-measure of each combination of settings.
+    Suggest subjects for documents, testing multiple limits and thresholds.
     \f
-    As with eval, you need to supply the documents in one of the supported
-    Document corpus formats. This command will read each document, assign
-    subjects to it using different limit and threshold values, and compare the
-    results with the gold standard subjects.
-
-    The output is a list of parameter combinations and their scores. From the
-    output, you can determine the optimum limit and threshold parameters
-    depending on which measure you want to target.
+    This command will use different limit (maximum number of subjects) and
+    score threshold values when assigning subjects to each document given by
+    ``PATHS`` and compare the results against the gold standard subjects in the
+    documents. The output is a list of parameter combinations and their scores.
+    From the output, you can determine the optimum limit and threshold
+    parameters depending on which measure you want to target.
     """
     project = get_project(project_id)
     backend_params = parse_backend_params(backend_param, project)
@@ -559,7 +560,8 @@ def run_optimize(project_id, paths, docs_limit, backend_param):
 def run_hyperopt(project_id, paths, docs_limit, trials, jobs, metric,
                  results_file):
     """
-    Optimize the hyperparameters of a project using a validation corpus.
+    Optimize the hyperparameters of a project using a validation corpus. Not
+    supported by all backends.
     """
     proj = get_project(project_id)
     documents = open_documents(paths, proj.subjects,

--- a/docs/commands-wiki/index.rst
+++ b/docs/commands-wiki/index.rst
@@ -4,7 +4,10 @@ Supported CLI commands in Annif
 
 These are the command line commands of Annif, with REST API equivalents when applicable.
 
-Most of these methods take a projectid parameter. Projects are identified by alphanumeric strings ``(A-Za-z0-9_-)``.
+
+.. contents::
+   :local:
+   :backlinks: none
 
 **********************
 Project administration

--- a/docs/commands-wiki/index.rst
+++ b/docs/commands-wiki/index.rst
@@ -1,0 +1,98 @@
+###############################
+Supported CLI commands in Annif
+###############################
+
+These are the command line commands of Annif, with REST API equivalents when applicable.
+
+Most of these methods take a projectid parameter. Projects are identified by alphanumeric strings ``(A-Za-z0-9_-)``.
+
+**********************
+Project administration
+**********************
+
+.. click:: annif.cli:run_loadvoc
+   :prog: annif loadvoc
+
+This will load the vocabulary to be used in subject indexing. Note that although ``PROJECT_ID`` is a parameter of the command, the vocabulary is shared by all the projects with the same vocab identifier in the project configuration, and the vocabulary only needs to be loaded for one of those projects.
+
+If a vocabulary has already been loaded, reinvoking ``loadvoc`` with a new subject file will update the Annif's internal vocabulary: label names are updated and any subject not appearing in the new subject file is removed. Note that new subjects will not be suggested before the project is retrained with the updated vocabulary. The update behavior can be overridden with the ``--force`` option.
+
+REST equivalent: N/A
+
+.. click:: annif.cli:run_list_projects
+   :prog: annif list-projects
+
+Show a list of currently defined projects. Projects are defined in a configuration file, normally called projects.cfg. See Project configuration for details.
+
+REST equivalent::
+
+  GET /projects/
+
+.. click:: annif.cli:run_show_project
+   :prog: annif show-project
+
+REST equivalent:::
+
+   GET /projects/<projectid>
+
+
+.. click:: annif.cli:run_clear_project
+   :prog: annif clear-project
+
+REST equivalent: N/A
+
+
+****************************
+Subject index administration
+****************************
+
+.. click:: annif.cli:run_train
+   :prog: annif train
+
+This will train the project using all the documents from the given directory or TSV file in a single batch operation.
+
+REST equivalent: N/A
+
+.. click:: annif.cli:run_learn
+   :prog: annif learn
+
+This will continue training an already trained project using all the documents from the given directory or TSV file in a single batch operation. Not supported by all backends.
+
+REST equivalent::
+
+   POST /projects/<projectid>/learn
+
+.. click:: annif.cli:run_suggest
+   :prog: annif suggest
+
+This will read a text document from standard input and suggest subjects for it.
+
+REST equivalent::
+
+  POST /projects/<projectid>/suggest
+
+.. click:: annif.cli:run_eval
+   :prog: annif eval
+
+You need to supply the documents in one of the supported Document corpus formats, i.e. either as a directory or as a TSV file. It is possible to give multiple corpora (even mixing corpus formats), in which case they will all be processed in the same run.
+
+The output is a list of statistical measures.
+
+REST equivalent: N/A
+
+.. click:: annif.cli:run_optimize
+   :prog: annif optimize
+
+As with eval, you need to supply the documents in one of the supported Document corpus formats. This command will read each document, assign subjects to it using different limit and threshold values, and compare the results with the gold standard subjects.
+
+The output is a list of parameter combinations and their scores. From the output, you can determine the optimum limit and threshold parameters depending on which measure you want to target.
+
+REST equivalent: N/A
+
+.. click:: annif.cli:run_index
+   :prog: annif index
+
+.. click:: flask.cli:run_command
+   :prog: annif run
+
+

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -42,6 +42,7 @@ master_doc = 'index'
 extensions = [
     'sphinx.ext.autodoc',
     'sphinxcontrib.apidoc',
+    'sphinx_click',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -51,7 +51,7 @@ templates_path = ['_templates']
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', 'venv']
 
 apidoc_module_dir = '../annif'
 apidoc_output_dir = 'source'

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,14 +12,15 @@ You are reading documentation for version |version|.
 
 
 .. toctree::
-   :maxdepth: 3
-   :caption: Annif API Reference:
+   :maxdepth: 1
+   :caption: Contents:
 
+   source/commands
    source/annif
 
 
 Indices and tables
-==================
+******************
 
 * :ref:`genindex`
 * :ref:`modindex`

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 sphinx==4.5.*
 sphinx-rtd-theme
 sphinxcontrib-apidoc==0.3.0
+sphinx-click
 docutils<0.18
-

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,4 +2,4 @@ sphinx==4.5.*
 sphinx-rtd-theme
 sphinxcontrib-apidoc==0.3.0
 sphinx-click
-docutils<0.18
+docutils==0.16

--- a/docs/source/commands.rst
+++ b/docs/source/commands.rst
@@ -2,9 +2,15 @@
 CLI commands
 ############
 
-These are the command line interface commands of Annif, with REST API equivalents when applicable.
+These are the command-line interface commands of Annif, with REST API
+equivalents when applicable.
 
-Most of these methods take a ``PROJECT_ID`` parameter. Projects are identified by alphanumeric strings ``(A-Za-z0-9_-)``.
+To reference a project most of the commands take a ``PROJECT_ID`` parameter,
+which is an alphanumeric string ``(A-Za-z0-9_-)``. Common options of the
+commands are ``--projects`` for setting a (non-default) path to a `project
+configuration file
+<https://github.com/NatLibFi/Annif/wiki/Project-configuration>`_ and
+``--verbosity`` for selecting logging level.
 
 .. contents::
    :local:

--- a/docs/source/commands.rst
+++ b/docs/source/commands.rst
@@ -17,14 +17,26 @@ Project administration
 .. click:: annif.cli:run_loadvoc
    :prog: annif loadvoc
 
+REST equivalent: N/A
+
 .. click:: annif.cli:run_list_projects
    :prog: annif list-projects
+
+REST equivalent::
+
+   GET /projects/
 
 .. click:: annif.cli:run_show_project
    :prog: annif show-project
 
+REST equivalent::
+
+   GET /projects/<PROJECT_ID>
+
 .. click:: annif.cli:run_clear_project
    :prog: annif clear-project
+
+REST equivalent: N/A
 
 ****************************
 Subject index administration
@@ -33,20 +45,38 @@ Subject index administration
 .. click:: annif.cli:run_train
    :prog: annif train
 
+REST equivalent: N/A
+
 .. click:: annif.cli:run_learn
    :prog: annif learn
+
+REST equivalent::
+
+   /projects/<PROJECT_ID>/learn
 
 .. click:: annif.cli:run_suggest
    :prog: annif suggest
 
+REST equivalent::
+
+   POST /projects/<PROJECT_ID>/suggest
+
 .. click:: annif.cli:run_eval
    :prog: annif eval
+
+REST equivalent: N/A
 
 .. click:: annif.cli:run_optimize
    :prog: annif optimize
 
+REST equivalent: N/A
+
 .. click:: annif.cli:run_index
    :prog: annif index
 
+REST equivalent: N/A
+
 .. click:: flask.cli:run_command
    :prog: annif run
+
+REST equivalent: N/A

--- a/docs/source/commands.rst
+++ b/docs/source/commands.rst
@@ -2,7 +2,7 @@
 CLI commands
 ############
 
-These are the command line commands of Annif, with REST API equivalents when applicable.
+These are the command line interface commands of Annif, with REST API equivalents when applicable.
 
 Most of these methods take a ``PROJECT_ID`` parameter. Projects are identified by alphanumeric strings ``(A-Za-z0-9_-)``.
 
@@ -17,34 +17,14 @@ Project administration
 .. click:: annif.cli:run_loadvoc
    :prog: annif loadvoc
 
-This will load the vocabulary to be used in subject indexing. Note that although ``PROJECT_ID`` is a parameter of the command, the vocabulary is shared by all the projects with the same vocab identifier in the project configuration, and the vocabulary only needs to be loaded for one of those projects.
-
-If a vocabulary has already been loaded, reinvoking ``loadvoc`` with a new subject file will update the Annif's internal vocabulary: label names are updated and any subject not appearing in the new subject file is removed. Note that new subjects will not be suggested before the project is retrained with the updated vocabulary. The update behavior can be overridden with the ``--force`` option.
-
-REST equivalent: N/A
-
 .. click:: annif.cli:run_list_projects
    :prog: annif list-projects
-
-Show a list of currently defined projects. Projects are defined in a configuration file, normally called projects.cfg. See Project configuration for details.
-
-REST equivalent::
-
-  GET /projects/
 
 .. click:: annif.cli:run_show_project
    :prog: annif show-project
 
-REST equivalent:::
-
-   GET /projects/<PROJECT_ID>
-
-
 .. click:: annif.cli:run_clear_project
    :prog: annif clear-project
-
-REST equivalent: N/A
-
 
 ****************************
 Subject index administration
@@ -53,49 +33,20 @@ Subject index administration
 .. click:: annif.cli:run_train
    :prog: annif train
 
-This will train the project using all the documents from the given directory or TSV file in a single batch operation.
-
-REST equivalent: N/A
-
 .. click:: annif.cli:run_learn
    :prog: annif learn
-
-This will continue training an already trained project using all the documents from the given directory or TSV file in a single batch operation. Not supported by all backends.
-
-REST equivalent::
-
-   POST /projects/<PROJECT_ID>/learn
 
 .. click:: annif.cli:run_suggest
    :prog: annif suggest
 
-This will read a text document from standard input and suggest subjects for it.
-
-REST equivalent::
-
-  POST /projects/<PROJECT_ID>/suggest
-
 .. click:: annif.cli:run_eval
    :prog: annif eval
 
-You need to supply the documents in one of the supported Document corpus formats, i.e. either as a directory or as a TSV file. It is possible to give multiple corpora (even mixing corpus formats), in which case they will all be processed in the same run.
-
-The output is a list of statistical measures.
-
-REST equivalent: N/A
-
 .. click:: annif.cli:run_optimize
    :prog: annif optimize
-
-As with eval, you need to supply the documents in one of the supported Document corpus formats. This command will read each document, assign subjects to it using different limit and threshold values, and compare the results with the gold standard subjects.
-
-The output is a list of parameter combinations and their scores. From the output, you can determine the optimum limit and threshold parameters depending on which measure you want to target.
-
-REST equivalent: N/A
 
 .. click:: annif.cli:run_index
    :prog: annif index
 
 .. click:: flask.cli:run_command
    :prog: annif run
-

--- a/docs/source/commands.rst
+++ b/docs/source/commands.rst
@@ -76,6 +76,11 @@ REST equivalent: N/A
 
 REST equivalent: N/A
 
+.. click:: annif.cli:run_hyperopt
+   :prog: annif hyperopt
+
+REST equivalent: N/A
+
 .. click:: flask.cli:run_command
    :prog: annif run
 

--- a/docs/source/commands.rst
+++ b/docs/source/commands.rst
@@ -17,26 +17,32 @@ Project administration
 .. click:: annif.cli:run_loadvoc
    :prog: annif loadvoc
 
-REST equivalent: N/A
+**REST equivalent**
+
+   N/A
 
 .. click:: annif.cli:run_list_projects
    :prog: annif list-projects
 
-REST equivalent::
+**REST equivalent**
+::
 
    GET /projects/
 
 .. click:: annif.cli:run_show_project
    :prog: annif show-project
 
-REST equivalent::
+**REST equivalent**
+::
 
    GET /projects/<PROJECT_ID>
 
 .. click:: annif.cli:run_clear_project
    :prog: annif clear-project
 
-REST equivalent: N/A
+**REST equivalent**
+
+   N/A
 
 ****************************
 Subject index administration
@@ -45,43 +51,57 @@ Subject index administration
 .. click:: annif.cli:run_train
    :prog: annif train
 
-REST equivalent: N/A
+**REST equivalent**
+
+   N/A
 
 .. click:: annif.cli:run_learn
    :prog: annif learn
 
-REST equivalent::
+**REST equivalent**
+::
 
    /projects/<PROJECT_ID>/learn
 
 .. click:: annif.cli:run_suggest
    :prog: annif suggest
 
-REST equivalent::
+**REST equivalent**
+::
 
    POST /projects/<PROJECT_ID>/suggest
 
 .. click:: annif.cli:run_eval
    :prog: annif eval
 
-REST equivalent: N/A
+**REST equivalent**
+
+   N/A
 
 .. click:: annif.cli:run_optimize
    :prog: annif optimize
 
-REST equivalent: N/A
+**REST equivalent**
+
+   N/A
 
 .. click:: annif.cli:run_index
    :prog: annif index
 
-REST equivalent: N/A
+**REST equivalent**
+
+   N/A
 
 .. click:: annif.cli:run_hyperopt
    :prog: annif hyperopt
 
-REST equivalent: N/A
+**REST equivalent**
+
+   N/A
 
 .. click:: flask.cli:run_command
    :prog: annif run
 
-REST equivalent: N/A
+**REST equivalent**
+
+   N/A

--- a/docs/source/commands.rst
+++ b/docs/source/commands.rst
@@ -1,7 +1,6 @@
-.. _my-reference-label:
-###############################
-Supported CLI commands in Annif
-###############################
+############
+CLI commands
+############
 
 These are the command line commands of Annif, with REST API equivalents when applicable.
 

--- a/docs/source/commands.rst
+++ b/docs/source/commands.rst
@@ -1,9 +1,11 @@
+.. _my-reference-label:
 ###############################
 Supported CLI commands in Annif
 ###############################
 
 These are the command line commands of Annif, with REST API equivalents when applicable.
 
+Most of these methods take a ``PROJECT_ID`` parameter. Projects are identified by alphanumeric strings ``(A-Za-z0-9_-)``.
 
 .. contents::
    :local:
@@ -36,7 +38,7 @@ REST equivalent::
 
 REST equivalent:::
 
-   GET /projects/<projectid>
+   GET /projects/<PROJECT_ID>
 
 
 .. click:: annif.cli:run_clear_project
@@ -63,7 +65,7 @@ This will continue training an already trained project using all the documents f
 
 REST equivalent::
 
-   POST /projects/<projectid>/learn
+   POST /projects/<PROJECT_ID>/learn
 
 .. click:: annif.cli:run_suggest
    :prog: annif suggest
@@ -72,7 +74,7 @@ This will read a text document from standard input and suggest subjects for it.
 
 REST equivalent::
 
-  POST /projects/<projectid>/suggest
+  POST /projects/<PROJECT_ID>/suggest
 
 .. click:: annif.cli:run_eval
    :prog: annif eval
@@ -97,5 +99,4 @@ REST equivalent: N/A
 
 .. click:: flask.cli:run_command
    :prog: annif run
-
 

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
         'swagger_ui_bundle',
         'flask>=1.0.4,<3',
         'flask-cors',
-        'click==8.0.*',
+        'click==8.1.*',
         'click-log',
         'joblib==1.1.0',
         'nltk',


### PR DESCRIPTION
Switches to document Annif CLI commands on annif.readthedocs.io with automated builds instead of manually maintaining documentation in a GitHub wiki page 

Template for the page is in `docs/source/commands.rst`. 

Due to an [issue with sphinx-rtd-theme](https://github.com/readthedocs/sphinx_rtd_theme/issues/1115) (not showing bullet points in TOC lists) an older version of docutils (0.16) is used.

Edit: Also [upgrades to Click 8.1.* to allow sphinx-click to access full docstring after truncation marker `\f`
](https://github.com/NatLibFi/Annif/pull/611/commits/e830bd0f077334c8040181fd44bba00f53188e8e)

Closes #595.