### PR TITLE
Use Lingua instead of pycld3 for language detection

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -49,7 +49,7 @@ jobs:
         # Selectively install the optional dependencies for some Python versions
         # For Python 3.8:
         if [[ ${{ matrix.python-version }} == '3.8' ]]; then
-          poetry install -E "nn omikuji yake voikko pycld3";
+          poetry install -E "nn omikuji yake voikko lingua";
         fi
         # For Python 3.9:
         if [[ ${{ matrix.python-version }} == '3.9' ]]; then
@@ -62,7 +62,6 @@ jobs:
           poetry install -E "nn omikuji yake";
         fi
         poetry run python -m nltk.downloader punkt
-
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.8-slim-bullseye
 LABEL maintainer="Juho Inkinen <juho.inkinen@helsinki.fi>"
 SHELL ["/bin/bash", "-c"]
 
-ARG optional_dependencies="fasttext voikko pycld3 fasttext nn omikuji yake spacy"
+ARG optional_dependencies="fasttext voikko lingua fasttext nn omikuji yake spacy"
 ARG POETRY_VIRTUALENVS_CREATE=false
 
 # Install system dependencies needed at runtime:

--- a/annif/transform/__init__.py
+++ b/annif/transform/__init__.py
@@ -48,4 +48,4 @@ try:
     _transforms.update({langfilter.LangFilter.name: langfilter.LangFilter})
 except ImportError:
     annif.logger.debug(
-        "pycld3 not available, not enabling filter_language transform")
+        "Lingua not available, not enabling filter_language transform")

