### PR TITLE
Allow overriding subject label language in CLI and REST suggest operations

### DIFF
--- a/annif/cli.py
+++ b/annif/cli.py
@@ -323,9 +323,10 @@ def run_learn(project_id, paths, docs_limit, backend_param):
 @click.argument('project_id')
 @click.option('--limit', '-l', default=10, help='Maximum number of subjects')
 @click.option('--threshold', '-t', default=0.0, help='Minimum score threshold')
+@click.option('--language', '-L', help='Language of subject labels')
 @backend_param_option
 @common_options
-def run_suggest(project_id, limit, threshold, backend_param):
+def run_suggest(project_id, limit, threshold, language, backend_param):
     """
     Suggest subjects for a single document from standard input.
     \f
@@ -334,6 +335,7 @@ def run_suggest(project_id, limit, threshold, backend_param):
     """
     project = get_project(project_id)
     text = sys.stdin.read()
+    lang = language or project.vocab_lang
     backend_params = parse_backend_params(backend_param, project)
     hit_filter = SuggestionFilter(project.subjects, limit, threshold)
     hits = hit_filter(project.suggest(text, backend_params))
@@ -343,7 +345,7 @@ def run_suggest(project_id, limit, threshold, backend_param):
             "<{}>\t{}\t{}".format(
                 subj.uri,
                 '\t'.join(filter(None,
-                                 (subj.labels[project.vocab_lang],
+                                 (subj.labels[lang],
                                   subj.notation))),
                 hit.score))
 

--- a/annif/cli.py
+++ b/annif/cli.py
@@ -362,16 +362,18 @@ def run_suggest(project_id, limit, threshold, language, backend_param):
               help='Force overwriting of existing result files')
 @click.option('--limit', '-l', default=10, help='Maximum number of subjects')
 @click.option('--threshold', '-t', default=0.0, help='Minimum score threshold')
+@click.option('--language', '-L', help='Language of subject labels')
 @backend_param_option
 @common_options
 def run_index(project_id, directory, suffix, force,
-              limit, threshold, backend_param):
+              limit, threshold, language, backend_param):
     """
     Index a directory with documents, suggesting subjects for each document.
     Write the results in TSV files with the given suffix (``.annif`` by
     default).
     """
     project = get_project(project_id)
+    lang = language or project.vocab_lang
     backend_params = parse_backend_params(backend_param, project)
     hit_filter = SuggestionFilter(project.subjects, limit, threshold)
 
