### PR TITLE
Migrate codestyle to Black v23

### DIFF
--- a/annif/backend/pav.py
+++ b/annif/backend/pav.py
@@ -91,7 +91,6 @@ class PAVBackend(ensemble.BaseEnsembleBackend):
             for cid in np.flatnonzero(
                 doc.subject_set.as_vector(len(source_project.subjects))
             ):
-
                 trow.append(docid)
                 tcol.append(cid)
             ndocs += 1

--- a/annif/backend/stwfsa.py
+++ b/annif/backend/stwfsa.py
@@ -23,7 +23,6 @@ _KEY_USE_TXT_VEC = "use_txt_vec"
 
 
 class StwfsaBackend(backend.AnnifBackend):
-
     name = "stwfsa"
 
     STWFSA_PARAMETERS = {

--- a/annif/lexical/mllm.py
+++ b/annif/lexical/mllm.py
@@ -234,7 +234,6 @@ class MLLMModel:
             for doc_subject_ids, candidates in pool.starmap(
                 MLLMCandidateGenerator.generate_candidates, params, 10
             ):
-
                 self._subj_freq.update(doc_subject_ids)
                 self._doc_freq.update([c.subject_id for c in candidates])
                 train_x.append(candidates)

--- a/annif/transform/inputlimiter.py
+++ b/annif/transform/inputlimiter.py
@@ -7,7 +7,6 @@ from . import transform
 
 
 class InputLimiter(transform.BaseTransform):
-
     name = "limit"
 
     def __init__(self, project, input_limit):

--- a/annif/transform/langfilter.py
+++ b/annif/transform/langfilter.py
@@ -11,7 +11,6 @@ logger = annif.logger
 
 
 class LangFilter(transform.BaseTransform):
-
     name = "filter_lang"
 
     def __init__(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ pytest-watch = "*"
 pytest-flask = "*"
 flake8 = "*"
 bumpversion = "*"
-black = "*"
+black = "23.*"
 isort = "*"
 
 [tool.poetry.extras]

--- a/tests/test_exception.py
+++ b/tests/test_exception.py
@@ -12,7 +12,6 @@ def test_annifexception_not_instantiable():
 
 
 def test_annifexception_is_clickexception():
-
     # we need to define a custom class to make an instantiable exception
     class CustomException(AnnifException):
         @property


### PR DESCRIPTION
Black v23.1 was released recently, and as their [Stability Policy](https://black.readthedocs.io/en/stable/the_black_code_style/index.html#stability-policy) states, Black style is allowed to change between yearly/major Black releases. 

To avoid surprising failures in CI/CD, this pins the Black version.

The code style change to v23 luckily just removes a few empty lines.