### PR TITLE
Add project info to web UI

### DIFF
--- a/annif/static/css/style.css
+++ b/annif/static/css/style.css
@@ -61,6 +61,7 @@ select {
 #limit-buttons label {
   border-radius: 50%;
   margin-right: 0.4rem;
+  margin-bottom: 1rem;
   width: 2rem;
   height: 2rem;
   display: inline-flex;

--- a/annif/static/css/style.css
+++ b/annif/static/css/style.css
@@ -39,8 +39,10 @@ label, #suggestions {
   font-size: 1.1rem;
   display: block;
 }
+#project-selection-wrapper {
+  margin-bottom: 1rem;
+}
 .form-control { border-radius: 0px; }
-.form-group { margin-bottom: 1rem; }
 select {
   -moz-appearance: none;
   -webkit-appearance: none;
@@ -74,11 +76,12 @@ select {
   color: white;
 }
 #show-project-info {
-  background-color: #6280dc;
-  color: white;
+  background: none;
+  color: #343260;
+  font-size: 1.1rem;
   border: none;
-  border-radius: 0px;
-  margin-bottom: 1rem;
+  padding-top: 0.5rem;
+  padding-bottom: 0;
 }
 #show-project-info.collapsed .if-not-collapsed {
   display: none;
@@ -87,15 +90,9 @@ select {
   display: none;
 }
 #project-info {
-  border-radius: 0px;
-  margin-bottom: 1rem;
-}
-#project-info span {
   font-size: 1.1rem;
-}
-#project-name {
-  margin-bottom: 0.5rem;
-  font-size: 1.2rem;
+  margin-top: 0.5rem;
+  margin-left: 1.75rem;
 }
 #get-suggestions {
   margin: 2rem 0;

--- a/annif/static/css/style.css
+++ b/annif/static/css/style.css
@@ -73,6 +73,30 @@ select {
   background-color: #6280dc;
   color: white;
 }
+#show-project-info {
+  background-color: #6280dc;
+  color: white;
+  border: none;
+  border-radius: 0px;
+  margin-bottom: 1rem;
+}
+#show-project-info.collapsed .if-not-collapsed {
+  display: none;
+}
+#show-project-info:not(.collapsed) .if-collapsed {
+  display: none;
+}
+#project-info {
+  border-radius: 0px;
+  margin-bottom: 1rem;
+}
+#project-info span {
+  font-size: 1.1rem;
+}
+#project-name {
+  margin-bottom: 0.5rem;
+  font-size: 1.2rem;
+}
 #get-suggestions {
   margin: 2rem 0;
   background-color: #6280dc;

--- a/annif/static/css/style.css
+++ b/annif/static/css/style.css
@@ -83,6 +83,7 @@ select {
   border: none;
   padding-top: 0.5rem;
   padding-bottom: 0;
+  padding-left: 0;
 }
 #show-project-info.collapsed .if-not-collapsed {
   display: none;
@@ -90,10 +91,14 @@ select {
 #show-project-info:not(.collapsed) .if-collapsed {
   display: none;
 }
+#show-project-info span span {
+  display: inline-block;
+  width: 1.25rem;
+}
 #project-info {
   font-size: 1.1rem;
   margin-top: 0.5rem;
-  margin-left: 1.75rem;
+  margin-left: 1.25rem;
 }
 #get-suggestions {
   margin: 2rem 0;

