### PR TITLE
Implement load-vocab and list-vocab commands

### DIFF
--- a/annif/cli.py
+++ b/annif/cli.py
@@ -279,15 +279,18 @@ def run_load_vocab(vocab_id, language, force, subjectfile):
     if annif.corpus.SubjectFileSKOS.is_rdf_file(subjectfile):
         # SKOS/RDF file supported by rdflib
         subjects = annif.corpus.SubjectFileSKOS(subjectfile)
+        click.echo(f"Loading vocabulary from SKOS file {subjectfile}...")
     elif annif.corpus.SubjectFileCSV.is_csv_file(subjectfile):
         # CSV file
         subjects = annif.corpus.SubjectFileCSV(subjectfile)
+        click.echo(f"Loading vocabulary from CSV file {subjectfile}...")
     else:
         # probably a TSV file - we need to know its language
         if not language:
             click.echo("Please use --language option to set the language of " +
                        "a TSV vocabulary.", err=True)
             sys.exit(1)
+        click.echo(f"Loading vocabulary from TSV file {subjectfile}...")
         subjects = annif.corpus.SubjectFileTSV(subjectfile, language)
     vocab.load_vocabulary(subjects, force=force)
 

--- a/annif/corpus/subject.py
+++ b/annif/corpus/subject.py
@@ -118,6 +118,10 @@ class SubjectIndex:
     def __len__(self):
         return len(self._subjects)
 
+    @property
+    def languages(self):
+        return self._languages
+
     def __getitem__(self, subject_id):
         return self._subjects[subject_id]
 

--- a/annif/project.py
+++ b/annif/project.py
@@ -31,6 +31,7 @@ class AnnifProject(DatadirMixin):
     _analyzer = None
     _backend = None
     _vocab = None
+    _vocab_lang = None
     initialized = False
 
     # default values for configuration settings
@@ -148,16 +149,24 @@ class AnnifProject(DatadirMixin):
                     backend_id)
         return self._backend
 
+    def _initialize_vocab(self):
+        if self.vocab_spec is None:
+            raise ConfigurationException("vocab setting is missing",
+                                         project_id=self.project_id)
+        self._vocab, self._vocab_lang = self.registry.get_vocab(
+            self.vocab_spec, self.language)
+
     @property
     def vocab(self):
         if self._vocab is None:
-            if self.vocab_spec is None:
-                raise ConfigurationException("vocab setting is missing",
-                                             project_id=self.project_id)
-            self._vocab = self.registry.get_vocab(self.vocab_spec,
-                                                  self.language)
-
+            self._initialize_vocab()
         return self._vocab
+
+    @property
+    def vocab_lang(self):
+        if self._vocab_lang is None:
+            self._initialize_vocab()
+        return self._vocab_lang
 
     @property
     def subjects(self):

--- a/annif/registry.py
+++ b/annif/registry.py
@@ -71,8 +71,10 @@ class AnnifRegistry:
             raise ValueError("No such project {}".format(project_id))
 
     def get_vocab(self, vocab_spec, default_language):
-        """Return an AnnifVocabulary corresponding to the vocab_spec. If no
-        language information is specified, use the given default language."""
+        """Return an (AnnifVocabulary, language) pair corresponding to the
+        vocab_spec. If no language information is specified, use the given
+        default language."""
+
         match = re.match(r'(\w+)(\((.*)\))?', vocab_spec)
         if match is None:
             raise ValueError(
@@ -84,8 +86,8 @@ class AnnifRegistry:
 
         if vocab_key not in self._vocabs[self._rid]:
             self._vocabs[self._rid][vocab_key] = AnnifVocabulary(
-                vocab_id, self._datadir, language)
-        return self._vocabs[self._rid][vocab_key]
+                vocab_id, self._datadir)
+        return self._vocabs[self._rid][vocab_key], language
 
 
 def initialize_projects(app):

--- a/annif/registry.py
+++ b/annif/registry.py
@@ -5,6 +5,7 @@ import re
 from flask import current_app
 import annif
 from annif.config import parse_config
+from annif.exception import ConfigurationException
 from annif.project import Access, AnnifProject
 from annif.vocab import AnnifVocabulary
 from annif.util import parse_args
