### PR TITLE
Allow use of hyphens in vocabulary IDs

### DIFF
--- a/annif/registry.py
+++ b/annif/registry.py
@@ -76,7 +76,7 @@ class AnnifRegistry:
         vocab_spec. If no language information is specified, use the given
         default language."""
 
-        match = re.match(r'(\w+)(\((.*)\))?', vocab_spec)
+        match = re.match(r'([\w-]+)(\((.*)\))?$', vocab_spec)
         if match is None:
             raise ValueError(
                 f"Invalid vocabulary specification: {vocab_spec}")

--- a/tests/projects.cfg
+++ b/tests/projects.cfg
@@ -68,7 +68,7 @@ analyzer=snowball(english)
 [noname]
 language=en
 backend=tfidf
-vocab=dummy
+vocab=dummy-noname
 analyzer=snowball(english)
 
 [noparams-tfidf-fi]

--- a/tests/test_vocab.py
+++ b/tests/test_vocab.py
@@ -25,6 +25,12 @@ def test_get_vocab_invalid(registry):
     assert 'Invalid vocabulary specification' in str(excinfo.value)
 
 
+def test_get_vocab_hyphen(registry):
+    vocab, lang = registry.get_vocab('dummy-noname', None)
+    assert vocab.vocab_id == 'dummy-noname'
+    assert vocab is not None
+
+
 def test_update_subject_index_with_no_changes(tmpdir):
     vocab = load_dummy_vocab(tmpdir)
 


### PR DESCRIPTION
This little PR fixes a parsing bug related to vocabulary IDs. If a vocabulary ID such as `yso-fi` or `yso-arch` was given in the configuration file, it would be shortened to `yso`. The regex for matching IDs was too restrictive.

This PR fixes the regex and adds a unit test verifying that it keeps working as intended.