### PR TITLE
fix: make NN ensemble suggest operations silent

### DIFF
--- a/annif/backend/nn_ensemble.py
+++ b/annif/backend/nn_ensemble.py
@@ -134,7 +134,7 @@ class NNEnsembleBackend(
                                  in hits_from_sources],
                                 dtype=np.float32)
         results = self._model.predict(
-            np.expand_dims(score_vector.transpose(), 0))
+            np.expand_dims(score_vector.transpose(), 0), verbose=0)
         return VectorSuggestionResult(results[0])
 
     def _create_model(self, sources):


### PR DESCRIPTION
This one-line PR makes NN ensemble suggest operations silent. They used to be quiet at least in Annif 0.57, but apparently something changed in TensorFlow and now there are messages like this:

    1/1 [==============================] - 0s 15ms/step 
    1/1 [==============================] - 0s 15ms/step 
    1/1 [==============================] - 0s 15ms/step
