### PR TITLE
Install linting tools with Poetry in CI/CD pipeline

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -35,13 +35,13 @@ jobs:
         poetry install --only dev
     - name: Lint with isort
       run: |
-        isort . --check-only --diff
+        poetry run isort . --check-only --diff
     - name: Lint with Black
       run: |
-        black . --check --diff
+        poetry run black . --check --diff
     - name: Lint with flake8
       run: |
-        flake8
+        poetry run flake8
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -16,6 +16,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     name: lint with isort, Black & flake8
+    env:
+      PYTHON_VERSION: "3.10"
     steps:
 
     - uses: actions/checkout@v3
@@ -26,11 +28,17 @@ jobs:
           ~/.cache/pipx/venvs
           ~/.local/bin
           ~/.cache/pypoetry/cache/repositories
-        key: poetry-installation-and-repos-3.10-${{ env.POETRY_VERSION }}  # Fixed Python version
+        key: poetry-installation-and-repos-${{ env.PYTHON_VERSION }}-${{ env.POETRY_VERSION }}
     - name: Install Poetry
       run: |
         pipx install poetry==$POETRY_VERSION
-    - name: Install dev dependencies
+    - name: Set up Python ${{ env.python-version }}
+      uses: actions/setup-python@b55428b1882923874294fa556849718a1d7f2ca5  # v4.2.0
+      with:
+        python-version: ${{ env.PYTHON_VERSION }}
+        cache: 'poetry'
+        cache-dependency-path: 'pyproject.toml'
+    - name: Install Python dev dependencies
       run: |
         poetry install --only dev
     - name: Lint with isort

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -17,13 +17,31 @@ jobs:
     runs-on: ubuntu-latest
     name: lint with isort, Black & flake8
     steps:
-      - uses: actions/checkout@v3
-      - uses: isort/isort-action@f14e57e1d457956c45a19c05a89cccdf087846e5  # v1.1.0
-      - uses: psf/black@6b42c2b8c9f9bd666120a2c19b8da509fe477f27
-      - name: Lint with flake8
-        run: |
-          pip install flake8
-          flake8
+
+    - uses: actions/checkout@v3
+    - name: Load cached Poetry installation and repositories info
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cache/pipx/venvs
+          ~/.local/bin
+          ~/.cache/pypoetry/cache/repositories
+        key: poetry-installation-and-repos-3.10-${{ env.POETRY_VERSION }}  # Fixed Python version
+    - name: Install Poetry
+      run: |
+        pipx install poetry==$POETRY_VERSION
+    - name: Install dev dependencies
+      run: |
+        poetry install --only dev
+    - name: Lint with isort
+      run: |
+        isort . --check-only --diff
+    - name: Lint with Black
+      run: |
+        black . --check --diff
+    - name: Lint with flake8
+      run: |
+        flake8
 
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
As discussed in #650, this PR switches installing isort and Black from PyPI with Poetry (instead of using the GH Actions) and flake8 with Poetry, so now the versions of these tools are the same in CI/CD and in local installations (maybe depending on the Python versions in the environments; in CI/CD linting job I chose to use Python 3.10). Also this approach might be a little more secure way to install the tools as it does not rely on the GH Actions.

Downside is longer and more complex definition.