### PR TITLE
Upgrade setup-python action to v4.4.0

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -33,7 +33,7 @@ jobs:
       run: |
         pipx install poetry==$POETRY_VERSION
     - name: Set up Python ${{ env.python-version }}
-      uses: actions/setup-python@2c3dd9e7e29afd70cc0950079bde6c979d1f69f9  # v4.3.1
+      uses: actions/setup-python@5ccb29d8773c3f3f653e1705f474dfaa8a06a912  # v4.4.0
       with:
         python-version: ${{ env.PYTHON_VERSION }}
         cache: 'poetry'
@@ -79,7 +79,7 @@ jobs:
       run: |
         pipx install poetry==$POETRY_VERSION
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@2c3dd9e7e29afd70cc0950079bde6c979d1f69f9  # v4.3.1
+      uses: actions/setup-python@5ccb29d8773c3f3f653e1705f474dfaa8a06a912  # v4.4.0
       with:
         python-version: ${{ matrix.python-version }}
         cache: 'poetry'
@@ -155,7 +155,7 @@ jobs:
       run: |
         pipx install poetry==$POETRY_VERSION
     - name: Set up Python 3.9
-      uses: actions/setup-python@2c3dd9e7e29afd70cc0950079bde6c979d1f69f9  # v4.3.1
+      uses: actions/setup-python@5ccb29d8773c3f3f653e1705f474dfaa8a06a912  # v4.4.0
       with:
         python-version: '3.9'
         cache: 'poetry'

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -33,7 +33,7 @@ jobs:
       run: |
         pipx install poetry==$POETRY_VERSION
     - name: Set up Python ${{ env.python-version }}
-      uses: actions/setup-python@b55428b1882923874294fa556849718a1d7f2ca5  # v4.2.0
+      uses: actions/setup-python@2c3dd9e7e29afd70cc0950079bde6c979d1f69f9  # v4.3.1
       with:
         python-version: ${{ env.PYTHON_VERSION }}
         cache: 'poetry'
@@ -79,7 +79,7 @@ jobs:
       run: |
         pipx install poetry==$POETRY_VERSION
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@b55428b1882923874294fa556849718a1d7f2ca5  # v4.2.0
+      uses: actions/setup-python@2c3dd9e7e29afd70cc0950079bde6c979d1f69f9  # v4.3.1
       with:
         python-version: ${{ matrix.python-version }}
         cache: 'poetry'
@@ -155,7 +155,7 @@ jobs:
       run: |
         pipx install poetry==$POETRY_VERSION
     - name: Set up Python 3.9
-      uses: actions/setup-python@b55428b1882923874294fa556849718a1d7f2ca5  # v4.2.0
+      uses: actions/setup-python@2c3dd9e7e29afd70cc0950079bde6c979d1f69f9  # v4.3.1
       with:
         python-version: '3.9'
         cache: 'poetry'

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -35,13 +35,13 @@ jobs:
         poetry install --only dev
     - name: Lint with isort
       run: |
-        isort . --check-only --diff
+        poetry run isort . --check-only --diff
     - name: Lint with Black
       run: |
-        black . --check --diff
+        poetry run black . --check --diff
     - name: Lint with flake8
       run: |
-        flake8
+        poetry run flake8
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -16,6 +16,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     name: lint with isort, Black & flake8
+    env:
+      PYTHON_VERSION: "3.10"
     steps:
 
     - uses: actions/checkout@v3
@@ -26,11 +28,17 @@ jobs:
           ~/.cache/pipx/venvs
           ~/.local/bin
           ~/.cache/pypoetry/cache/repositories
-        key: poetry-installation-and-repos-3.10-${{ env.POETRY_VERSION }}  # Fixed Python version
+        key: poetry-installation-and-repos-${{ env.PYTHON_VERSION }}-${{ env.POETRY_VERSION }}
     - name: Install Poetry
       run: |
         pipx install poetry==$POETRY_VERSION
-    - name: Install dev dependencies
+    - name: Set up Python ${{ env.python-version }}
+      uses: actions/setup-python@b55428b1882923874294fa556849718a1d7f2ca5  # v4.2.0
+      with:
+        python-version: ${{ env.PYTHON_VERSION }}
+        cache: 'poetry'
+        cache-dependency-path: 'pyproject.toml'
+    - name: Install Python dev dependencies
       run: |
         poetry install --only dev
     - name: Lint with isort

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -17,13 +17,31 @@ jobs:
     runs-on: ubuntu-latest
     name: lint with isort, Black & flake8
     steps:
-      - uses: actions/checkout@v3
-      - uses: isort/isort-action@f14e57e1d457956c45a19c05a89cccdf087846e5  # v1.1.0
-      - uses: psf/black@6b42c2b8c9f9bd666120a2c19b8da509fe477f27
-      - name: Lint with flake8
-        run: |
-          pip install flake8
-          flake8
+
+    - uses: actions/checkout@v3
+    - name: Load cached Poetry installation and repositories info
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cache/pipx/venvs
+          ~/.local/bin
+          ~/.cache/pypoetry/cache/repositories
+        key: poetry-installation-and-repos-3.10-${{ env.POETRY_VERSION }}  # Fixed Python version
+    - name: Install Poetry
+      run: |
+        pipx install poetry==$POETRY_VERSION
+    - name: Install dev dependencies
+      run: |
+        poetry install --only dev
+    - name: Lint with isort
+      run: |
+        isort . --check-only --diff
+    - name: Lint with Black
+      run: |
+        black . --check --diff
+    - name: Lint with flake8
+      run: |
+        flake8
 
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
I noticed the following warnings in the CI/CD pipeline:
```
The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```
They are given by the [setup-python Action](https://github.com/marketplace/actions/setup-python), and updating it should make the warnings go away.

I leave this as a draft for now, as this branch is based on the branch for #656, which should be merged first.