@@ -115,4 +116,29 @@ def get_project(project_id, min_access=Access.private):
     try:
         return projects[project_id]
     except KeyError:
-        raise ValueError("No such project {}".format(project_id))
+        raise ValueError(f"No such project '{project_id}'")
+
+
+def get_vocabs(min_access=Access.private):
+    """Return the available vocabularies as a dict of vocab_id ->
+    AnnifVocabulary. The min_access parameter may be used to set the minimum
+    access level required for the returned vocabularies."""
+
+    vocabs = {}
+    for proj in get_projects(min_access).values():
+        try:
+            vocabs[proj.vocab.vocab_id] = proj.vocab
+        except ConfigurationException:
+            pass
+
+    return vocabs
+
+
+def get_vocab(vocab_id, min_access=Access.private):
+    """return a single AnnifVocabulary by vocabulary id"""
+
+    vocabs = get_vocabs(min_access)
+    try:
+        return vocabs[vocab_id]
+    except KeyError:
+        raise ValueError(f"No such vocabulary '{vocab_id}'")

--- a/annif/rest.py
+++ b/annif/rest.py
@@ -75,7 +75,7 @@ def suggest(project_id, text, limit, threshold):
         return server_error(err)
     hits = hit_filter(result).as_list()
     return {'results': [_suggestion_to_dict(hit, project.subjects,
-                                            project.vocab.language)
+                                            project.vocab_lang)
                         for hit in hits]}
 
 

--- a/annif/vocab.py
+++ b/annif/vocab.py
@@ -97,6 +97,13 @@ class AnnifVocabulary(DatadirMixin):
 
         raise NotInitializedException(f'graph file {path} not found')
 
