### PR TITLE
Add language detection to REST API

### DIFF
--- a/annif/analyzer/simplemma.py
+++ b/annif/analyzer/simplemma.py
@@ -2,9 +2,7 @@
 
 from __future__ import annotations
 
-import simplemma
-
-import annif.langsupport
+import annif.simplemma_util
 
 from . import analyzer
 
@@ -14,10 +12,7 @@ class SimplemmaAnalyzer(analyzer.Analyzer):
 
     def __init__(self, param: str, **kwargs) -> None:
         self.lang = param
-        self.lemmatizer = simplemma.Lemmatizer(
-            lemmatization_strategy=annif.langsupport.lemmatization_strategy
-        )
         super().__init__(**kwargs)
 
     def _normalize_word(self, word: str) -> str:
-        return self.lemmatizer.lemmatize(word, lang=self.lang)
+        return annif.simplemma_util.lemmatizer.lemmatize(word, lang=self.lang)

--- a/annif/analyzer/simplemma.py
+++ b/annif/analyzer/simplemma.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import simplemma
 
+import annif.langsupport
+
 from . import analyzer
 
 
@@ -12,7 +14,10 @@ class SimplemmaAnalyzer(analyzer.Analyzer):
 
     def __init__(self, param: str, **kwargs) -> None:
         self.lang = param
+        self.lemmatizer = simplemma.Lemmatizer(
+            lemmatization_strategy=annif.langsupport.lemmatization_strategy
+        )
         super().__init__(**kwargs)
 
     def _normalize_word(self, word: str) -> str:
-        return simplemma.lemmatize(word, lang=self.lang)
+        return self.lemmatizer.lemmatize(word, lang=self.lang)

--- a/annif/langsupport.py
+++ b/annif/langsupport.py
@@ -1,9 +1,0 @@
-"""Language support and language detection functionality for Annif"""
-
-from simplemma.strategies import DefaultStrategy
-from simplemma.strategies.dictionaries import DefaultDictionaryFactory
-
-LANG_CACHE_SIZE = 5  # How many language dictionaries to keep in memory at once (max)
-
-dictionary_factory = DefaultDictionaryFactory(cache_max_size=LANG_CACHE_SIZE)
-lemmatization_strategy = DefaultStrategy(dictionary_factory=dictionary_factory)

--- a/annif/langsupport.py
+++ b/annif/langsupport.py
@@ -1,0 +1,9 @@
+"""Language support and language detection functionality for Annif"""
+
+from simplemma.strategies import DefaultStrategy
+from simplemma.strategies.dictionaries import DefaultDictionaryFactory
+
+LANG_CACHE_SIZE = 5  # How many language dictionaries to keep in memory at once (max)
+
+dictionary_factory = DefaultDictionaryFactory(cache_max_size=LANG_CACHE_SIZE)
+lemmatization_strategy = DefaultStrategy(dictionary_factory=dictionary_factory)

--- a/annif/openapi/annif.yaml
+++ b/annif/openapi/annif.yaml
@@ -190,7 +190,7 @@ paths:
       operationId: annif.rest.detect_language
       requestBody:
         content:
-          application/x-www-form-urlencoded:
+          application/json:
             schema:
               type: object
               required:
@@ -200,6 +200,7 @@ paths:
                 text:
                   type: string
                   description: input text
+                  example: A quick brown fox jumped over the lazy dog.
                 candidates:
                   type: array
                   description: candidate languages as ISO 639-1 codes
@@ -207,6 +208,7 @@ paths:
                     type: string
                     maxLength: 2
                     minLength: 2
+                    example: en
         required: true
       responses:
         200:

--- a/annif/openapi/annif.yaml
+++ b/annif/openapi/annif.yaml
@@ -182,6 +182,39 @@ paths:
         "503":
           $ref: '#/components/responses/ServiceUnavailable'
       x-codegen-request-body-name: documents
+  /detect_language:
+    post:
+      tags:
+      - Languages detection
+      summary: detect the language of a text given a list of candidate languages
+      operationId: annif.rest.detect_language
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              required:
+              - text
+              - candidates
+              properties:
+                text:
+                  type: string
+                  description: input text
+                candidates:
+                  type: array
+                  description: candidate languages as ISO 639-1 codes
+                  items:
+                    type: string
+                    maxLength: 2
+                    minLength: 2
+        required: true
+      responses:
+        200:
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DetectedLanguages'
 components:
   schemas:
     ApiInfo:
