### PR TITLE
Remove Poetry cache from Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,8 @@ COPY pyproject.toml setup.cfg README.md LICENSE.txt CITATION.cff projects.cfg.di
 
 # First round of installation for Docker layer caching:
 RUN echo "Installing dependencies for optional features: $optional_dependencies" \
-	&& poetry install -E "$optional_dependencies"
+	&& poetry install -E "$optional_dependencies" \
+	&& rm -rf /root/.cache/pypoetry  # No need for cache because of poetry.lock
 
 # Download nltk data
 RUN python -m nltk.downloader punkt -d /usr/share/nltk_data


### PR DESCRIPTION
Switching to use Poetry in Dockerfile (#605) increased the Docker image size to 3.2 GB. The image size for Annif v0.58 is 1.92 GB.

Simple fix is to just delete the cache after the installation (the `--no-cache` option of Poetry had no effect). The dependency resolution creates the `poetry.lock` file, which is used on the second round of installation (after adding Annif source code), so cache is unnecessary.