### PR TITLE
Increase timeout of test and publish GH Actions jobs

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10"]
@@ -79,6 +79,7 @@ jobs:
     name: publish latest Docker image
     needs: test
     runs-on: ubuntu-20.04
+    timeout-minutes: 15
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     steps:
     - name: Login to Quay.io


### PR DESCRIPTION
The first attempt of the [test job in GH Actions failed](https://github.com/NatLibFi/Annif/actions/runs/3111298513/attempts/1) when releasing v0.59 because it took longer than the 10 min timeout limit. The run took longer than usually as for this run the Poetry cache was not available.

To avoid such problems in the future it is best to increase the timeout for both jobs.