+    def __len__(self):
+        return len(self.subjects)
+
+    @property
+    def languages(self):
+        return self.subjects.languages
+
     def load_vocabulary(self, subject_corpus, force=False):
         """Load subjects from a subject corpus and save them into one
         or more subject index files as well as a SKOS/Turtle file for later

--- a/annif/vocab.py
+++ b/annif/vocab.py
@@ -111,13 +111,15 @@ class AnnifVocabulary(DatadirMixin):
 
         if not force and os.path.exists(
                 os.path.join(self.datadir, self.INDEX_FILENAME_CSV)):
-            logger.info('updating existing vocabulary')
+            logger.info('updating existing subject index')
             self._subjects = self._update_subject_index(subject_corpus)
         else:
+            logger.info('creating subject index')
             self._subjects = self._create_subject_index(subject_corpus)
 
-        subject_corpus.save_skos(
-            os.path.join(self.datadir, self.INDEX_FILENAME_TTL))
+        skosfile = os.path.join(self.datadir, self.INDEX_FILENAME_TTL)
+        logger.info(f'saving vocabulary into SKOS file {skosfile}')
+        subject_corpus.save_skos(skosfile)
 
     def as_graph(self):
         """return the vocabulary as an rdflib graph"""

--- a/annif/vocab.py
+++ b/annif/vocab.py
@@ -22,10 +22,9 @@ class AnnifVocabulary(DatadirMixin):
     INDEX_FILENAME_TTL = "subjects.ttl"
     INDEX_FILENAME_CSV = "subjects.csv"
 
-    def __init__(self, vocab_id, datadir, language):
+    def __init__(self, vocab_id, datadir):
         DatadirMixin.__init__(self, datadir, 'vocabs', vocab_id)
         self.vocab_id = vocab_id
-        self.language = language
         self._skos_vocab = None
 
     def _create_subject_index(self, subject_corpus):

--- a/docs/source/commands.rst
+++ b/docs/source/commands.rst
@@ -5,10 +5,10 @@ CLI commands
 These are the command-line interface commands of Annif, with REST API
 equivalents when applicable.
 
-To reference a project most of the commands take a ``PROJECT_ID`` parameter,
-which is an alphanumeric string ``(A-Za-z0-9_-)``. Common options of the
-commands are ``--projects`` for setting a (non-default) path to a `project
-configuration file
+To reference a vocabulary or a project, most of the commands take either a
+``VOCAB_ID`` or a ``PROJECT_ID`` parameter, which are alphanumeric strings
+``(A-Za-z0-9_-)``. Common options of the commands are ``--projects`` for
+setting a (non-default) path to a `project configuration file
 <https://github.com/NatLibFi/Annif/wiki/Project-configuration>`_ and
 ``--verbosity`` for selecting logging level.
 
@@ -16,16 +16,27 @@ configuration file
    :local:
    :backlinks: none
 
-**********************
-Project administration
-**********************
+*************************
+Vocabulary administration
+*************************
 
-.. click:: annif.cli:run_loadvoc
-   :prog: annif loadvoc
+.. click:: annif.cli:run_load_vocab
+   :prog: annif load-vocab
 
 **REST equivalent**
 
    N/A
+
+.. click:: annif.cli:run_list_vocabs
+   :prog: annif list-vocabs
+
+**REST equivalent**
+
+   N/A
+
+**********************
+Project administration
+**********************
 
 .. click:: annif.cli:run_list_projects
    :prog: annif list-projects

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -76,13 +76,13 @@ def subject_file():
 @pytest.fixture(scope='module')
 def dummy_subject_index(testdatadir):
     """a fixture to access the subject index of the dummy vocabulary"""
-    vocab = annif.vocab.AnnifVocabulary('dummy', testdatadir, 'en')
+    vocab = annif.vocab.AnnifVocabulary('dummy', testdatadir)
     return vocab.subjects
 
 
 @pytest.fixture(scope='module')
 def vocabulary(datadir):
-    vocab = annif.vocab.AnnifVocabulary('my-vocab', datadir, 'fi')
+    vocab = annif.vocab.AnnifVocabulary('my-vocab', datadir)
     subjfile = os.path.join(
         os.path.dirname(__file__),
         'corpora',

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -339,6 +339,21 @@ def test_load_vocab_ttl(testdatadir):
     assert testdatadir.join('vocabs/yso/subjects.dump.gz').size() > 0
 
 
+def test_load_vocab_nonexistent_vocab():
+    subjectfile = os.path.join(
+        os.path.dirname(__file__),
+        'corpora',
+        'archaeology',
+        'yso-archaeology.ttl')
+    failed_result = runner.invoke(
+        annif.cli.cli, [
+            'load-vocab', 'notfound', subjectfile])
+    assert failed_result.exception
+    assert failed_result.exit_code != 0
+    assert "No vocabularies found with the id 'notfound'." \
+        in failed_result.output
+
+
 def test_load_vocab_nonexistent_path():
     failed_result = runner.invoke(
         annif.cli.cli, [

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,6 +4,7 @@ import contextlib
 import random
 import re
 import os.path
+import shutil
 import importlib
 import json
 from click.testing import CliRunner
@@ -110,6 +111,16 @@ def test_clear_project_nonexistent_data(testdatadir, caplog):
     assert len(caplog.records) == 1
     expected_msg = 'No model data to remove for project dummy-fi.'
     assert expected_msg == caplog.records[0].message
+
+
+def test_list_vocabs_before_load(testdatadir):
+    with contextlib.suppress(FileNotFoundError):
+        shutil.rmtree(str(testdatadir.join('vocabs/yso/')))
+    result = runner.invoke(annif.cli.cli, ["list-vocabs"])
+    assert not result.exception
+    assert result.exit_code == 0
+    assert re.search(r'^yso\s+-\s+-\s+False',
+                     result.output, re.MULTILINE)
 
 
 def test_loadvoc_csv(testdatadir):
@@ -378,7 +389,7 @@ def test_load_vocab_nonexistent_path():
            "File 'nonexistent_path' does not exist." in failed_result.output
 
 
-def test_list_vocabs():
+def test_list_vocabs_after_load():
     result = runner.invoke(annif.cli.cli, ["list-vocabs"])
     assert not result.exception
     assert result.exit_code == 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -114,9 +114,9 @@ def test_clear_project_nonexistent_data(testdatadir, caplog):
 
 def test_loadvoc_csv(testdatadir):
     with contextlib.suppress(FileNotFoundError):
-        os.remove(str(testdatadir.join('projects/tfidf-fi/subjects.csv')))
+        os.remove(str(testdatadir.join('vocabs/yso/subjects.csv')))
     with contextlib.suppress(FileNotFoundError):
-        os.remove(str(testdatadir.join('projects/tfidf-fi/subjects.ttl')))
+        os.remove(str(testdatadir.join('vocabs/yso/subjects.ttl')))
     subjectfile = os.path.join(
         os.path.dirname(__file__),
         'corpora',
@@ -135,9 +135,9 @@ def test_loadvoc_csv(testdatadir):
 
 def test_loadvoc_tsv(testdatadir):
     with contextlib.suppress(FileNotFoundError):
-        os.remove(str(testdatadir.join('projects/tfidf-fi/subjects.csv')))
+        os.remove(str(testdatadir.join('vocabs/yso/subjects.csv')))
     with contextlib.suppress(FileNotFoundError):
-        os.remove(str(testdatadir.join('projects/tfidf-fi/subjects.ttl')))
+        os.remove(str(testdatadir.join('vocabs/yso/subjects.ttl')))
     subjectfile = os.path.join(
         os.path.dirname(__file__),
         'corpora',
@@ -156,9 +156,9 @@ def test_loadvoc_tsv(testdatadir):
 
 def test_loadvoc_tsv_with_bom(testdatadir):
     with contextlib.suppress(FileNotFoundError):
-        os.remove(str(testdatadir.join('projects/tfidf-fi/subjects.csv')))
+        os.remove(str(testdatadir.join('vocabs/yso/subjects.csv')))
     with contextlib.suppress(FileNotFoundError):
-        os.remove(str(testdatadir.join('projects/tfidf-fi/subjects.ttl')))
+        os.remove(str(testdatadir.join('vocabs/yso/subjects.ttl')))
     subjectfile = os.path.join(
         os.path.dirname(__file__),
         'corpora',
@@ -177,9 +177,9 @@ def test_loadvoc_tsv_with_bom(testdatadir):
 
 def test_loadvoc_rdf(testdatadir):
     with contextlib.suppress(FileNotFoundError):
-        os.remove(str(testdatadir.join('projects/tfidf-fi/subjects.csv')))
+        os.remove(str(testdatadir.join('vocabs/yso/subjects.csv')))
     with contextlib.suppress(FileNotFoundError):
-        os.remove(str(testdatadir.join('projects/tfidf-fi/subjects.ttl')))
+        os.remove(str(testdatadir.join('vocabs/yso/subjects.ttl')))
     subjectfile = os.path.join(
         os.path.dirname(__file__),
         'corpora',
@@ -198,9 +198,9 @@ def test_loadvoc_rdf(testdatadir):
 
 def test_loadvoc_ttl(testdatadir):
     with contextlib.suppress(FileNotFoundError):
-        os.remove(str(testdatadir.join('projects/tfidf-fi/subjects.csv')))
+        os.remove(str(testdatadir.join('vocabs/yso/subjects.csv')))
     with contextlib.suppress(FileNotFoundError):
-        os.remove(str(testdatadir.join('projects/tfidf-fi/subjects.ttl')))
+        os.remove(str(testdatadir.join('vocabs/yso/subjects.ttl')))
     subjectfile = os.path.join(
         os.path.dirname(__file__),
         'corpora',

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -272,6 +272,20 @@ def test_load_vocab_tsv(testdatadir):
     assert testdatadir.join('vocabs/yso/subjects.dump.gz').size() > 0
 
 
+def test_load_vocab_tsv_no_lang(testdatadir):
+    subjectfile = os.path.join(
+        os.path.dirname(__file__),
+        'corpora',
+        'archaeology',
+        'subjects.tsv')
+    failed_result = runner.invoke(annif.cli.cli,
+                                  ['load-vocab', 'yso', subjectfile])
+    assert failed_result.exception
+    assert failed_result.exit_code != 0
+    assert "Please use --language option to set the language " \
+        "of a TSV vocabulary." in failed_result.output
+
+
 def test_load_vocab_tsv_with_bom(testdatadir):
     with contextlib.suppress(FileNotFoundError):
         os.remove(str(testdatadir.join('vocabs/yso/subjects.csv')))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -112,16 +112,6 @@ def test_clear_project_nonexistent_data(testdatadir, caplog):
     assert expected_msg == caplog.records[0].message
 
 
-def test_list_vocabs():
-    result = runner.invoke(annif.cli.cli, ["list-vocabs"])
-    assert not result.exception
-    assert result.exit_code == 0
-    assert re.search(r'^dummy\s+en,fi\s+2\s+True',
-                     result.output, re.MULTILINE)
-    assert re.search(r'^yso\s+en,fi,sv\s+130\s+True',
-                     result.output, re.MULTILINE)
-
-
 def test_loadvoc_csv(testdatadir):
     with contextlib.suppress(FileNotFoundError):
         os.remove(str(testdatadir.join('vocabs/yso/subjects.csv')))
@@ -235,6 +225,138 @@ def test_loadvoc_nonexistent_path():
     assert failed_result.exit_code != 0
     assert "Invalid value for 'SUBJECTFILE': " \
            "File 'nonexistent_path' does not exist." in failed_result.output
+
+
+def test_load_vocab_csv(testdatadir):
+    with contextlib.suppress(FileNotFoundError):
+        os.remove(str(testdatadir.join('vocabs/yso/subjects.csv')))
+    with contextlib.suppress(FileNotFoundError):
+        os.remove(str(testdatadir.join('vocabs/yso/subjects.ttl')))
+    subjectfile = os.path.join(
+        os.path.dirname(__file__),
+        'corpora',
+        'archaeology',
+        'subjects.csv')
+    result = runner.invoke(annif.cli.cli,
+                           ['load-vocab', 'yso', subjectfile])
+    assert not result.exception
+    assert result.exit_code == 0
+    assert testdatadir.join('vocabs/yso/subjects.csv').exists()
+    assert testdatadir.join('vocabs/yso/subjects.csv').size() > 0
+    assert testdatadir.join('vocabs/yso/subjects.ttl').exists()
+    assert testdatadir.join('vocabs/yso/subjects.ttl').size() > 0
+    assert testdatadir.join('vocabs/yso/subjects.dump.gz').exists()
+    assert testdatadir.join('vocabs/yso/subjects.dump.gz').size() > 0
+
+
+def test_load_vocab_tsv(testdatadir):
+    with contextlib.suppress(FileNotFoundError):
+        os.remove(str(testdatadir.join('vocabs/yso/subjects.csv')))
+    with contextlib.suppress(FileNotFoundError):
+        os.remove(str(testdatadir.join('vocabs/yso/subjects.ttl')))
+    subjectfile = os.path.join(
+        os.path.dirname(__file__),
+        'corpora',
+        'archaeology',
+        'subjects.tsv')
+    result = runner.invoke(annif.cli.cli,
+                           ['load-vocab', '--language', 'fi',
+                            'yso', subjectfile])
+    assert not result.exception
+    assert result.exit_code == 0
+    assert testdatadir.join('vocabs/yso/subjects.csv').exists()
+    assert testdatadir.join('vocabs/yso/subjects.csv').size() > 0
+    assert testdatadir.join('vocabs/yso/subjects.ttl').exists()
+    assert testdatadir.join('vocabs/yso/subjects.ttl').size() > 0
+    assert testdatadir.join('vocabs/yso/subjects.dump.gz').exists()
+    assert testdatadir.join('vocabs/yso/subjects.dump.gz').size() > 0
+
+
+def test_load_vocab_tsv_with_bom(testdatadir):
+    with contextlib.suppress(FileNotFoundError):
+        os.remove(str(testdatadir.join('vocabs/yso/subjects.csv')))
+    with contextlib.suppress(FileNotFoundError):
+        os.remove(str(testdatadir.join('vocabs/yso/subjects.ttl')))
+    subjectfile = os.path.join(
+        os.path.dirname(__file__),
+        'corpora',
+        'archaeology',
+        'subjects-bom.tsv')
+    result = runner.invoke(annif.cli.cli,
+                           ['load-vocab', '--language', 'fi',
+                            'yso', subjectfile])
+    assert not result.exception
+    assert result.exit_code == 0
+    assert testdatadir.join('vocabs/yso/subjects.csv').exists()
+    assert testdatadir.join('vocabs/yso/subjects.csv').size() > 0
+    assert testdatadir.join('vocabs/yso/subjects.ttl').exists()
+    assert testdatadir.join('vocabs/yso/subjects.ttl').size() > 0
+    assert testdatadir.join('vocabs/yso/subjects.dump.gz').exists()
+    assert testdatadir.join('vocabs/yso/subjects.dump.gz').size() > 0
+
+
+def test_load_vocab_rdf(testdatadir):
+    with contextlib.suppress(FileNotFoundError):
+        os.remove(str(testdatadir.join('vocabs/yso/subjects.csv')))
+    with contextlib.suppress(FileNotFoundError):
+        os.remove(str(testdatadir.join('vocabs/yso/subjects.ttl')))
+    subjectfile = os.path.join(
+        os.path.dirname(__file__),
+        'corpora',
+        'archaeology',
+        'yso-archaeology.rdf')
+    result = runner.invoke(annif.cli.cli,
+                           ['load-vocab', 'yso', subjectfile])
+    assert not result.exception
+    assert result.exit_code == 0
+    assert testdatadir.join('vocabs/yso/subjects.csv').exists()
+    assert testdatadir.join('vocabs/yso/subjects.csv').size() > 0
+    assert testdatadir.join('vocabs/yso/subjects.ttl').exists()
+    assert testdatadir.join('vocabs/yso/subjects.ttl').size() > 0
+    assert testdatadir.join('vocabs/yso/subjects.dump.gz').exists()
+    assert testdatadir.join('vocabs/yso/subjects.dump.gz').size() > 0
+
+
+def test_load_vocab_ttl(testdatadir):
+    with contextlib.suppress(FileNotFoundError):
+        os.remove(str(testdatadir.join('vocabs/yso/subjects.csv')))
+    with contextlib.suppress(FileNotFoundError):
+        os.remove(str(testdatadir.join('vocabs/yso/subjects.ttl')))
+    subjectfile = os.path.join(
+        os.path.dirname(__file__),
+        'corpora',
+        'archaeology',
+        'yso-archaeology.ttl')
+    result = runner.invoke(annif.cli.cli,
+                           ['load-vocab', 'yso', subjectfile])
+    assert not result.exception
+    assert result.exit_code == 0
+    assert testdatadir.join('vocabs/yso/subjects.csv').exists()
+    assert testdatadir.join('vocabs/yso/subjects.csv').size() > 0
+    assert testdatadir.join('vocabs/yso/subjects.ttl').exists()
+    assert testdatadir.join('vocabs/yso/subjects.ttl').size() > 0
+    assert testdatadir.join('vocabs/yso/subjects.dump.gz').exists()
+    assert testdatadir.join('vocabs/yso/subjects.dump.gz').size() > 0
+
+
+def test_load_vocab_nonexistent_path():
+    failed_result = runner.invoke(
+        annif.cli.cli, [
+            'load-vocab', 'dummy', 'nonexistent_path'])
+    assert failed_result.exception
+    assert failed_result.exit_code != 0
+    assert "Invalid value for 'SUBJECTFILE': " \
+           "File 'nonexistent_path' does not exist." in failed_result.output
+
+
+def test_list_vocabs():
+    result = runner.invoke(annif.cli.cli, ["list-vocabs"])
+    assert not result.exception
+    assert result.exit_code == 0
+    assert re.search(r'^dummy\s+en,fi\s+2\s+True',
+                     result.output, re.MULTILINE)
+    assert re.search(r'^yso\s+en,fi,sv\s+130\s+True',
+                     result.output, re.MULTILINE)
 
 
 def test_train(testdatadir):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -112,6 +112,16 @@ def test_clear_project_nonexistent_data(testdatadir, caplog):
     assert expected_msg == caplog.records[0].message
 
 
+def test_list_vocabs():
+    result = runner.invoke(annif.cli.cli, ["list-vocabs"])
+    assert not result.exception
+    assert result.exit_code == 0
+    assert re.search(r'^dummy\s+en,fi\s+2\s+True',
+                     result.output, re.MULTILINE)
+    assert re.search(r'^yso\s+en,fi,sv\s+130\s+True',
+                     result.output, re.MULTILINE)
+
+
 def test_loadvoc_csv(testdatadir):
     with contextlib.suppress(FileNotFoundError):
         os.remove(str(testdatadir.join('vocabs/yso/subjects.csv')))

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -34,6 +34,7 @@ def test_get_project_fi(registry):
     assert project.language == 'fi'
     assert project.analyzer.name == 'snowball'
     assert project.analyzer.param == 'finnish'
+    assert project.vocab_lang == 'fi'
     assert project.access == Access.public
     assert isinstance(project.backend, annif.backend.dummy.DummyBackend)
 

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -56,7 +56,7 @@ def test_get_project_dummy_vocablang(registry):
     assert project.analyzer.param == 'english'
     # project uses the dummy vocab, with language overridden to Finnish
     assert project.vocab.vocab_id == 'dummy'
-    assert project.vocab.language == 'fi'
+    assert project.vocab_lang == 'fi'
     assert project.access == Access.public
     assert isinstance(project.backend, annif.backend.dummy.DummyBackend)
 

--- a/tests/test_vocab.py
+++ b/tests/test_vocab.py
@@ -9,7 +9,7 @@ import rdflib.namespace
 
 
 def load_dummy_vocab(tmpdir):
-    vocab = annif.vocab.AnnifVocabulary('vocab-id', str(tmpdir), 'en')
+    vocab = annif.vocab.AnnifVocabulary('vocab-id', str(tmpdir))
     subjfile = os.path.join(
         os.path.dirname(__file__),
         'corpora',

--- a/tests/test_vocab_skos.py
+++ b/tests/test_vocab_skos.py
@@ -50,7 +50,6 @@ yso:p9285
     subjects = list(corpus.subjects)
     assert len(subjects) == 1  # one of the concepts was deprecated
     assert subjects[0].uri == 'http://www.yso.fi/onto/yso/p8993'
-    print(subjects[0].labels)
     assert subjects[0].labels['fi'] == 'hylyt'
     assert subjects[0].notation is None
 


### PR DESCRIPTION
This PR adds two new CLI commands, `annif load-vocab` and `annif list-vocabs`. It also deprecates the old `annif loadvoc` command. The main difference between `load-vocab` and `loadvoc` is that `load-vocab` operates directly on the vocabulary and takes a vocabulary ID as argument, while `loadvoc` takes a project ID as argument. See #602 for more details on these.

Here are examples of running the new commands:

```
$ annif load-vocab dummy tests/corpora/dummy-subjects.csv 
Loading vocabulary from CSV file tests/corpora/dummy-subjects.csv...
updating existing subject index
saving vocabulary into SKOS file data/vocabs/dummy/subjects.ttl
```

As is apparent, the `load-vocab` command is more verbose than `loadvoc` which produced little or no output.

The new `list-vocabs` command shows some basic information about the vocabularies:

```
$ annif list-vocabs
Vocabulary ID       Languages                 Size  Loaded
----------------------------------------------------------
yso                 en,fi,sv                 37869  True  
stw                 de,en                     6243  True  
gnd                 -                            -  False 
yletest             -                            -  False 
arch                fi                         125  True  
ykl                 -                            -  False 
dummy               en,fi                        2  True  
```

The `loadvoc` command now shows a deprecation message (in red color when possible) and has also become slightly more verbose:

```
$ annif loadvoc dummy-fi tests/corpora/dummy-subjects.csv 
DeprecationWarning: The command 'loadvoc' is deprecated.
updating existing subject index
saving vocabulary into SKOS file data/vocabs/dummy/subjects.ttl
```

There are also changes to the CLI commands documentation that is nowadays published on ReadTheDocs (see #611). The section on `loadvoc` command has been deleted, since we don't want to encourage its use. I will file a separate issue on removing the `loadvoc` command in a future release, probably 0.60.

Fixes #602