### PR TITLE
Use isort to order import statements

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,4 +1,4 @@
 # Migrate code style to Black
 3bc18907354a40f1d89dca1833a2719ba7fb0933
 # Reorder import statements with isort
-7027e328451d2482b8072124113bd257ce021af1
+68a72c5a603283f70abce2651dcde9c6f0177c41

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,4 @@
 # Migrate code style to Black
 3bc18907354a40f1d89dca1833a2719ba7fb0933
+# Reorder import statements with isort
+7027e328451d2482b8072124113bd257ce021af1

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -15,9 +15,10 @@ jobs:
 
   lint:
     runs-on: ubuntu-latest
-    name: lint with Black
+    name: lint with isort & Black
     steps:
       - uses: actions/checkout@v3
+      - uses: isort/isort-action@f14e57e1d457956c45a19c05a89cccdf087846e5  # v1.1.0
       - uses: psf/black@6b42c2b8c9f9bd666120a2c19b8da509fe477f27
 
   test:

--- a/README.md
+++ b/README.md
@@ -102,12 +102,13 @@ pytest-watch by running `ptw`.
 
 ## Code style
 
-Annif code should follow the [Black style](https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html).
-The Black tool is included as a developoment dependency; you can run `black .` in the project root to autoformat code. 
-You can set up a [pre-commit hook](https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks) to automate linting with Black and flake8 with every git commit by using the following in the file `.git/hooks/pre-commit`, which should have execute permission set:
+Annif code should follow the [Black style](https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html) and import statements should be [grouped and ordered](https://peps.python.org/pep-0008/#imports).
+To achive this, the Black and isort tools are included as developoment dependencies; you can run `black .` and `isort .` in the project root to autoformat code. 
+You can set up a [pre-commit hook](https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks) to automate linting with isort, Black and flake8 with every git commit by using the following in the file `.git/hooks/pre-commit`, which should have execute permission set:
 ```bash
 #!/bin/sh
 
+isort . --check-only --diff
 black . --check --diff
 flake8
 ```

--- a/annif/__init__.py
+++ b/annif/__init__.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 
+import logging
 import os
 import os.path
-import logging
+
 import connexion
 from flask_cors import CORS
 

--- a/annif/analyzer/__init__.py
+++ b/annif/analyzer/__init__.py
@@ -1,11 +1,11 @@
 """Collection of language-specific analyzers and analyzer registry for Annif"""
 
 import re
-from . import simple
-from . import snowball
-from . import simplemma
+
 import annif
 from annif.util import parse_args
+
+from . import simple, simplemma, snowball
 
 _analyzers = {}
 

--- a/annif/analyzer/simplemma.py
+++ b/annif/analyzer/simplemma.py
@@ -1,6 +1,7 @@
 """Simplemma analyzer for Annif, based on simplemma lemmatizer."""
 
 import simplemma
+
 from . import analyzer
 
 

--- a/annif/analyzer/snowball.py
+++ b/annif/analyzer/snowball.py
@@ -1,6 +1,7 @@
 """Snowball analyzer for Annif, based on nltk Snowball stemmer."""
 
 import functools
+
 from . import analyzer
 
 

--- a/annif/analyzer/spacy.py
+++ b/annif/analyzer/spacy.py
@@ -1,8 +1,9 @@
 """spaCy analyzer for Annif which uses spaCy for lemmatization"""
 
-from . import analyzer
-from annif.exception import OperationFailedException
 import annif.util
+from annif.exception import OperationFailedException
+
+from . import analyzer
 
 _KEY_LOWERCASE = "lowercase"
 

--- a/annif/analyzer/voikko.py
+++ b/annif/analyzer/voikko.py
@@ -1,7 +1,9 @@
 """Voikko analyzer for Annif, based on libvoikko library."""
 
 import functools
+
 import voikko.libvoikko
+
 from . import analyzer
 
 

--- a/annif/backend/backend.py
+++ b/annif/backend/backend.py
@@ -4,6 +4,7 @@ import abc
 import os.path
 from datetime import datetime, timezone
 from glob import glob
+
 from annif import logger
 
 

--- a/annif/backend/dummy.py
+++ b/annif/backend/dummy.py
@@ -1,7 +1,8 @@
 """Dummy backend for testing basic interaction of projects and backends"""
 
 
-from annif.suggestion import SubjectSuggestion, ListSuggestionResult
+from annif.suggestion import ListSuggestionResult, SubjectSuggestion
+
 from . import backend
 
 

--- a/annif/backend/ensemble.py
+++ b/annif/backend/ensemble.py
@@ -1,13 +1,13 @@
 """Ensemble backend that combines results from multiple projects"""
 
 
+import annif.eval
 import annif.parallel
 import annif.suggestion
 import annif.util
-import annif.eval
-from . import backend
-from . import hyperopt
 from annif.exception import NotSupportedException
+
+from . import backend, hyperopt
 
 
 class BaseEnsembleBackend(backend.AnnifBackend):

--- a/annif/backend/fasttext.py
+++ b/annif/backend/fasttext.py
@@ -2,12 +2,14 @@
 
 import collections
 import os.path
-import annif.util
-from annif.suggestion import SubjectSuggestion, ListSuggestionResult
-from annif.exception import NotInitializedException, NotSupportedException
+
 import fasttext
-from . import backend
-from . import mixins
+
+import annif.util
+from annif.exception import NotInitializedException, NotSupportedException
+from annif.suggestion import ListSuggestionResult, SubjectSuggestion
+
+from . import backend, mixins
 
 
 class FastTextBackend(mixins.ChunkingBackend, backend.AnnifBackend):

--- a/annif/backend/http.py
+++ b/annif/backend/http.py
@@ -5,8 +5,10 @@ and returns the results"""
 import dateutil.parser
 import requests
 import requests.exceptions
-from annif.suggestion import SubjectSuggestion, ListSuggestionResult
+
 from annif.exception import OperationFailedException
+from annif.suggestion import ListSuggestionResult, SubjectSuggestion
+
 from . import backend
 
 

--- a/annif/backend/hyperopt.py
+++ b/annif/backend/hyperopt.py
@@ -3,10 +3,11 @@
 import abc
 import collections
 import warnings
+
 import optuna
 import optuna.exceptions
-from .backend import AnnifBackend
 
+from .backend import AnnifBackend
 
 HPRecommendation = collections.namedtuple("HPRecommendation", "lines score")
 

--- a/annif/backend/mixins.py
+++ b/annif/backend/mixins.py
@@ -3,8 +3,10 @@
 
 import abc
 import os.path
+
 import joblib
 from sklearn.feature_extraction.text import TfidfVectorizer
+
 import annif.util
 from annif.exception import NotInitializedException
 from annif.suggestion import ListSuggestionResult

--- a/annif/backend/mllm.py
+++ b/annif/backend/mllm.py
@@ -1,16 +1,17 @@
 """Maui-like Lexical Matching backend"""
 
 import os.path
+
 import joblib
 import numpy as np
+
 import annif.eval
 import annif.util
-from annif.exception import NotInitializedException
-from annif.exception import NotSupportedException
+from annif.exception import NotInitializedException, NotSupportedException
 from annif.lexical.mllm import MLLMModel
 from annif.suggestion import VectorSuggestionResult
-from . import backend
-from . import hyperopt
+
+from . import backend, hyperopt
 
 
 class MLLMOptimizer(hyperopt.HyperparameterOptimizer):

--- a/annif/backend/nn_ensemble.py
+++ b/annif/backend/nn_ensemble.py
@@ -2,24 +2,26 @@
 projects."""
 
 
-from io import BytesIO
-import shutil
 import os.path
-import numpy as np
-from scipy.sparse import csr_matrix, csc_matrix
+import shutil
+from io import BytesIO
+
 import joblib
 import lmdb
-from tensorflow.keras.layers import Input, Dense, Add, Flatten, Dropout, Layer
+import numpy as np
+import tensorflow.keras.backend as K
+from scipy.sparse import csc_matrix, csr_matrix
+from tensorflow.keras.layers import Add, Dense, Dropout, Flatten, Input, Layer
 from tensorflow.keras.models import Model, load_model
 from tensorflow.keras.utils import Sequence
-import tensorflow.keras.backend as K
+
 import annif.corpus
 import annif.parallel
 import annif.util
 from annif.exception import NotInitializedException, NotSupportedException
 from annif.suggestion import VectorSuggestionResult
-from . import backend
-from . import ensemble
+
+from . import backend, ensemble
 
 
 def idx_to_key(idx):

--- a/annif/backend/omikuji.py
+++ b/annif/backend/omikuji.py
@@ -1,17 +1,19 @@
 """Annif backend using the Omikuji classifier"""
 
-import omikuji
 import os.path
 import shutil
+
+import omikuji
+
 import annif.util
-from annif.suggestion import SubjectSuggestion, ListSuggestionResult
 from annif.exception import (
     NotInitializedException,
     NotSupportedException,
     OperationFailedException,
 )
-from . import backend
-from . import mixins
+from annif.suggestion import ListSuggestionResult, SubjectSuggestion
+
+from . import backend, mixins
 
 
 class OmikujiBackend(mixins.TfidfVectorizerMixin, backend.AnnifBackend):

--- a/annif/backend/pav.py
+++ b/annif/backend/pav.py
@@ -4,16 +4,18 @@ PAV algorithm, a.k.a. isotonic regression, to turn raw scores returned by
 individual backends into probabilities."""
 
 import os.path
+
 import joblib
+import numpy as np
 from scipy.sparse import coo_matrix, csc_matrix
 from sklearn.isotonic import IsotonicRegression
-import numpy as np
+
 import annif.corpus
 import annif.suggestion
 import annif.util
 from annif.exception import NotInitializedException, NotSupportedException
-from . import backend
-from . import ensemble
+
+from . import backend, ensemble
 
 
 class PAVBackend(ensemble.BaseEnsembleBackend):

--- a/annif/backend/stwfsa.py
+++ b/annif/backend/stwfsa.py
@@ -1,10 +1,12 @@
 import os
+
 from stwfsapy.predictor import StwfsapyPredictor
+
 from annif.exception import NotInitializedException, NotSupportedException
 from annif.suggestion import ListSuggestionResult, SubjectSuggestion
-from . import backend
 from annif.util import atomic_save, boolean
 
+from . import backend
 
 _KEY_CONCEPT_TYPE_URI = "concept_type_uri"
 _KEY_SUBTHESAURUS_TYPE_URI = "sub_thesaurus_type_uri"

--- a/annif/backend/svc.py
+++ b/annif/backend/svc.py
@@ -1,15 +1,17 @@
 """Annif backend using a SVM classifier"""
 
 import os.path
+
 import joblib
 import numpy as np
 import scipy.special
 from sklearn.svm import LinearSVC
+
 import annif.util
-from annif.suggestion import SubjectSuggestion, ListSuggestionResult
 from annif.exception import NotInitializedException, NotSupportedException
-from . import backend
-from . import mixins
+from annif.suggestion import ListSuggestionResult, SubjectSuggestion
+
+from . import backend, mixins
 
 
 class SVCBackend(mixins.TfidfVectorizerMixin, backend.AnnifBackend):

--- a/annif/backend/tfidf.py
+++ b/annif/backend/tfidf.py
@@ -3,13 +3,15 @@ TF-IDF normalized bag-of-words vector space"""
 
 import os.path
 import tempfile
-import annif.util
+
 import gensim.similarities
 from gensim.matutils import Sparse2Corpus
-from annif.suggestion import VectorSuggestionResult
+
+import annif.util
 from annif.exception import NotInitializedException, NotSupportedException
-from . import backend
-from . import mixins
+from annif.suggestion import VectorSuggestionResult
+
+from . import backend, mixins
 
 
 class SubjectBuffer:

--- a/annif/backend/yake.py
+++ b/annif/backend/yake.py
@@ -2,16 +2,19 @@
 # For license remarks of this backend see README.md:
 # https://github.com/NatLibFi/Annif#license.
 
-import yake
-import joblib
 import os.path
 import re
 from collections import defaultdict
+
+import joblib
+import yake
 from rdflib.namespace import SKOS
+
 import annif.util
-from . import backend
-from annif.suggestion import SubjectSuggestion, ListSuggestionResult
 from annif.exception import ConfigurationException, NotSupportedException
+from annif.suggestion import ListSuggestionResult, SubjectSuggestion
+
+from . import backend
 
 
 class YakeBackend(backend.AnnifBackend):

--- a/annif/cli.py
+++ b/annif/cli.py
@@ -3,23 +3,28 @@ operations and printing the results to console."""
 
 
 import collections
+import json
 import os.path
 import re
 import sys
-import json
+
 import click
 import click_log
 from flask import current_app
 from flask.cli import FlaskGroup, ScriptInfo
+
 import annif
 import annif.corpus
 import annif.parallel
 import annif.project
 import annif.registry
+from annif.exception import (
+    ConfigurationException,
+    NotInitializedException,
+    NotSupportedException,
+)
 from annif.project import Access
-from annif.suggestion import SuggestionFilter, ListSuggestionResult
-from annif.exception import ConfigurationException, NotSupportedException
-from annif.exception import NotInitializedException
+from annif.suggestion import ListSuggestionResult, SuggestionFilter
 from annif.util import metric_code
 
 logger = annif.logger

--- a/annif/config.py
+++ b/annif/config.py
@@ -1,14 +1,15 @@
 """Configuration file handling"""
 
 
-import os.path
 import configparser
+import os.path
+from glob import glob
+
 import tomli
+
 import annif
 import annif.util
-from glob import glob
 from annif.exception import ConfigurationException
-
 
 logger = annif.logger
 

--- a/annif/corpus/__init__.py
+++ b/annif/corpus/__init__.py
@@ -1,18 +1,17 @@
 """Annif corpus operations"""
 
 
+from .combine import CombinedCorpus
 from .document import (
     DocumentDirectory,
     DocumentFile,
     DocumentList,
-    TransformingDocumentCorpus,
     LimitingDocumentCorpus,
+    TransformingDocumentCorpus,
 )
-from .subject import Subject, SubjectFileTSV, SubjectFileCSV
-from .subject import SubjectIndex, SubjectSet
 from .skos import SubjectFileSKOS
+from .subject import Subject, SubjectFileCSV, SubjectFileTSV, SubjectIndex, SubjectSet
 from .types import Document
-from .combine import CombinedCorpus
 
 __all__ = [
     "DocumentDirectory",

--- a/annif/corpus/combine.py
+++ b/annif/corpus/combine.py
@@ -1,6 +1,7 @@
 """Class for combining multiple corpora so they behave like a single corpus"""
 
 import itertools
+
 from .types import DocumentCorpus
 
 

--- a/annif/corpus/document.py
+++ b/annif/corpus/document.py
@@ -1,13 +1,15 @@
 """Clases for supporting document corpora"""
 
 import glob
+import gzip
 import os.path
 import re
-import gzip
-import annif.util
 from itertools import islice
-from .types import DocumentCorpus, Document
+
+import annif.util
+
 from .subject import SubjectSet
+from .types import Document, DocumentCorpus
 
 logger = annif.logger
 

--- a/annif/corpus/skos.py
+++ b/annif/corpus/skos.py
@@ -3,11 +3,14 @@
 import collections
 import os.path
 import shutil
+
 import joblib
 import rdflib
 import rdflib.util
-from rdflib.namespace import SKOS, RDF, OWL, RDFS
+from rdflib.namespace import OWL, RDF, RDFS, SKOS
+
 import annif.util
+
 from .types import Subject, SubjectCorpus
 
 

--- a/annif/corpus/subject.py
+++ b/annif/corpus/subject.py
@@ -1,12 +1,15 @@
 """Classes for supporting subject corpora expressed as directories or files"""
 
 import csv
-import numpy as np
-import annif.util
 import os.path
+
+import numpy as np
+
+import annif.util
 from annif import logger
-from .types import Subject, SubjectCorpus
+
 from .skos import serialize_subjects_to_skos
+from .types import Subject, SubjectCorpus
 
 
 class SubjectFileTSV(SubjectCorpus):

--- a/annif/corpus/types.py
+++ b/annif/corpus/types.py
@@ -3,7 +3,6 @@
 import abc
 import collections
 
-
 Document = collections.namedtuple("Document", "text subject_set")
 
 

--- a/annif/eval.py
+++ b/annif/eval.py
@@ -2,10 +2,16 @@
 
 import statistics
 import warnings
+
 import numpy as np
 from scipy.sparse import csr_matrix
-from sklearn.metrics import precision_score, recall_score, f1_score
-from sklearn.metrics import label_ranking_average_precision_score
+from sklearn.metrics import (
+    f1_score,
+    label_ranking_average_precision_score,
+    precision_score,
+    recall_score,
+)
+
 from annif.exception import NotSupportedException
 
 

--- a/annif/lexical/mllm.py
+++ b/annif/lexical/mllm.py
@@ -2,21 +2,25 @@
 
 import collections
 import math
-import joblib
-from statistics import mean
 from enum import IntEnum
+from statistics import mean
+
+import joblib
 import numpy as np
 from rdflib.namespace import SKOS
-from sklearn.feature_extraction.text import CountVectorizer
 from sklearn.ensemble import BaggingClassifier
+from sklearn.feature_extraction.text import CountVectorizer
 from sklearn.tree import DecisionTreeClassifier
-import annif.util
+
 import annif.parallel
+import annif.util
 from annif.exception import OperationFailedException
 from annif.lexical.tokenset import TokenSet, TokenSetIndex
-from annif.lexical.util import get_subject_labels
-from annif.lexical.util import make_relation_matrix, make_collection_matrix
-
+from annif.lexical.util import (
+    get_subject_labels,
+    make_collection_matrix,
+    make_relation_matrix,
+)
 
 Term = collections.namedtuple("Term", "subject_id label is_pref")
 

--- a/annif/lexical/util.py
+++ b/annif/lexical/util.py
@@ -1,9 +1,10 @@
 """Utility methods for lexical algorithms"""
 
 import collections
+
 from rdflib import URIRef
 from rdflib.namespace import SKOS
-from scipy.sparse import lil_matrix, csc_matrix
+from scipy.sparse import csc_matrix, lil_matrix
 
 
 def get_subject_labels(graph, uri, properties, language):

--- a/annif/project.py
+++ b/annif/project.py
@@ -3,18 +3,19 @@
 import enum
 import os.path
 from shutil import rmtree
+
 import annif
-import annif.transform
 import annif.analyzer
+import annif.backend
 import annif.corpus
 import annif.suggestion
-import annif.backend
+import annif.transform
 from annif.datadir import DatadirMixin
 from annif.exception import (
     AnnifException,
     ConfigurationException,
-    NotSupportedException,
     NotInitializedException,
+    NotSupportedException,
 )
 
 logger = annif.logger

--- a/annif/registry.py
+++ b/annif/registry.py
@@ -2,13 +2,15 @@
 
 import collections
 import re
+
 from flask import current_app
+
 import annif
 from annif.config import parse_config
 from annif.exception import ConfigurationException
 from annif.project import Access, AnnifProject
-from annif.vocab import AnnifVocabulary
 from annif.util import parse_args
+from annif.vocab import AnnifVocabulary
 
 logger = annif.logger
 

--- a/annif/rest.py
+++ b/annif/rest.py
@@ -2,11 +2,12 @@
 methods defined in the Swagger specification."""
 
 import connexion
+
 import annif.registry
 from annif.corpus import Document, DocumentList, SubjectSet
-from annif.suggestion import SuggestionFilter
 from annif.exception import AnnifException
 from annif.project import Access
+from annif.suggestion import SuggestionFilter
 
 
 def project_not_found_error(project_id):

--- a/annif/suggestion.py
+++ b/annif/suggestion.py
@@ -3,8 +3,8 @@
 import abc
 import collections
 import itertools
-import numpy as np
 
+import numpy as np
 
 SubjectSuggestion = collections.namedtuple("SubjectSuggestion", "subject_id score")
 WeightedSuggestion = collections.namedtuple(

--- a/annif/transform/__init__.py
+++ b/annif/transform/__init__.py
@@ -1,11 +1,12 @@
 """Functionality for obtaining text transformation from string specification"""
 
 import re
+
 import annif
-from . import transform
-from . import inputlimiter
-from annif.util import parse_args
 from annif.exception import ConfigurationException
+from annif.util import parse_args
+
+from . import inputlimiter, transform
 
 
 def parse_specs(transform_specs):

--- a/annif/transform/inputlimiter.py
+++ b/annif/transform/inputlimiter.py
@@ -2,6 +2,7 @@
 given character length."""
 
 from annif.exception import ConfigurationException
+
 from . import transform
 
 

--- a/annif/transform/langfilter.py
+++ b/annif/transform/langfilter.py
@@ -1,8 +1,10 @@
 """Transformation filtering out parts of a text that are in a language
 different from the language of the project."""
 
-import annif
 import cld3
+
+import annif
+
 from . import transform
 
 logger = annif.logger

--- a/annif/transform/transform.py
+++ b/annif/transform/transform.py
@@ -1,6 +1,7 @@
 """Common functionality for transforming text of input documents."""
 
 import abc
+
 from annif.corpus import TransformingDocumentCorpus
 from annif.exception import ConfigurationException
 

--- a/annif/util.py
+++ b/annif/util.py
@@ -4,7 +4,9 @@ import glob
 import os
 import os.path
 import tempfile
+
 import numpy as np
+
 from annif import logger
 from annif.suggestion import VectorSuggestionResult
 

--- a/annif/vocab.py
+++ b/annif/vocab.py
@@ -1,6 +1,7 @@
 """Vocabulary management functionality for Annif"""
 
 import os.path
+
 import annif
 import annif.corpus
 import annif.util

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,3 +92,8 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.pytest.ini_options]
 addopts = "--flake8"
+
+[tool.isort]
+profile = "black"
+line_length = "88"
+skip_gitignore = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ pytest-flake8 = "*"
 flake8 = "4.*"
 bumpversion = "*"
 black = "*"
+isort = "*"
 
 [tool.poetry.extras]
 fasttext = ["fasttext-wheel"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,9 +2,11 @@
 
 import os.path
 import shutil
-import pytest
-import py.path
 import unittest.mock
+
+import py.path
+import pytest
+
 import annif
 import annif.analyzer
 import annif.corpus

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -1,6 +1,7 @@
 """Unit tests for analyzers in Annif"""
 
 import pytest
+
 import annif.analyzer
 
 

--- a/tests/test_analyzer_simplemma.py
+++ b/tests/test_analyzer_simplemma.py
@@ -1,6 +1,7 @@
 """Unit tests for simplemma analyzer in Annif"""
 
 import pytest
+
 import annif.analyzer
 
 simplemma = pytest.importorskip("annif.analyzer.simplemma")

--- a/tests/test_analyzer_spacy.py
+++ b/tests/test_analyzer_spacy.py
@@ -1,6 +1,7 @@
 """Unit tests for spacy analyzer in Annif"""
 
 import pytest
+
 import annif.analyzer
 from annif.exception import OperationFailedException
 

--- a/tests/test_analyzer_voikko.py
+++ b/tests/test_analyzer_voikko.py
@@ -1,6 +1,7 @@
 """Unit tests for voikko analyzer in Annif"""
 
 import pytest
+
 import annif.analyzer
 
 voikko = pytest.importorskip("annif.analyzer.voikko")

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1,10 +1,12 @@
 """Unit tests for backends in Annif"""
 
+import importlib.util
+
 import pytest
+
 import annif
 import annif.backend
 import annif.corpus
-import importlib.util
 
 
 def test_get_backend_nonexistent():

--- a/tests/test_backend_ensemble.py
+++ b/tests/test_backend_ensemble.py
@@ -1,6 +1,7 @@
 """Unit tests for the ensemble backend in Annif"""
 
 import pytest
+
 import annif.backend
 from annif.exception import NotSupportedException
 

--- a/tests/test_backend_fasttext.py
+++ b/tests/test_backend_fasttext.py
@@ -1,7 +1,9 @@
 """Unit tests for the fastText backend in Annif"""
 
 import logging
+
 import pytest
+
 import annif.backend
 import annif.corpus
 from annif.exception import NotSupportedException

--- a/tests/test_backend_http.py
+++ b/tests/test_backend_http.py
@@ -1,12 +1,14 @@
 """Unit tests for the HTTP backend in Annif"""
 
+import unittest.mock
 from datetime import datetime, timezone
+
 import pytest
 import requests.exceptions
-import unittest.mock
+
 import annif.backend.http
-from annif.exception import OperationFailedException
 from annif.corpus import Subject
+from annif.exception import OperationFailedException
 
 
 def test_http_suggest(app_project):

--- a/tests/test_backend_mllm.py
+++ b/tests/test_backend_mllm.py
@@ -1,10 +1,10 @@
 """Unit tests for the MLLM backend in Annif"""
 
 import pytest
+
 import annif
 import annif.backend
-from annif.exception import NotInitializedException
-from annif.exception import NotSupportedException
+from annif.exception import NotInitializedException, NotSupportedException
 
 
 def test_mllm_default_params(project):

--- a/tests/test_backend_nn_ensemble.py
+++ b/tests/test_backend_nn_ensemble.py
@@ -1,9 +1,11 @@
 """Unit tests for the nn_ensemble backend in Annif"""
 
 import time
-import pytest
-import py.path
 from datetime import datetime, timedelta, timezone
+
+import py.path
+import pytest
+
 import annif.backend
 import annif.corpus
 from annif.exception import NotInitializedException, NotSupportedException

--- a/tests/test_backend_omikuji.py
+++ b/tests/test_backend_omikuji.py
@@ -1,10 +1,10 @@
 """Unit tests for the Omikuji backend in Annif"""
 
 import pytest
+
 import annif.backend
 import annif.corpus
-from annif.exception import NotInitializedException
-from annif.exception import NotSupportedException
+from annif.exception import NotInitializedException, NotSupportedException
 
 pytest.importorskip("annif.backend.omikuji")
 

--- a/tests/test_backend_pav.py
+++ b/tests/test_backend_pav.py
@@ -1,9 +1,11 @@
 """Unit tests for the PAV backend in Annif"""
 
 import logging
+from datetime import datetime, timedelta, timezone
+
 import py.path
 import pytest
-from datetime import datetime, timedelta, timezone
+
 import annif.backend
 import annif.corpus
 from annif.exception import NotSupportedException

--- a/tests/test_backend_stwfsa.py
+++ b/tests/test_backend_stwfsa.py
@@ -1,9 +1,9 @@
-from annif.backend import get_backend
-import annif.corpus
-from annif.backend.stwfsa import StwfsaBackend
-from annif.exception import NotInitializedException, NotSupportedException
 import pytest
 
+import annif.corpus
+from annif.backend import get_backend
+from annif.backend.stwfsa import StwfsaBackend
+from annif.exception import NotInitializedException, NotSupportedException
 
 _backend_conf = {
     "language": "fi",

--- a/tests/test_backend_svc.py
+++ b/tests/test_backend_svc.py
@@ -1,10 +1,10 @@
 """Unit tests for the SVC backend in Annif"""
 
 import pytest
+
 import annif.backend
 import annif.corpus
-from annif.exception import NotInitializedException
-from annif.exception import NotSupportedException
+from annif.exception import NotInitializedException, NotSupportedException
 
 
 def test_svc_default_params(project):

--- a/tests/test_backend_yake.py
+++ b/tests/test_backend_yake.py
@@ -1,8 +1,9 @@
 """Unit tests for the Yake backend in Annif"""
 
+import pytest
+
 import annif
 import annif.backend
-import pytest
 from annif.exception import ConfigurationException, NotSupportedException
 
 pytest.importorskip("annif.backend.yake")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,13 +1,15 @@
 """Unit test module for Annif CLI commands"""
 
 import contextlib
-import random
-import re
-import os.path
-import shutil
 import importlib
 import json
+import os.path
+import random
+import re
+import shutil
+
 from click.testing import CliRunner
+
 import annif.cli
 
 runner = CliRunner(env={"ANNIF_CONFIG": "annif.default_config.TestingConfig"})

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,7 +1,9 @@
 """Unit tests for configuration handling in Annif"""
 
 import logging
+
 import pytest
+
 import annif.config
 from annif.exception import ConfigurationException
 

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -1,8 +1,10 @@
 """Unit tests for corpus functionality in Annif"""
 
 import gzip
+
 import numpy as np
 import pytest
+
 import annif.corpus
 from annif.corpus import TransformingDocumentCorpus
 

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -1,6 +1,7 @@
 """Unit tests for evaluation metrics in Annif"""
 
 import numpy as np
+
 import annif.corpus
 import annif.eval
 import annif.suggestion

--- a/tests/test_exception.py
+++ b/tests/test_exception.py
@@ -1,8 +1,9 @@
 """Unit tests for Annif exception classes"""
 
 import pytest
-from annif.exception import AnnifException
 from click import ClickException
+
+from annif.exception import AnnifException
 
 
 def test_annifexception_not_instantiable():

--- a/tests/test_lexical_mllm.py
+++ b/tests/test_lexical_mllm.py
@@ -2,8 +2,9 @@
 
 import numpy as np
 import pytest
-from annif.lexical.mllm import MLLMModel
+
 from annif.exception import OperationFailedException
+from annif.lexical.mllm import MLLMModel
 
 
 def test_mllmmodel_prepare_terms(vocabulary):

--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -2,6 +2,7 @@
 
 import multiprocessing
 import multiprocessing.dummy
+
 import annif.parallel
 
 

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1,10 +1,12 @@
 """Unit tests for projects in Annif"""
 
 import logging
-import pytest
 from datetime import datetime, timedelta, timezone
-import annif.project
+
+import pytest
+
 import annif.backend.dummy
+import annif.project
 from annif.exception import ConfigurationException, NotSupportedException
 from annif.project import Access
 

--- a/tests/test_suggestion.py
+++ b/tests/test_suggestion.py
@@ -1,15 +1,16 @@
 """Unit tests for suggestion processing in Annif"""
 
+import numpy as np
+
+from annif.corpus import Subject
 from annif.suggestion import (
-    SubjectSuggestion,
-    SuggestionResult,
     LazySuggestionResult,
     ListSuggestionResult,
-    VectorSuggestionResult,
+    SubjectSuggestion,
     SuggestionFilter,
+    SuggestionResult,
+    VectorSuggestionResult,
 )
-from annif.corpus import Subject
-import numpy as np
 
 
 def generate_suggestions(n, subject_index):

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -1,6 +1,7 @@
 """Unit tests for the input-transforms in Annif"""
 
 import pytest
+
 import annif.transform
 from annif.exception import ConfigurationException
 from annif.transform import parse_specs

--- a/tests/test_transform_langfilter.py
+++ b/tests/test_transform_langfilter.py
@@ -1,6 +1,7 @@
 """Unit tests for the language-filter transform in Annif"""
 
 import pytest
+
 import annif.transform
 
 pytest.importorskip("annif.transform.langfilter")

--- a/tests/test_vocab.py
+++ b/tests/test_vocab.py
@@ -1,11 +1,13 @@
 """Unit tests for vocabulary functionality in Annif"""
 
-import pytest
 import os
+
+import pytest
+import rdflib.namespace
+
 import annif.corpus
 import annif.vocab
 from annif.exception import NotInitializedException
-import rdflib.namespace
 
 
 def load_dummy_vocab(tmpdir):


### PR DESCRIPTION
PR #640 introduced Black style and tool for checking and autoformatting code. However, Black does not care about the order of import statements, but [isort](https://github.com/PyCQA/isort) does. Using isort a developer does not need worry about the order of imports.

This PR contains similar changes as the one for Black.

## Manual local usage
Just run this to sort imports:
```
isort .
```
## Automated local usage
isort can check the import order automatically when committing by adding this line to `.git/hooks/pre-commit`:
```
isort . --check-only --diff
```
## CI usage
isort check is added to the linting job in GH Actions.