### PR TITLE
Restore ability to use vocab language different from project language

### DIFF
--- a/annif/cli.py
+++ b/annif/cli.py
@@ -226,7 +226,7 @@ def run_train(project_id, paths, cached, docs_limit, jobs, backend_param):
         documents = 'cached'
     else:
         documents = open_documents(paths, proj.subjects,
-                                   proj.language, docs_limit)
+                                   proj.vocab.language, docs_limit)
     proj.train(documents, backend_params, jobs)
 
 
@@ -245,7 +245,7 @@ def run_learn(project_id, paths, docs_limit, backend_param):
     proj = get_project(project_id)
     backend_params = parse_backend_params(backend_param, proj)
     documents = open_documents(paths, proj.subjects,
-                               proj.language, docs_limit)
+                               proj.vocab.language, docs_limit)
     proj.learn(documents, backend_params)
 
 
@@ -270,7 +270,7 @@ def run_suggest(project_id, limit, threshold, backend_param):
             "<{}>\t{}\t{}".format(
                 subj.uri,
                 '\t'.join(filter(None,
-                                 (subj.labels[project.language],
+                                 (subj.labels[project.vocab.language],
                                   subj.notation))),
                 hit.score))
 
@@ -392,7 +392,7 @@ def run_eval(
             raise NotSupportedException(
                 "cannot open results-file for writing: " + str(e))
     docs = open_documents(paths, project.subjects,
-                          project.language, docs_limit)
+                          project.vocab.language, docs_limit)
 
     jobs, pool_class = annif.parallel.get_pool(jobs)
 
@@ -409,7 +409,7 @@ def run_eval(
     template = "{0:<30}\t{1}"
     metrics = eval_batch.results(metrics=metric,
                                  results_file=results_file,
-                                 language=project.language)
+                                 language=project.vocab.language)
     for metric, score in metrics.items():
         click.echo(template.format(metric + ":", score))
     if metrics_file:
@@ -442,7 +442,7 @@ def run_optimize(project_id, paths, docs_limit, backend_param):
 
     ndocs = 0
     docs = open_documents(paths, project.subjects,
-                          project.language, docs_limit)
+                          project.vocab.language, docs_limit)
     for doc in docs.documents:
         raw_hits = project.suggest(doc.text, backend_params)
         hits = raw_hits.filter(project.subjects, limit=BATCH_MAX_LIMIT)