@@ -392,7 +394,7 @@ def run_index(project_id, directory, suffix, force,
                 subj = project.subjects[hit.subject_id]
                 line = "<{}>\t{}\t{}".format(
                     subj.uri,
-                    '\t'.join(filter(None, (subj.labels[project.vocab_lang],
+                    '\t'.join(filter(None, (subj.labels[lang],
                                             subj.notation))),
                     hit.score)
                 click.echo(line, file=subjfile)

--- a/annif/cli.py
+++ b/annif/cli.py
@@ -336,6 +336,9 @@ def run_suggest(project_id, limit, threshold, language, backend_param):
     project = get_project(project_id)
     text = sys.stdin.read()
     lang = language or project.vocab_lang
+    if lang not in project.vocab.languages:
+        raise click.BadParameter(
+            f'language "{lang}" not supported by vocabulary')
     backend_params = parse_backend_params(backend_param, project)
     hit_filter = SuggestionFilter(project.subjects, limit, threshold)
     hits = hit_filter(project.suggest(text, backend_params))
@@ -374,6 +377,9 @@ def run_index(project_id, directory, suffix, force,
     """
     project = get_project(project_id)
     lang = language or project.vocab_lang
+    if lang not in project.vocab.languages:
+        raise click.BadParameter(
+            f'language "{lang}" not supported by vocabulary')
     backend_params = parse_backend_params(backend_param, project)
     hit_filter = SuggestionFilter(project.subjects, limit, threshold)
 

--- a/annif/rest.py
+++ b/annif/rest.py
@@ -58,7 +58,7 @@ def _suggestion_to_dict(suggestion, subject_index, language):
     }
 
 
-def suggest(project_id, text, limit, threshold):
+def suggest(project_id, text, limit, threshold, language=None):
     """suggest subjects for the given text and return a dict with results
     formatted according to Swagger spec"""
 
@@ -75,7 +75,7 @@ def suggest(project_id, text, limit, threshold):
         return server_error(err)
     hits = hit_filter(result).as_list()
     return {'results': [_suggestion_to_dict(hit, project.subjects,
-                                            project.vocab_lang)
+                                            language or project.vocab_lang)
                         for hit in hits]}
 
 

--- a/annif/swagger/annif.yaml
+++ b/annif/swagger/annif.yaml
@@ -73,6 +73,11 @@ paths:
           required: false
           type: number
           default: 0
+        - name: language
+          in: formData
+          description: language of subject labels
+          required: false
+          type: string
       responses:
         '200':
           description: successful operation

--- a/annif/swagger/annif.yaml
+++ b/annif/swagger/annif.yaml
@@ -83,6 +83,10 @@ paths:
           description: successful operation
           schema:
             $ref: '#/definitions/SuggestionResultList'
+        '400':
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/Problem'
         '404':
           description: Project not found
           schema:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -520,6 +520,19 @@ def test_index(tmpdir):
         'utf-8') == "<http://example.org/dummy>\tdummy-fi\t1.0\n"
 
 
+def test_index_with_language_override(tmpdir):
+    tmpdir.join('doc1.txt').write('nothing special')
+
+    result = runner.invoke(
+        annif.cli.cli, ['index', '--language', 'fi', 'dummy-en', str(tmpdir)])
+    assert not result.exception
+    assert result.exit_code == 0
+
+    assert tmpdir.join('doc1.annif').exists()
+    assert tmpdir.join('doc1.annif').read_text(
+        'utf-8') == "<http://example.org/dummy>\tdummy-fi\t1.0\n"
+
+
 def test_index_nonexistent_path():
     failed_result = runner.invoke(
         annif.cli.cli, [

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -416,6 +416,16 @@ def test_suggest():
     assert result.exit_code == 0
 
 
+def test_suggest_with_language_override():
+    result = runner.invoke(
+        annif.cli.cli,
+        ['suggest', '--language', 'en', 'dummy-fi'],
+        input='kissa')
+    assert not result.exception
+    assert result.output == "<http://example.org/dummy>\tdummy\t1.0\n"
+    assert result.exit_code == 0
+
+
 def test_suggest_with_different_vocab_language():
     # project language is English - input should be in English
     # vocab language is Finnish - subject labels should be in Finnish

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -426,6 +426,16 @@ def test_suggest_with_language_override():
     assert result.exit_code == 0
 
 
+def test_suggest_with_language_override_bad_value():
+    failed_result = runner.invoke(
+        annif.cli.cli,
+        ['suggest', '--language', 'xx', 'dummy-fi'],
+        input='kissa')
+    assert failed_result.exception
+    assert failed_result.exit_code != 0
+    assert 'language "xx" not supported by vocabulary' in failed_result.output
+
+
 def test_suggest_with_different_vocab_language():
     # project language is English - input should be in English
     # vocab language is Finnish - subject labels should be in Finnish
@@ -531,6 +541,17 @@ def test_index_with_language_override(tmpdir):
     assert tmpdir.join('doc1.annif').exists()
     assert tmpdir.join('doc1.annif').read_text(
         'utf-8') == "<http://example.org/dummy>\tdummy-fi\t1.0\n"
+
+
+def test_index_with_language_override_bad_value(tmpdir):
+    tmpdir.join('doc1.txt').write('nothing special')
+
+    failed_result = runner.invoke(
+        annif.cli.cli, ['index', '--language', 'xx', 'dummy-en', str(tmpdir)])
+
+    assert failed_result.exception
+    assert failed_result.exit_code != 0
+    assert 'language "xx" not supported by vocabulary' in failed_result.output
 
 
 def test_index_nonexistent_path():

--- a/tests/test_rest.py
+++ b/tests/test_rest.py
@@ -108,6 +108,17 @@ def test_rest_suggest_with_language_override(app):
         assert result['results'][0]['label'] == 'dummy'
 
 
+def test_rest_suggest_with_language_override_bad_value(app):
+    with app.app_context():
+        result = annif.rest.suggest(
+            'dummy-vocablang',
+            text='example text',
+            limit=10,
+            threshold=0.0,
+            language='xx')
+        assert result.status_code == 400
+
+
 def test_rest_suggest_with_different_vocab_language(app):
     # project language is English - input should be in English
     # vocab language is Finnish - subject labels should be in Finnish

--- a/tests/test_rest.py
+++ b/tests/test_rest.py
@@ -97,6 +97,17 @@ def test_rest_suggest_novocab(app):
         assert result.status_code == 503
 
 
+def test_rest_suggest_with_language_override(app):
+    with app.app_context():
+        result = annif.rest.suggest(
+            'dummy-vocablang',
+            text='example text',
+            limit=10,
+            threshold=0.0,
+            language='en')
+        assert result['results'][0]['label'] == 'dummy'
+
+
 def test_rest_suggest_with_different_vocab_language(app):
     # project language is English - input should be in English
     # vocab language is Finnish - subject labels should be in Finnish


### PR DESCRIPTION
Fixes #628

This PR implements an option `--language` / `-L` for the `annif suggest` command as well as an optional `language` parameter for the REST API `suggest` method, both of which allow overriding the language of returned subject labels.

TODO:

- [x] error handling: don't break if the given language is broken or not available in the vocabulary
- [x] implement the `--language` option for the `annif index` command as well
- [x] address QA tool complaints