### PR TITLE
Use tailored user-agent in requests by HTTP-backend

### DIFF
--- a/annif/backend/http.py
+++ b/annif/backend/http.py
@@ -2,6 +2,8 @@
 and returns the results"""
 
 
+import importlib
+
 import dateutil.parser
 import requests
 import requests.exceptions
@@ -14,6 +16,13 @@ from . import backend
 
 class HTTPBackend(backend.AnnifBackend):
     name = "http"
+
+    @property
+    def _headers(self):
+        version = importlib.metadata.version("annif")
+        return {
+            "User-Agent": f"Annif/{version}",
+        }
 
     @property
     def is_trained(self):
@@ -29,7 +38,9 @@ class HTTPBackend(backend.AnnifBackend):
     def _get_project_info(self, key):
         params = self._get_backend_params(None)
         try:
-            req = requests.get(params["endpoint"].replace("/suggest", ""))
+            req = requests.get(
+                params["endpoint"].replace("/suggest", ""), headers=self._headers
+            )
             req.raise_for_status()
         except requests.exceptions.RequestException as err:
             msg = f"HTTP request failed: {err}"
@@ -51,7 +62,7 @@ class HTTPBackend(backend.AnnifBackend):
             data["project"] = params["project"]
 
         try:
-            req = requests.post(params["endpoint"], data=data)
+            req = requests.post(params["endpoint"], data=data, headers=self._headers)
             req.raise_for_status()
         except requests.exceptions.RequestException as err:
             self.warning("HTTP request failed: {}".format(err))

--- a/annif/backend/http.py
+++ b/annif/backend/http.py
@@ -16,13 +16,16 @@ from . import backend
 
 class HTTPBackend(backend.AnnifBackend):
     name = "http"
+    _headers = None
 
     @property
-    def _headers(self):
-        version = importlib.metadata.version("annif")
-        return {
-            "User-Agent": f"Annif/{version}",
-        }
+    def headers(self):
+        if self._headers is None:
+            version = importlib.metadata.version("annif")
+            self._headers = {
+                "User-Agent": f"Annif/{version}",
+            }
+        return self._headers
 
     @property
     def is_trained(self):
@@ -39,7 +42,7 @@ class HTTPBackend(backend.AnnifBackend):
         params = self._get_backend_params(None)
         try:
             req = requests.get(
-                params["endpoint"].replace("/suggest", ""), headers=self._headers
+                params["endpoint"].replace("/suggest", ""), headers=self.headers
             )
             req.raise_for_status()
         except requests.exceptions.RequestException as err:
@@ -62,7 +65,7 @@ class HTTPBackend(backend.AnnifBackend):
             data["project"] = params["project"]
 
         try:
-            req = requests.post(params["endpoint"], data=data, headers=self._headers)
+            req = requests.post(params["endpoint"], data=data, headers=self.headers)
             req.raise_for_status()
         except requests.exceptions.RequestException as err:
             self.warning("HTTP request failed: {}".format(err))

--- a/tests/test_backend_http.py
+++ b/tests/test_backend_http.py
@@ -1,5 +1,6 @@
 """Unit tests for the HTTP backend in Annif"""
 
+import importlib
 import unittest.mock
 from datetime import datetime, timezone
 
@@ -263,3 +264,22 @@ def test_http_get_project_info_json_decode_error(project):
         )
         with pytest.raises(OperationFailedException):
             http._get_project_info("is_trained")
+
+
+def test_headers(project):
+    with unittest.mock.patch("requests.post"):
+        http_type = annif.backend.get_backend("http")
+        http = http_type(
+            backend_id="http",
+            config_params={
+                "endpoint": "http://api.example.org/suggest",
+                "project": "dummy",
+            },
+            project=project,
+        )
+        http.suggest("this is some text")
+
+        version = importlib.metadata.version("annif")
+        assert requests.post.call_args.kwargs["headers"] == {
+            "User-Agent": f"Annif/{version}"
+        }


### PR DESCRIPTION
The http-backend uses requests library, and so the headers have now user-agent `python-requests/2.28.1`, which is shown e.g. in logs of the targeted server.

It is better to use a user-agent tailored for Annif. This PR changes the user-agent that http-backend sends in request headers to `Annif/<version>`, e.g. currently to `Annif/0.60.0.dev0`.