@@ -523,7 +523,7 @@ def run_hyperopt(project_id, paths, docs_limit, trials, jobs, metric,
     """
     proj = get_project(project_id)
     documents = open_documents(paths, proj.subjects,
-                               proj.language, docs_limit)
+                               proj.vocab.language, docs_limit)
     click.echo(f"Looking for optimal hyperparameters using {trials} trials")
     rec = proj.hyperopt(documents, trials, jobs, metric, results_file)
     click.echo(f"Got best {metric} score {rec.score:.4f} with:")

--- a/annif/rest.py
+++ b/annif/rest.py
@@ -75,7 +75,7 @@ def suggest(project_id, text, limit, threshold):
         return server_error(err)
     hits = hit_filter(result).as_list()
     return {'results': [_suggestion_to_dict(hit, project.subjects,
-                                            project.language)
+                                            project.vocab.language)
                         for hit in hits]}
 
 

--- a/tests/corpora/dummy-subjects.csv
+++ b/tests/corpora/dummy-subjects.csv
@@ -1,3 +1,3 @@
 uri,notation,label_fi,label_en
-http://example.org/dummy,,dummy,dummy
-http://example.org/none,42.42,none,none
+http://example.org/dummy,,dummy-fi,dummy
+http://example.org/none,42.42,none-fi,none

--- a/tests/projects.cfg
+++ b/tests/projects.cfg
@@ -17,8 +17,8 @@ analyzer=snowball(english)
 vocab=dummy
 access=hidden
 
-[dummydummy]
-name=Dummy+Dummy combination
+[dummy-vocablang]
+name=Dummy with a different vocab language
 language=en
 backend=dummy
 analyzer=snowball(english)
@@ -37,7 +37,7 @@ vocab=dummy
 name=Ensemble
 language=en
 backend=ensemble
-sources=dummy-en,dummydummy
+sources=dummy-en,dummy-vocablang
 vocab=dummy
 
 [noanalyzer]

--- a/tests/projects.cfg
+++ b/tests/projects.cfg
@@ -17,13 +17,20 @@ analyzer=snowball(english)
 vocab=dummy
 access=hidden
 
+[dummy-private]
+name=Dummy private project
+language=en
+backend=dummy
+analyzer=snowball(english)
+vocab=dummy
+access=private
+
 [dummy-vocablang]
 name=Dummy with a different vocab language
 language=en
 backend=dummy
 analyzer=snowball(english)
 vocab=dummy(fi)
-access=private
 
 [dummy-transform]
 name=Dummy with pass-through transform
@@ -37,7 +44,7 @@ vocab=dummy
 name=Ensemble
 language=en
 backend=ensemble
-sources=dummy-en,dummy-vocablang
+sources=dummy-en,dummy-private
 vocab=dummy
 
 [noanalyzer]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -26,7 +26,7 @@ def test_list_projects():
     # hidden project should be visible
     assert 'dummy-en' in result.output
     # private project should be visible
-    assert 'dummy-vocablang' in result.output
+    assert 'dummy-private' in result.output
     # project with no access setting should be visible
     assert 'ensemble' in result.output
 
@@ -777,7 +777,7 @@ def test_hyperopt_ensemble(tmpdir):
     assert result.exit_code == 0
 
     assert re.search(
-        r'sources=dummy-en:0.\d+,dummy-vocablang:0.\d+',
+        r'sources=dummy-en:0.\d+,dummy-private:0.\d+',
         result.output) is not None
 
 
@@ -800,7 +800,7 @@ def test_hyperopt_ensemble_resultsfile(tmpdir):
         assert header.strip('\n') == '\t'.join(['trial',
                                                 'value',
                                                 'dummy-en',
-                                                'dummy-vocablang'])
+                                                'dummy-private'])
         for idx, line in enumerate(f):
             assert line.strip() != ''
             parts = line.split('\t')

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -359,6 +359,18 @@ def test_suggest():
     assert result.exit_code == 0
 
 
+def test_suggest_with_different_vocab_language():
+    # project language is English - input should be in English
+    # vocab language is Finnish - subject labels should be in Finnish
+    result = runner.invoke(
+        annif.cli.cli,
+        ['suggest', 'dummy-vocablang'],
+        input='the cat sat on the mat')
+    assert not result.exception
+    assert result.output == "<http://example.org/dummy>\tdummy-fi\t1.0\n"
+    assert result.exit_code == 0
+
+
 def test_suggest_with_notations():
     result = runner.invoke(
         annif.cli.cli,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -26,7 +26,7 @@ def test_list_projects():
     # hidden project should be visible
     assert 'dummy-en' in result.output
     # private project should be visible
-    assert 'dummydummy' in result.output
+    assert 'dummy-vocablang' in result.output
     # project with no access setting should be visible
     assert 'ensemble' in result.output
 
@@ -355,7 +355,7 @@ def test_suggest():
         ['suggest', 'dummy-fi'],
         input='kissa')
     assert not result.exception
-    assert result.output == "<http://example.org/dummy>\tdummy\t1.0\n"
+    assert result.output == "<http://example.org/dummy>\tdummy-fi\t1.0\n"
     assert result.exit_code == 0
 
 
@@ -366,7 +366,7 @@ def test_suggest_with_notations():
          '--backend-param', 'dummy.uri=http://example.org/none', 'dummy-fi'],
         input='kissa')
     assert not result.exception
-    assert result.output == "<http://example.org/none>\tnone\t42.42\t1.0\n"
+    assert result.output == "<http://example.org/none>\tnone-fi\t42.42\t1.0\n"
     assert result.exit_code == 0
 
 
@@ -387,7 +387,7 @@ def test_suggest_param():
         ['suggest', '--backend-param', 'dummy.score=0.8', 'dummy-fi'],
         input='kissa')
     assert not result.exception
-    assert result.output == "<http://example.org/dummy>\tdummy\t0.8\n"
+    assert result.output == "<http://example.org/dummy>\tdummy-fi\t0.8\n"
     assert result.exit_code == 0
 
 
@@ -438,7 +438,7 @@ def test_index(tmpdir):
     assert tmpdir.join('doc1.annif').exists()
     assert "Not overwriting" not in result.output
     assert tmpdir.join('doc1.annif').read_text(
-        'utf-8') == "<http://example.org/dummy>\tdummy\t1.0\n"
+        'utf-8') == "<http://example.org/dummy>\tdummy-fi\t1.0\n"
 
 
 def test_index_nonexistent_path():
@@ -777,7 +777,7 @@ def test_hyperopt_ensemble(tmpdir):
     assert result.exit_code == 0
 
     assert re.search(
-        r'sources=dummy-en:0.\d+,dummydummy:0.\d+',
+        r'sources=dummy-en:0.\d+,dummy-vocablang:0.\d+',
         result.output) is not None
 
 
@@ -800,7 +800,7 @@ def test_hyperopt_ensemble_resultsfile(tmpdir):
         assert header.strip('\n') == '\t'.join(['trial',
                                                 'value',
                                                 'dummy-en',
-                                                'dummydummy'])
+                                                'dummy-vocablang'])
         for idx, line in enumerate(f):
             assert line.strip() != ''
             parts = line.split('\t')

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -48,7 +48,7 @@ def test_find_config_not_exists_default(monkeypatch, caplog):
 def test_parse_config_cfg_nondefault():
     cfg = annif.config.parse_config('tests/projects.cfg')
     assert isinstance(cfg, annif.config.AnnifConfigCFG)
-    assert len(cfg.project_ids) == 16
+    assert len(cfg.project_ids) == 17
     assert cfg['dummy-fi'] is not None
 
 
@@ -57,7 +57,7 @@ def test_parse_config_cfg_default(monkeypatch):
     monkeypatch.chdir('tests')
     cfg = annif.config.parse_config('')
     assert isinstance(cfg, annif.config.AnnifConfigCFG)
-    assert len(cfg.project_ids) == 16
+    assert len(cfg.project_ids) == 17
     assert cfg['dummy-fi'] is not None
 
 
@@ -79,7 +79,7 @@ def test_parse_config_toml_failed(tmpdir):
 def test_parse_config_directory():
     cfg = annif.config.parse_config('tests/projects.d')
     assert isinstance(cfg, annif.config.AnnifConfigDirectory)
-    assert len(cfg.project_ids) == 16 + 2  # projects.cfg + projects.toml
+    assert len(cfg.project_ids) == 17 + 2  # projects.cfg + projects.toml
     assert cfg['dummy-fi'] is not None
     assert cfg['dummy-fi-toml'] is not None
 

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -38,6 +38,16 @@ def test_get_project_fi(registry):
     assert isinstance(project.backend, annif.backend.dummy.DummyBackend)
 
 
+def test_get_project_dummy_private(registry):
+    project = registry.get_project('dummy-private')
+    assert project.project_id == 'dummy-private'
+    assert project.language == 'en'
+    assert project.analyzer.name == 'snowball'
+    assert project.analyzer.param == 'english'
+    assert project.access == Access.private
+    assert isinstance(project.backend, annif.backend.dummy.DummyBackend)
+
+
 def test_get_project_dummy_vocablang(registry):
     project = registry.get_project('dummy-vocablang')
     assert project.project_id == 'dummy-vocablang'
@@ -47,7 +57,7 @@ def test_get_project_dummy_vocablang(registry):
     # project uses the dummy vocab, with language overridden to Finnish
     assert project.vocab.vocab_id == 'dummy'
     assert project.vocab.language == 'fi'
-    assert project.access == Access.private
+    assert project.access == Access.public
     assert isinstance(project.backend, annif.backend.dummy.DummyBackend)
 
 
@@ -275,7 +285,7 @@ def test_project_directory():
     app = annif.create_app(
         config_name='annif.default_config.TestingDirectoryConfig')
     with app.app_context():
-        assert len(annif.registry.get_projects()) == 16 + 2
+        assert len(annif.registry.get_projects()) == 17 + 2
         assert annif.registry.get_project('dummy-fi').project_id == 'dummy-fi'
         assert annif.registry.get_project('dummy-fi-toml').project_id \
             == 'dummy-fi-toml'

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -38,9 +38,9 @@ def test_get_project_fi(registry):
     assert isinstance(project.backend, annif.backend.dummy.DummyBackend)
 
 
-def test_get_project_dummydummy(registry):
-    project = registry.get_project('dummydummy')
-    assert project.project_id == 'dummydummy'
+def test_get_project_dummy_vocablang(registry):
+    project = registry.get_project('dummy-vocablang')
+    assert project.project_id == 'dummy-vocablang'
     assert project.language == 'en'
     assert project.analyzer.name == 'snowball'
     assert project.analyzer.param == 'english'
@@ -220,18 +220,8 @@ def test_project_suggest(registry):
     assert hits[0].score == 1.0
 
 
-def test_project_suggest_combine(registry):
-    project = registry.get_project('dummydummy')
-    result = project.suggest('this is some text')
-    assert len(result) == 1
-    hits = result.as_list()
-    assert hits[0].subject_id == project.subjects.by_uri(
-        'http://example.org/dummy')
-    assert hits[0].score == 1.0
-
-
 def test_project_train_state_not_available(registry, caplog):
-    project = registry.get_project('dummydummy')
+    project = registry.get_project('dummy-vocablang')
     project.backend.is_trained = None
     with caplog.at_level(logging.WARNING):
         result = project.suggest('this is some text')

--- a/tests/test_rest.py
+++ b/tests/test_rest.py
@@ -97,6 +97,18 @@ def test_rest_suggest_novocab(app):
         assert result.status_code == 503
 
 
+def test_rest_suggest_with_different_vocab_language(app):
+    # project language is English - input should be in English
+    # vocab language is Finnish - subject labels should be in Finnish
+    with app.app_context():
+        result = annif.rest.suggest(
+            'dummy-vocablang',
+            text='example text',
+            limit=10,
+            threshold=0.0)
+        assert result['results'][0]['label'] == 'dummy-fi'
+
+
 def test_rest_suggest_with_notations(app):
     with app.app_context():
         result = annif.rest.suggest(

--- a/tests/test_rest.py
+++ b/tests/test_rest.py
@@ -12,7 +12,7 @@ def test_rest_list_projects(app):
         # hidden project should not be returned
         assert 'dummy-en' not in project_ids
         # private project should not be returned
-        assert 'dummy-vocablang' not in project_ids
+        assert 'dummy-private' not in project_ids
         # project with no access level setting should be returned
         assert 'ensemble' in project_ids
 
@@ -34,7 +34,7 @@ def test_rest_show_project_hidden(app):
 def test_rest_show_project_private(app):
     # private projects should not be accessible via REST
     with app.app_context():
-        result = annif.rest.show_project('dummy-vocablang')
+        result = annif.rest.show_project('dummy-private')
         assert result.status_code == 404
 
 
@@ -70,7 +70,7 @@ def test_rest_suggest_private(app):
     # private projects should not be accessible via REST
     with app.app_context():
         result = annif.rest.suggest(
-            'dummy-vocablang',
+            'dummy-private',
             text='example text',
             limit=10,
             threshold=0.0)

--- a/tests/test_rest.py
+++ b/tests/test_rest.py
@@ -12,7 +12,7 @@ def test_rest_list_projects(app):
         # hidden project should not be returned
         assert 'dummy-en' not in project_ids
         # private project should not be returned
-        assert 'dummydummy' not in project_ids
+        assert 'dummy-vocablang' not in project_ids
         # project with no access level setting should be returned
         assert 'ensemble' in project_ids
 
@@ -34,7 +34,7 @@ def test_rest_show_project_hidden(app):
 def test_rest_show_project_private(app):
     # private projects should not be accessible via REST
     with app.app_context():
-        result = annif.rest.show_project('dummydummy')
+        result = annif.rest.show_project('dummy-vocablang')
         assert result.status_code == 404
 
 
@@ -70,7 +70,7 @@ def test_rest_suggest_private(app):
     # private projects should not be accessible via REST
     with app.app_context():
         result = annif.rest.suggest(
-            'dummydummy',
+            'dummy-vocablang',
             text='example text',
             limit=10,
             threshold=0.0)


### PR DESCRIPTION
The ability to use a vocabulary language different from the project language was implemented in PR #600, but subsequently broken by mistake in PR #608. For example, it should be possible to use `vocab=lcsh(en)` in a project with `language=fi` where all documents are in Finnish but English language labels are used for LCSH concepts (which don't even have Finnish labels) both when reading corpora and outputting results.

This PR aims to restore that functionality by making sure that

1. When reading corpora in the directory-based format, labels are compared to vocabulary labels in the vocabulary language;
2. When performing suggest operations (CLI or REST), the labels of suggested subjects are in the vocabulary language;
3. When writing an evaluation results file which contains subject labels, the labels will be in the vocabulary language.

Currently there are unit tests to verify item 2. above, but not 1. or 3.

Also some of the test vocabularies were renamed and repurposed to better match current needs.