@@ -316,6 +349,21 @@ components:
                 type: string
                 example: Vulpes vulpes
       description: A document with attached, known good subjects
+    DetectedLanguages:
+      type: object
+      properties:
+        results:
+          type: array
+          items:
+            type: object
+            properties:
+              language:
+                type: string
+                example: en
+              score:
+                type: number
+                example: 0.85
+      description: Candidate languages with their associated scores
     Problem:
       type: object
       properties:

--- a/annif/openapi/annif.yaml
+++ b/annif/openapi/annif.yaml
@@ -185,7 +185,7 @@ paths:
   /detect-language:
     post:
       tags:
-      - Languages detection
+      - Language detection
       summary: detect the language of a text given a list of candidate languages
       operationId: annif.rest.detect_language
       requestBody:
@@ -203,10 +203,10 @@ paths:
                   example: A quick brown fox jumped over the lazy dog.
                 candidates:
                   type: array
-                  description: candidate languages as ISO 639-1 codes
+                  description: candidate languages as IETF BCP 47 codes
                   items:
                     type: string
-                    maxLength: 2
+                    maxLength: 3
                     minLength: 2
                     example: en
         required: true

--- a/annif/openapi/annif.yaml
+++ b/annif/openapi/annif.yaml
@@ -217,6 +217,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/DetectedLanguages'
+        400:
+          description: Bad Request
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
 components:
   schemas:
     ApiInfo:

--- a/annif/openapi/annif.yaml
+++ b/annif/openapi/annif.yaml
@@ -368,6 +368,7 @@ components:
               language:
                 type: string
                 example: en
+                nullable: true
               score:
                 type: number
                 example: 0.85

--- a/annif/openapi/annif.yaml
+++ b/annif/openapi/annif.yaml
@@ -195,13 +195,13 @@ paths:
               type: object
               required:
               - text
-              - candidates
+              - languages
               properties:
                 text:
                   type: string
                   description: input text
                   example: A quick brown fox jumped over the lazy dog.
-                candidates:
+                languages:
                   type: array
                   description: candidate languages as IETF BCP 47 codes
                   items:
@@ -209,6 +209,8 @@ paths:
                     maxLength: 3
                     minLength: 2
                     example: en
+                  minItems: 1
+                  maxItems: 5
         required: true
       responses:
         200:

--- a/annif/openapi/annif.yaml
+++ b/annif/openapi/annif.yaml
@@ -182,7 +182,7 @@ paths:
         "503":
           $ref: '#/components/responses/ServiceUnavailable'
       x-codegen-request-body-name: documents
-  /detect_language:
+  /detect-language:
     post:
       tags:
       - Languages detection

--- a/annif/rest.py
+++ b/annif/rest.py
@@ -87,16 +87,9 @@ def detect_language(body: dict[str, Any]):
     """return scores for detected languages formatted according to Swagger spec"""
 
     text = body.get("text")
-    candidates = body.get("candidates")
+    languages = body.get("languages")
 
-    if not candidates:
-        return connexion.problem(
-            status=400,
-            title="Bad Request",
-            detail="no candidate languages given",
-        )
-
-    detector = get_language_detector(tuple(candidates))
+    detector = get_language_detector(tuple(languages))
     try:
         proportions = detector.proportion_in_each_language(text)
     except ValueError:

--- a/annif/rest.py
+++ b/annif/rest.py
@@ -7,6 +7,7 @@ import importlib
 from typing import TYPE_CHECKING, Any
 
 import connexion
+from simplemma.langdetect import lang_detector
 
 import annif.registry
 from annif.corpus import Document, DocumentList, SubjectSet
