### PR TITLE
Add REST API root resource

### DIFF
--- a/annif/openapi/annif.yaml
+++ b/annif/openapi/annif.yaml
@@ -5,6 +5,19 @@ info:
 servers:
 - url: /v1
 paths:
+  /:
+    get:
+      tags:
+      - API information
+      summary: get basic information about the API service
+      operationId: annif.rest.show_info
+      responses:
+        200:
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiInfo'
   /projects:
     get:
       tags:
@@ -136,6 +149,19 @@ paths:
       x-codegen-request-body-name: documents
 components:
   schemas:
+    ApiInfo:
+      required:
+      - title
+      - version
+      type: object
+      properties:
+        title:
+          type: string
+          example: Annif REST API
+        version:
+          type: string
+          example: 0.60.0
+      description: REST API information
     ProjectBackend:
       required:
       - backend_id

--- a/annif/rest.py
+++ b/annif/rest.py
@@ -34,10 +34,7 @@ def server_error(err):
 def show_info():
     """return version of annif and a title for the api according to Swager spec"""
 
-    return {
-        "title": "Annif REST API",
-        "version": importlib.metadata.version("annif")
-    }
+    return {"title": "Annif REST API", "version": importlib.metadata.version("annif")}
 
 
 def list_projects():

--- a/annif/rest.py
+++ b/annif/rest.py
@@ -32,7 +32,7 @@ def server_error(err):
 
 
 def show_info():
-    """return version of annif and a title for the api according to Swager spec"""
+    """return version of annif and a title for the api according to Swagger spec"""
 
     return {"title": "Annif REST API", "version": importlib.metadata.version("annif")}
 

--- a/annif/rest.py
+++ b/annif/rest.py
@@ -1,9 +1,9 @@
 """Definitions for REST API operations. These are wired via Connexion to
 methods defined in the Swagger specification."""
 
-import connexion
-
 import importlib
+
+import connexion
 
 import annif.registry
 from annif.corpus import Document, DocumentList, SubjectSet

--- a/annif/rest.py
+++ b/annif/rest.py
@@ -3,6 +3,8 @@ methods defined in the Swagger specification."""
 
 import connexion
 
+import importlib
+
 import annif.registry
 from annif.corpus import Document, DocumentList, SubjectSet
 from annif.exception import AnnifException
@@ -27,6 +29,15 @@ def server_error(err):
     return connexion.problem(
         status=503, title="Service unavailable", detail=err.format_message()
     )
+
+
+def show_info():
+    """return version of annif and a title for the api according to Swager spec"""
+
+    return {
+        "title": "Annif REST API",
+        "version": importlib.metadata.version("annif")
+    }
 
 
 def list_projects():

--- a/tests/test_rest.py
+++ b/tests/test_rest.py
@@ -1,5 +1,7 @@
 """Unit tests for REST API backend code in Annif"""
 
+import importlib
+
 import annif.rest
 
 
@@ -15,6 +17,13 @@ def test_rest_list_projects(app):
         assert "dummy-private" not in project_ids
         # project with no access level setting should be returned
         assert "ensemble" in project_ids
+
+
+def test_rest_show_info(app):
+    with app.app_context():
+        result = annif.rest.show_info()
+        version = importlib.metadata.version("annif")
+        assert result == {"title": "Annif REST API", "version": version}
 
 
 def test_rest_show_project_public(app):


### PR DESCRIPTION
This PR adds a resource to the root of the REST API (i.e. http://<annif_host>/v1/) that gives basic information on the API. The information given is a title for the API and the version of Annif being used. The response is a json object with the format:
```json
{
    "title": "Annif REST API",
    "version": "0.60.0"
}
```

Implements #655 