### PR TITLE
add support for spawn multiprocessing mode

### DIFF
--- a/annif/parallel.py
+++ b/annif/parallel.py
@@ -4,6 +4,11 @@
 import multiprocessing
 import multiprocessing.dummy
 
+# Start method for processes created by the multiprocessing module.
+# A value of None means using the platform-specific default.
+# Intended to be overridden in unit tests.
+MP_START_METHOD = None
+
 
 class BaseWorker:
     """Base class for workers that implement tasks executed via
@@ -48,13 +53,15 @@ def get_pool(n_jobs):
     """return a suitable multiprocessing pool class, and the correct jobs
     argument for its constructor, for the given amount of parallel jobs"""
 
+    ctx = multiprocessing.get_context(MP_START_METHOD)
+
     if n_jobs < 1:
         n_jobs = None
-        pool_class = multiprocessing.Pool
+        pool_class = ctx.Pool
     elif n_jobs == 1:
         # use the dummy wrapper around threading to avoid subprocess overhead
         pool_class = multiprocessing.dummy.Pool
     else:
-        pool_class = multiprocessing.Pool
+        pool_class = ctx.Pool
 
     return n_jobs, pool_class

--- a/annif/registry.py
+++ b/annif/registry.py
@@ -30,16 +30,22 @@ class AnnifRegistry:
 
     def __init__(self, projects_config_path, datadir, init_projects):
         self._rid = id(self)
+        self._projects_config_path = projects_config_path
         self._datadir = datadir
-        self._projects[self._rid] = self._create_projects(projects_config_path)
-        self._vocabs[self._rid] = {}
+        self._init_vars()
         if init_projects:
             for project in self._projects[self._rid].values():
                 project.initialize()
 
-    def _create_projects(self, projects_config_path):
+    def _init_vars(self):
+        # initialize the static variables, if necessary
+        if self._rid not in self._projects:
+            self._projects[self._rid] = self._create_projects()
+            self._vocabs[self._rid] = {}
+
+    def _create_projects(self):
         # parse the configuration
-        config = parse_config(projects_config_path)
+        config = parse_config(self._projects_config_path)
 
         # handle the case where the config file doesn't exist
         if config is None:
@@ -58,6 +64,7 @@ class AnnifRegistry:
         AnnifProject. The min_access parameter may be used to set the minimum
         access level required for the returned projects."""
 
+        self._init_vars()
         return {
             project_id: project
             for project_id, project in self._projects[self._rid].items()
@@ -86,6 +93,7 @@ class AnnifRegistry:
         language = posargs[0] if posargs else default_language
         vocab_key = (vocab_id, language)
 
+        self._init_vars()
         if vocab_key not in self._vocabs[self._rid]:
             self._vocabs[self._rid][vocab_key] = AnnifVocabulary(
                 vocab_id, self._datadir

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,6 +11,7 @@ import shutil
 from click.testing import CliRunner
 
 import annif.cli
+import annif.parallel
 
 runner = CliRunner(env={"ANNIF_CONFIG": "annif.default_config.TestingConfig"})
 
@@ -795,6 +796,22 @@ def test_eval_two_jobs(tmpdir):
     tmpdir.join("doc2.key").write("none")
     tmpdir.join("doc3.txt").write("doc3")
 
+    result = runner.invoke(
+        annif.cli.cli, ["eval", "--jobs", "2", "dummy-en", str(tmpdir)]
+    )
+    assert not result.exception
+    assert result.exit_code == 0
+
+
+def test_eval_two_jobs_spawn(tmpdir, monkeypatch):
+    tmpdir.join("doc1.txt").write("doc1")
+    tmpdir.join("doc1.key").write("dummy")
+    tmpdir.join("doc2.txt").write("doc2")
+    tmpdir.join("doc2.key").write("none")
+    tmpdir.join("doc3.txt").write("doc3")
+
+    # use spawn method for starting multiprocessing worker processes
+    monkeypatch.setattr(annif.parallel, "MP_START_METHOD", "spawn")
     result = runner.invoke(
         annif.cli.cli, ["eval", "--jobs", "2", "dummy-en", str(tmpdir)]
     )

--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -2,6 +2,7 @@
 
 import multiprocessing
 import multiprocessing.dummy
+import multiprocessing.pool
 
 import annif.parallel
 
@@ -9,7 +10,7 @@ import annif.parallel
 def test_get_pool_0():
     n_jobs, pool_class = annif.parallel.get_pool(0)
     assert n_jobs is None
-    assert pool_class is multiprocessing.Pool
+    assert isinstance(pool_class(), multiprocessing.pool.Pool)
 
 
 def test_get_pool_1():
@@ -21,4 +22,4 @@ def test_get_pool_1():
 def test_get_pool_2():
     n_jobs, pool_class = annif.parallel.get_pool(2)
     assert n_jobs == 2
-    assert pool_class is multiprocessing.Pool
+    assert isinstance(pool_class(), multiprocessing.pool.Pool)


### PR DESCRIPTION
This (draft) PR attempts to add support for the `spawn` multiprocessing mode. This is the only mode supported on Windows, and the default mode on Mac OS. The `fork` mode, supported on Linux and some other *nix systems, is more efficient because it allows loading models only once and then reusing them in forked child processes, with most of the memory shared between the processes. But `spawn` mode is still better than not being able to perform multiprocessing at all.

This PR needs more testing, ideally on both Mac OS and Windows. Currently there is just a single unit test that exercises parallel evaluation using the `spawn` mode.

Fixes #637