@@ -80,6 +81,18 @@ def show_project(
     except ValueError:
         return project_not_found_error(project_id)
     return project.dump(), 200, {"Content-Type": "application/json"}
+
+
+def detect_language(body):
+    """return scores for detected languages formatted according to Swagger spec"""
+
+    scores = lang_detector(body.get("text"), tuple(body.get("candidates")))
+    return {
+        "results": [
+            {"language": s[0] if s[0] != "unk" else None, "score": s[1]}
+            for s in scores
+        ]
+    }
 
 
 def _suggestion_to_dict(

--- a/annif/rest.py
+++ b/annif/rest.py
@@ -86,7 +86,25 @@ def show_project(
 def detect_language(body):
     """return scores for detected languages formatted according to Swagger spec"""
 
-    scores = lang_detector(body.get("text"), tuple(body.get("candidates")))
+    text = body.get("text")
+    candidates = body.get("candidates")
+
+    if not candidates:
+        return connexion.problem(
+            status=400,
+            title="Bad Request",
+            detail="no candidate languages given",
+        )
+
+    scores = lang_detector(text, tuple(candidates))
+
+    if not scores:
+        return connexion.problem(
+            status=400,
+            title="Bad Request",
+            detail="unsupported candidate languages",
+        )
+
     return {
         "results": [
             {"language": lang if lang != "unk" else None, "score": score}

--- a/annif/rest.py
+++ b/annif/rest.py
@@ -89,8 +89,8 @@ def detect_language(body):
     scores = lang_detector(body.get("text"), tuple(body.get("candidates")))
     return {
         "results": [
-            {"language": s[0] if s[0] != "unk" else None, "score": s[1]}
-            for s in scores
+            {"language": lang if lang != "unk" else None, "score": score}
+            for lang, score in scores
         ]
     }
 

--- a/annif/simplemma_util.py
+++ b/annif/simplemma_util.py
@@ -1,0 +1,15 @@
+"""Wrapper code for using Simplemma functionality in Annif"""
+
+from simplemma import LanguageDetector, Lemmatizer
+from simplemma.strategies import DefaultStrategy
+from simplemma.strategies.dictionaries import DefaultDictionaryFactory
+
+LANG_CACHE_SIZE = 5  # How many language dictionaries to keep in memory at once (max)
+
+_dictionary_factory = DefaultDictionaryFactory(cache_max_size=LANG_CACHE_SIZE)
+_lemmatization_strategy = DefaultStrategy(dictionary_factory=_dictionary_factory)
+lemmatizer = Lemmatizer(lemmatization_strategy=_lemmatization_strategy)
+
+
+def get_language_detector(lang: str) -> LanguageDetector:
+    return LanguageDetector(lang, lemmatization_strategy=_lemmatization_strategy)

--- a/annif/simplemma_util.py
+++ b/annif/simplemma_util.py
@@ -1,5 +1,7 @@
 """Wrapper code for using Simplemma functionality in Annif"""
 
+from typing import Tuple, Union
+
 from simplemma import LanguageDetector, Lemmatizer
 from simplemma.strategies import DefaultStrategy
 from simplemma.strategies.dictionaries import DefaultDictionaryFactory
@@ -11,5 +13,5 @@ _lemmatization_strategy = DefaultStrategy(dictionary_factory=_dictionary_factory
 lemmatizer = Lemmatizer(lemmatization_strategy=_lemmatization_strategy)
 
 
-def get_language_detector(lang: str) -> LanguageDetector:
+def get_language_detector(lang: Union[str, Tuple[str, ...]]) -> LanguageDetector:
     return LanguageDetector(lang, lemmatization_strategy=_lemmatization_strategy)

--- a/annif/transform/langfilter.py
+++ b/annif/transform/langfilter.py
@@ -5,10 +5,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from simplemma import LanguageDetector
-
 import annif
-import annif.langsupport
+import annif.simplemma_util
 
 from . import transform
 
@@ -32,9 +30,8 @@ class LangFilter(transform.BaseTransform):
         self.text_min_length = int(text_min_length)
         self.sentence_min_length = int(sentence_min_length)
         self.min_ratio = float(min_ratio)
-        self.language_detector = LanguageDetector(
-            self.project.language,
-            lemmatization_strategy=annif.langsupport.lemmatization_strategy,
+        self.language_detector = annif.simplemma_util.get_language_detector(
+            self.project.language
         )
 
     def transform_fn(self, text: str) -> str:

--- a/annif/transform/langfilter.py
+++ b/annif/transform/langfilter.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from simplemma.langdetect import in_target_language
+from simplemma import LanguageDetector
 
 import annif
+import annif.langsupport
 
 from . import transform
 
@@ -31,6 +32,10 @@ class LangFilter(transform.BaseTransform):
         self.text_min_length = int(text_min_length)
         self.sentence_min_length = int(sentence_min_length)
         self.min_ratio = float(min_ratio)
+        self.language_detector = LanguageDetector(
+            self.project.language,
+            lemmatization_strategy=annif.langsupport.lemmatization_strategy,
+        )
 
     def transform_fn(self, text: str) -> str:
         if len(text) < self.text_min_length:
@@ -41,7 +46,7 @@ class LangFilter(transform.BaseTransform):
             if len(sent) < self.sentence_min_length:
                 retained_sentences.append(sent)
                 continue
-            proportion = in_target_language(sent, lang=(self.project.language,))
+            proportion = self.language_detector.proportion_in_target_languages(sent)
             if proportion >= self.min_ratio:
                 retained_sentences.append(sent)
         return " ".join(retained_sentences)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ numpy = "1.26.*"
 optuna = "3.6.*"
 python-dateutil = "2.9.*"
 tomli = { version = "2.0.*", python = "<3.11" }
-simplemma = { git = "https://github.com/adbar/simplemma", branch = "main" }
+simplemma = "1.0.*"
 jsonschema = "4.21.*"
 huggingface-hub = "0.22.*"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ numpy = "1.26.*"
 optuna = "3.6.*"
 python-dateutil = "2.9.*"
 tomli = { version = "2.0.*", python = "<3.11" }
-simplemma = "1.0.*"
+simplemma = "~1.1.1"
 jsonschema = "4.21.*"
 huggingface-hub = "0.22.*"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ numpy = "1.26.*"
 optuna = "3.6.*"
 python-dateutil = "2.9.*"
 tomli = { version = "2.0.*", python = "<3.11" }
-simplemma = "0.9.*"
+simplemma = { git = "https://github.com/adbar/simplemma", branch = "main" }
 jsonschema = "4.21.*"
 huggingface-hub = "0.22.*"
 

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -126,3 +126,15 @@ def test_openapi_learn_novocab(app_client):
     data = []
     req = app_client.post("http://localhost:8000/v1/projects/novocab/learn", json=data)
     assert req.status_code == 503
+
+
+def test_rest_detect_language_no_candidates(app_client):
+    data = {"text": "example text", "languages": []}
+    req = app_client.post("http://localhost:8000/v1/detect-language", json=data)
+    assert req.status_code == 400
+
+
+def test_rest_detect_language_too_many_candidates(app_client):
+    data = {"text": "example text", "languages": ["en", "fr", "de", "it", "es", "nl"]}
+    req = app_client.post("http://localhost:8000/v1/detect-language", json=data)
+    assert req.status_code == 400

--- a/tests/test_rest.py
+++ b/tests/test_rest.py
@@ -57,7 +57,7 @@ def test_rest_detect_language_english(app):
     # english text should be detected
     with app.app_context():
         result = annif.rest.detect_language(
-            {"text": "example text", "candidates": ["en", "fi", "sv"]}
+            {"text": "example text", "languages": ["en", "fi", "sv"]}
         )[0]
         assert {"language": "en", "score": 1} in result["results"]
 
@@ -66,27 +66,21 @@ def test_rest_detect_language_unknown(app):
     # an unknown language should return None
     with app.app_context():
         result = annif.rest.detect_language(
-            {"text": "exampley texty", "candidates": ["fi", "sv"]}
+            {"text": "exampley texty", "languages": ["fi", "sv"]}
         )[0]
         assert {"language": None, "score": 1} in result["results"]
 
 
 def test_rest_detect_language_no_text(app):
     with app.app_context():
-        result = annif.rest.detect_language({"text": "", "candidates": ["en"]})[0]
+        result = annif.rest.detect_language({"text": "", "languages": ["en"]})[0]
         assert {"language": None, "score": 1} in result["results"]
-
-
-def test_rest_detect_language_no_candidates(app):
-    with app.app_context():
-        result = annif.rest.detect_language({"text": "example text", "candidates": []})
-        assert result.status_code == 400
 
 
 def test_rest_detect_language_unsupported_candidates(app):
     with app.app_context():
         result = annif.rest.detect_language(
-            {"text": "example text", "candidates": ["unk"]}
+            {"text": "example text", "languages": ["unk"]}
         )
         assert result.status_code == 400
 

--- a/tests/test_rest.py
+++ b/tests/test_rest.py
@@ -53,6 +53,24 @@ def test_rest_show_project_nonexistent(app):
         assert result.status_code == 404
 
 
+def test_rest_detect_language_english(app):
+    # english text should be detected
+    with app.app_context():
+        result = annif.rest.detect_language(
+            {"text": "example text", "candidates": ["en", "fi", "sv"]}
+        )
+        assert {"language": "en", "score": 1} in result["results"]
+
+
+def test_rest_detect_language_unknown(app):
+    # an unknown language should return None
+    with app.app_context():
+        result = annif.rest.detect_language(
+            {"text": "example text", "candidates": ["fi", "sv"]}
+        )
+        assert {"language": None, "score": 1} in result["results"]
+
+
 def test_rest_suggest_public(app):
     # public projects should be accessible via REST
     with app.app_context():

--- a/tests/test_rest.py
+++ b/tests/test_rest.py
@@ -58,7 +58,7 @@ def test_rest_detect_language_english(app):
     with app.app_context():
         result = annif.rest.detect_language(
             {"text": "example text", "candidates": ["en", "fi", "sv"]}
-        )
+        )[0]
         assert {"language": "en", "score": 1} in result["results"]
 
 
@@ -66,14 +66,14 @@ def test_rest_detect_language_unknown(app):
     # an unknown language should return None
     with app.app_context():
         result = annif.rest.detect_language(
-            {"text": "example text", "candidates": ["fi", "sv"]}
-        )
+            {"text": "exampley texty", "candidates": ["fi", "sv"]}
+        )[0]
         assert {"language": None, "score": 1} in result["results"]
 
 
 def test_rest_detect_language_no_text(app):
     with app.app_context():
-        result = annif.rest.detect_language({"text": "", "candidates": ["en"]})
+        result = annif.rest.detect_language({"text": "", "candidates": ["en"]})[0]
         assert {"language": None, "score": 1} in result["results"]
 
 

--- a/tests/test_rest.py
+++ b/tests/test_rest.py
@@ -71,6 +71,26 @@ def test_rest_detect_language_unknown(app):
         assert {"language": None, "score": 1} in result["results"]
 
 
+def test_rest_detect_language_no_text(app):
+    with app.app_context():
+        result = annif.rest.detect_language({"text": "", "candidates": ["en"]})
+        assert {"language": None, "score": 1} in result["results"]
+
+
+def test_rest_detect_language_no_candidates(app):
+    with app.app_context():
+        result = annif.rest.detect_language({"text": "example text", "candidates": []})
+        assert result.status_code == 400
+
+
+def test_rest_detect_language_unsupported_candidates(app):
+    with app.app_context():
+        result = annif.rest.detect_language(
+            {"text": "example text", "candidates": ["unk"]}
+        )
+        assert result.status_code == 400
+
+
 def test_rest_suggest_public(app):
     # public projects should be accessible via REST
     with app.app_context():

--- a/tests/test_simplemma_util.py
+++ b/tests/test_simplemma_util.py
@@ -1,0 +1,17 @@
+"""Unit tests for Simplemma utility functions"""
+
+from annif.simplemma_util import get_language_detector
+
+
+def test_get_language_detector():
+    detector = get_language_detector("en")
+    text = "She said 'au revoir' and left"
+    proportion = detector.proportion_in_target_languages(text)
+    assert proportion == 0.75
+
+
+def test_get_language_detector_many():
+    detector = get_language_detector(("en", "fr"))
+    text = "She said 'au revoir' and left"
+    proportion = detector.proportion_in_target_languages(text)
+    assert proportion == 1.0

--- a/tests/test_simplemma_util.py
+++ b/tests/test_simplemma_util.py
@@ -1,5 +1,7 @@
 """Unit tests for Simplemma utility functions"""
 
+import pytest
+
 from annif.simplemma_util import get_language_detector
 
 
@@ -7,11 +9,11 @@ def test_get_language_detector():
     detector = get_language_detector("en")
     text = "She said 'au revoir' and left"
     proportion = detector.proportion_in_target_languages(text)
-    assert proportion == 0.75
+    assert proportion == pytest.approx(0.75)
 
 
 def test_get_language_detector_many():
     detector = get_language_detector(("en", "fr"))
     text = "She said 'au revoir' and left"
     proportion = detector.proportion_in_target_languages(text)
-    assert proportion == 1.0
+    assert proportion == pytest.approx(1.0)


### PR DESCRIPTION
This PR adds the ability to detect the language of a text to the REST API. The language detection uses the simplemma python library.

A POST method is added to the end-point `/detect-language`. It expects the request body to include a json object with the text whose language is to be detected and a list of candidate languages as their [IETF BCP 47](https://en.wikipedia.org/wiki/IETF_language_tag) ~[ISO 639-1 codes](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes)~. For example:
```json
{
  "languages": ["en", "fi"],
  "text": "A quick brown fox jumped over the lazy dog."
}
```

The response is a json object with the format:
```json
{
  "results": [
    {"language": "en", "score": 0.85},
    {"language": "fi", "score": 0.1},
    {"language": null, "score": 0.1} 
  ]
}
```
where the scores range from 0 to 1 and a `null` value is used for an unknown language.

Implements REST API part of #631.

---

@juhoinkinen: I edited this for the latest changes (parameter name change candidates -> languages). 