### PR TITLE
Remove curl from Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,8 @@ RUN apt-get update && \
 			libvoikko1 \
 			voikko-fi; \
 	fi && \
-	# curl for Docker healthcheck and rsync for model transfers:
-	apt-get install -y --no-install-recommends curl rsync && \
+	# Install rsync for model transfers:
+	apt-get install -y --no-install-recommends rsync && \
 	rm -rf /var/lib/apt/lists/* /usr/include/*
 
 WORKDIR /Annif


### PR DESCRIPTION
Curl was being used for [health checks for Annif](https://github.com/NatLibFi/Annif/blob/1c815dbe8689274093fd768dd4b47f01f949595f/docker-compose-ai.finto.fi.yml#L18) instances run in the Docker Swarm / Portainer environment. Now, since the service are running in OpenShift platform, curl is no more needed in Docker image because OpenShift has internal http functionality for [health checks](https://docs.openshift.com/container-platform/4.6/applications/application-health.html). 