--- a/annif/templates/home.html
+++ b/annif/templates/home.html
@@ -172,8 +172,8 @@ Vue.component('annif-project-info', {
   },
   template: '<div v-if="projects.length > 0">\
   <button id="show-project-info" class="btn btn-primary collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapse-info" aria-expanded="false" aria-controls="collapse-info">\
-    <span class="if-collapsed"><strong>▸ Project information<strong></span>\
-    <span class="if-not-collapsed"><strong>▾ Project information<strong></span>\
+    <span class="if-collapsed"><span>▸</span>Project information</span>\
+    <span class="if-not-collapsed"><span>▾</span>Project information</span>\
   </button>\
   <div id="collapse-info" class="collapse">\
     <div id="project-info">\

--- a/annif/templates/home.html
+++ b/annif/templates/home.html
@@ -53,8 +53,10 @@
           <annif-textarea @text-changed="onTextChanged" @text-cleared="onTextCleared"></annif-textarea>
         </div>
         <div class="col-md-4">
-          <annif-projects :projects="projects" @project-selected="onProjectSelected"></annif-projects>
-          <annif-project-info :projects="projects" :project="project"></annif-project-info>
+          <div id="project-selection-wrapper">
+            <annif-projects :projects="projects" @project-selected="onProjectSelected"></annif-projects>
+            <annif-project-info :projects="projects" :project="project"></annif-project-info>
+          </div>
           <annif-limit :limit="limit" @limit-selected="onLimitSelected"></annif-limit>
           <button id="get-suggestions" type="button" class="btn btn-primary" @click="suggest" :disabled="loading">
             <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true" v-if="loading"></span>
@@ -149,6 +151,7 @@ Vue.component('annif-projects', {
 </div>'
 });
 
+// Component with project information
 Vue.component('annif-project-info', {
   delimiters: ['<%','%>'],
   props: ['projects', 'project'],
@@ -168,16 +171,15 @@ Vue.component('annif-project-info', {
   },
   template: '<div v-if="projects.length > 0">\
   <button id="show-project-info" class="btn btn-primary collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapse-info" aria-expanded="false" aria-controls="collapse-info">\
-    <span class="if-collapsed">Show project info</span>\
-    <span class="if-not-collapsed">Hide project info</span>\
+    <span class="if-collapsed"><strong>▸ Project information<strong></span>\
+    <span class="if-not-collapsed"><strong>▾ Project information<strong></span>\
   </button>\
   <div id="collapse-info" class="collapse">\
-    <div id="project-info" class="card card-body">\
-      <span id="project-name"><strong><% getSelectedProject().name %></strong></span>\
-      <span>Project ID: <% getSelectedProject().project_id %></span>\
-      <span>Language: <% getSelectedProject().language %></span>\
-      <span>Backend type: <% getSelectedProject().backend.backend_id %></span>\
-      <span>Trained: <% getSelectedProject().is_trained ? "Yes" : "No" %></span>\
+    <div id="project-info">\
+      <span>Project ID: <% getSelectedProject().project_id %></span><br>\
+      <span>Language: <% getSelectedProject().language %></span><br>\
+      <span>Backend type: <% getSelectedProject().backend.backend_id %></span><br>\
+      <span>Trained: <% getSelectedProject().is_trained ? "Yes" : "No" %></span><br>\
       <span>Last modified: <% getDateString(getSelectedProject().modification_time) %></span>\
     </div>\
   </div>\

--- a/annif/templates/home.html
+++ b/annif/templates/home.html
@@ -162,9 +162,10 @@ Vue.component('annif-project-info', {
     },
     getDateString: function(d) {
       // Returns modification time in the format 'yyyy-mm-dd hh:mm:ss UTC'
+      console.log(d)
       date = new Date(d);
       return (
-        [ date.getUTCFullYear(), ('0' + date.getUTCMonth()).slice(-2), ('0' + date.getUTCDate()).slice(-2) ].join('-') + ' ' +
+        [ date.getUTCFullYear(), ('0' + (date.getUTCMonth() + 1)).slice(-2), ('0' + date.getUTCDate()).slice(-2) ].join('-') + ' ' +
         [ ('0' + date.getUTCHours()).slice(-2), ('0' + date.getUTCMinutes()).slice(-2), ('0' + date.getUTCSeconds()).slice(-2) ].join(':') + ' UTC'
       );
     }

--- a/annif/templates/home.html
+++ b/annif/templates/home.html
@@ -54,6 +54,7 @@
         </div>
         <div class="col-md-4">
           <annif-projects :projects="projects" @project-selected="onProjectSelected"></annif-projects>
+          <annif-project-info :projects="projects" :project="project"></annif-project-info>
           <annif-limit :limit="limit" @limit-selected="onLimitSelected"></annif-limit>
           <button id="get-suggestions" type="button" class="btn btn-primary" @click="suggest" :disabled="loading">
             <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true" v-if="loading"></span>
@@ -143,6 +144,41 @@ Vue.component('annif-projects', {
     <select class="form-control" id="project" @input="handleProjectSelected">\
       <option v-for="project in projects" v-bind:value="project.project_id"><% project.name %></option>\
     </select>\
+    </div>\
+  </div>\
+</div>'
+});
+
+Vue.component('annif-project-info', {
+  delimiters: ['<%','%>'],
+  props: ['projects', 'project'],
+  methods: {
+    getSelectedProject: function() {
+      // Returns the selected project as an object
+      return this.projects.find(p => {return p.project_id===this.project})
+    },
+    getDateString: function(d) {
+      // Returns modification time in the format 'yyyy-mm-dd hh:mm:ss UTC'
+      date = new Date(d);
+      return (
+        [ date.getUTCFullYear(), ('0' + date.getUTCMonth()).slice(-2), ('0' + date.getUTCDate()).slice(-2) ].join('-') + ' ' +
+        [ ('0' + date.getUTCHours()).slice(-2), ('0' + date.getUTCMinutes()).slice(-2), ('0' + date.getUTCSeconds()).slice(-2) ].join(':') + ' UTC'
+      );
+    }
+  },
+  template: '<div v-if="projects.length > 0">\
+  <button id="show-project-info" class="btn btn-primary collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapse-info" aria-expanded="false" aria-controls="collapse-info">\
+    <span class="if-collapsed">Show project info</span>\
+    <span class="if-not-collapsed">Hide project info</span>\
+  </button>\
+  <div id="collapse-info" class="collapse">\
+    <div id="project-info" class="card card-body">\
+      <span id="project-name"><strong><% getSelectedProject().name %></strong></span>\
+      <span>Project ID: <% getSelectedProject().project_id %></span>\
+      <span>Language: <% getSelectedProject().language %></span>\
+      <span>Backend type: <% getSelectedProject().backend.backend_id %></span>\
+      <span>Trained: <% getSelectedProject().is_trained ? "Yes" : "No" %></span>\
+      <span>Last modified: <% getDateString(getSelectedProject().modification_time) %></span>\
     </div>\
   </div>\
 </div>'

--- a/annif/templates/home.html
+++ b/annif/templates/home.html
@@ -162,7 +162,6 @@ Vue.component('annif-project-info', {
     },
     getDateString: function(d) {
       // Returns modification time in the format 'yyyy-mm-dd hh:mm:ss UTC'
-      console.log(d)
       date = new Date(d);
       return (
         [ date.getUTCFullYear(), ('0' + (date.getUTCMonth() + 1)).slice(-2), ('0' + date.getUTCDate()).slice(-2) ].join('-') + ' ' +


### PR DESCRIPTION
This PR adds information about a selected project to the web UI.

A button is added under the project selection:
![Screenshot 2022-12-08 at 11-43-39 Annif](https://user-images.githubusercontent.com/45235116/206415341-05170f62-7948-41cf-8a82-db65a95ef4ba.png)

This opens a box with the information on the project:
![Screenshot 2022-12-08 at 11-43-48 Annif](https://user-images.githubusercontent.com/45235116/206415532-ff3f2efd-1bb3-4c82-90f3-25fde46600fc.png)

IMO a version with the info in a popup next to the project selection would look cleaner but I'm not sure how to implement it yet. 