### PR TITLE
upgrade to simplemma 0.8 and disable unnecessary cache

### DIFF
--- a/annif/analyzer/simplemma.py
+++ b/annif/analyzer/simplemma.py
@@ -1,6 +1,5 @@
 """Simplemma analyzer for Annif, based on simplemma lemmatizer."""
 
-import functools
 import simplemma
 from . import analyzer
 
@@ -12,6 +11,5 @@ class SimplemmaAnalyzer(analyzer.Analyzer):
         self.lang = param
         super().__init__(**kwargs)
 
-    @functools.lru_cache(maxsize=500000)
     def _normalize_word(self, word):
         return simplemma.lemmatize(word, self.lang)

--- a/annif/analyzer/simplemma.py
+++ b/annif/analyzer/simplemma.py
@@ -12,4 +12,4 @@ class SimplemmaAnalyzer(analyzer.Analyzer):
         super().__init__(**kwargs)
 
     def _normalize_word(self, word):
-        return simplemma.lemmatize(word, self.lang)
+        return simplemma.lemmatize(word, lang=self.lang)

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
         'stwfsapy==0.3.*',
         'python-dateutil',
         'tomli==2.0.*',
-        'simplemma==0.7.*'
+        'simplemma==0.8.*'
     ],
     tests_require=['py', 'pytest', 'requests'],
     extras_require={


### PR DESCRIPTION
Fixes #617

This PR upgrades Simplemma to version 0.8.* (from 0.7.*) and removes the LRU cache, because Simplemma nowadays already has a similar cache. Thanks to @adbar for the tip!