### PR TITLE
Upgrade TensorFlow to version 2.11.*

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ simplemma = "0.9.*"
 
 fasttext-wheel = {version = "0.9.2", optional = true}
 voikko = {version = "*", optional = true}
-tensorflow-cpu = {version = "2.9.1", optional = true}
+tensorflow-cpu = {version = "2.11.*", optional = true}
 lmdb = {version = "1.3.0", optional = true}
 omikuji = {version = "0.5.*", optional = true}
 yake = {version = "0.4.5", optional = true}


### PR DESCRIPTION
We are currently using TensorFlow 2.9.1, which has reported vulnerabilities. Also dependabot is complaining about them.
It would be trivial to upgrade to 2.9.3, where those issues have been fixed.

But instead, I tested upgrading directly to 2.11.0. Everything seems to work fine with this new version. I also tested a small model that was trained on 2.9.1, before the upgrade, and it worked perfectly well.

I pinned this as `2.11.*` so that upgrading to patch releases is allowed in the future.