--- a/annif/transform/langfilter.py
+++ b/annif/transform/langfilter.py
@@ -2,7 +2,7 @@
 different from the language of the project."""
 
 import annif
-import cld3
+import lingua
 from . import transform
 
 logger = annif.logger
@@ -16,14 +16,20 @@ class LangFilter(transform.BaseTransform):
         super().__init__(project)
         self.text_min_length = int(text_min_length)
         self.sentence_min_length = int(sentence_min_length)
+        self.detector = (
+            lingua.LanguageDetectorBuilder
+            .from_all_languages()
+            .with_low_accuracy_mode()
+            .build()
+        )
 
     def _detect_language(self, text):
         """Tries to detect the language of a text input. Outputs a BCP-47-style
         language code (e.g. 'en')."""
 
-        lan_info = cld3.get_language(text)
-        if lan_info is not None and lan_info.is_reliable:
-            return lan_info.language
+        lan_info = self.detector.detect_language_of(text)
+        if lan_info is not None:
+            return lan_info.iso_code_639_1.name.lower()
         else:
             return None
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ tensorflow-cpu = {version = "2.9.1", optional = true}
 lmdb = {version = "1.3.0", optional = true}
 omikuji = {version = "0.5.*", optional = true}
 yake = {version = "0.4.5", optional = true}
-pycld3 = {version = "*", optional = true}
+lingua-language-detector = {version = "1.1.1", optional = true}
 spacy = {version = "3.3.*", optional = true}
 
 [tool.poetry.dev-dependencies]
@@ -79,7 +79,7 @@ voikko = ["voikko"]
 nn = ["tensorflow-cpu", "lmdb"]
 omikuji = ["omikuji"]
 yake = ["yake"]
-pycld3 = ["pycld3"]
+lingua = ["lingua-language-detector"]
 spacy = ["spacy"]
 
 [tool.poetry.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ tensorflow-cpu = {version = "2.9.1", optional = true}
 lmdb = {version = "1.3.0", optional = true}
 omikuji = {version = "0.5.*", optional = true}
 yake = {version = "0.4.5", optional = true}
-lingua-language-detector = {version = "1.1.1", optional = true}
+lingua-language-detector = {version = "1.1.2", optional = true}
 spacy = {version = "3.3.*", optional = true}
 
 [tool.poetry.dev-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ tensorflow-cpu = {version = "2.9.1", optional = true}
 lmdb = {version = "1.3.0", optional = true}
 omikuji = {version = "0.5.*", optional = true}
 yake = {version = "0.4.5", optional = true}
-lingua-language-detector = {version = "1.1.2", optional = true}
+lingua-language-detector = {version = "1.1.3", optional = true}
 spacy = {version = "3.3.*", optional = true}
 
 [tool.poetry.dev-dependencies]

--- a/tests/test_transform_langfilter.py
+++ b/tests/test_transform_langfilter.py
@@ -32,7 +32,6 @@ def test_lang_filter(project):
         Kansalliskirjasto on kaikille avoin kulttuuriperintöorganisaatio, joka
         palvelee valtakunnallisesti kansalaisia, tiedeyhteisöjä ja muita
         yhteiskunnan toimijoita.
-        Abc defghij klmnopqr stuwxyz abc defghij klmnopqr stuwxyz.
         Turvaamme Suomessa julkaistun tai Suomea koskevan julkaistun
         kulttuuriperinnön saatavuuden sekä välittämme ja tuotamme
         tietosisältöjä tutkimukselle, opiskelulle, kansalaisille ja


### PR DESCRIPTION
This draft PR fixes #593 by switching from the pycld3 language detection library to Lingua (by @pemistahl).

Lingua is used in the low accuracy mode, because it is much faster than the high accuracy mode and needs a lot less memory. I tested the high accuracy mode very briefly but just the startup overhead was so high (tens of seconds) that I considered it a non-starter.

I did a little benchmarking using the [Annif tutorial](https://github.com/NatLibFi/Annif-tutorial) yso-nlf data set and two project configurations used in the tutorial with two backend algorithms, MLLM and Omikuji Parabel. I compared current master (which uses pycld3) to this PR branch which uses Lingua 1.1.1. As a baseline, I also used project configurations with no language filtering. Here are the project configurations:

```
[yso-mllm-en-filter]
name=YSO MLLM project
language=en
backend=mllm
vocab=yso-en
analyzer=snowball(english)
transform=limit(10000),filter_lang,limit(5000)

[yso-omikuji-parabel-en-filter]
name=Omikuji Parabel English
language=en
backend=omikuji
analyzer=snowball(english)
vocab=yso-en
transform=limit(10000),filter_lang,limit(5000)
```

For the unfiltered baseline I used `transform=limit(5000)` instead.

Here are some performance stats (total user time over all CPU cores and maximum resident set size) that I measured using `/usr/bin/time -v`:

operation | notes | no filter time | no filter mem | pycld3 time | pycld3 mem | lingua-low time | lingua-low mem
-- | -- | -- | -- | -- | -- | -- | --
pytest | optionals: dev,omikuji,pycld3/lingua | - | - | 76 | 1302904 | 77 | 1299056
loadvoc yso | yso-skos.ttl | 121 | 2468144 | - | - | 120 | 2466232
train mllm | -d 2000 -j 8 | 646 | 1876336 | 608 | 1879700 | 2176 | 1893320
suggest mllm | 2017-D-52518.txt | 7 | 283548 | 7 | 278576 | 14 | 291960
eval mllm | -j 8 | 128 | 360836 | 131 | 361688 | 624 | 359360
train omikuji | -j 8 yso-finna-small.tsv.gz | 124 | 663368 | 125 | 682708 | 131 | 684188
suggest omikuji | 2017-D-52518.txt | 5 | 400784 | 6 | 396836 | 14 | 410744
eval omikuji | -j 8 | 22 | 483988 | 29 | 483704 | 513 | 481508

Here are the evaluation results (running `annif eval` on the 300 documents in the test set and measuring F1@5 and nDCG scores - higher is better):

| Project type | no filter f1@5 | no filter ndcg | pycld3 f1@5 | pycld3 ndcg | lingua-low f1@5 | lingua-low ndcg |
| ------------ | -------------- | -------------- | ----------- | ----------- | --------------- | --------------- |
| mllm         | 0.3276         | 0.4334         | 0.3236      | 0.4282      | 0.3183          | 0.4228          |
| omikuji      | 0.2562         | 0.3543         | 0.2435      | 0.3287      | 0.2524          | 0.3385          |

The good news:

- Lingua starts up quickly (in low-accuracy mode)
- Lingua doesn't use any more memory than pycld3 (in low-accuracy mode)

The bad news:

- Lingua is still a lot slower than pycld3 in the grunt work of filtering long documents sentence by sentence. For example, when training MLLM with 2000 documents (truncated to max 10000 characters each by the limit filter), the user time increased from ~600 to ~2100 seconds. Likewise, evaluation time on 300 documents increased by ~500 seconds. For suggest operations on a single document, the increase was ~7 seconds (but this most likely includes some initialization overhead, so the next document would have been processed faster).
- In general, this experiment didn't show any benefit of language filtering. The evaluation results were actually best for the baseline experiment with no filtering; using either pycld3 or Lingua just made the results worse. For other data sets and languages, the situation could be different.
- Maybe this is nitpicking, but it was surprisingly hard to get a standard lowercase ISO 639-1 language code out of Lingua. Eventually I found out that using an expression like `result.iso_code_639_1.name.lower()` does the trick. pycld3 returns language codes directly, which makes the API easier to use.

I think the take home message is that if Lingua could be made faster still for the detection process, then we could consider switching to it. Right now it seems that the performance cost is quite high. It would also be nice to identify a data set where the language filtering actually improves results; we could then measure whether Lingua does this better than pycld3 or not. This data set was not a good choice in that respect.