### PR TITLE
Batch suggest in Omikuji backend

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -157,7 +157,12 @@ A backend can define these key fields and methods:
 * `name`: field for a name for the backend (a single word, all lowercase)
 * `initialize` (optional): method setting up the necessary internal data structures
 * `_train` (optional): method for training the model on a given document corpus
-* `_suggest`: method for feeding a single document (text) and getting suggested subjects
+* `_suggest`: method for feeding a single document (text) and getting suggested subjects for it
+* `_suggest_batch`: method for feeding a batch of documents (texts) and getting suggested subjects for each of them
+
+It is only necessary to implement either `_suggest` or `_suggest_batch`, but
+not both. Processing batches is often more efficient and should be used if
+possible.
 
 Learning backends additionally implement:
 

--- a/annif/backend/backend.py
+++ b/annif/backend/backend.py
@@ -73,10 +73,10 @@ class AnnifBackend(metaclass=abc.ABCMeta):
         parallel operation."""
         pass
 
-    @abc.abstractmethod
     def _suggest(self, text, params):
-        """This method should implemented by backends. It implements
-        the suggest functionality, with pre-processed parameters."""
+        """Either this method or _suggest_batch should be implemented by by
+        backends.  It implements the suggest functionality for a single
+        document, with pre-processed parameters."""
         pass  # pragma: no cover
 
     def _suggest_batch(self, texts, params):


### PR DESCRIPTION
This PR clarifies that backends only have to implement either one of `_suggest` and `_suggest_batch`, then implements batched suggest in the Omikuji backend. In practice, only the text vectorization is performed on the whole batch at once; the Omikuji implementation only supports a [predict method](https://github.com/tomtung/omikuji/blob/master/python-wrapper/omikuji/__init__.py#L106) for a single document at a time so it has to be done within a `for` loop.

There seems to be a small performance benefit. I tested this using `annif eval` the Finto AI yso-parabel-fi project/model, with the kirjaesittelyt2021/fin/test corpus. The evaluation results were unchanged, only the amount of time spent was slightly different. Memory usage remained pretty much the same.

# With 1 job

|                 | user time | wall time | max rss |
| --------------- | --------- | --------- | ------- |
| before (master) | 86.69     | 1:29.94   | 6322624 |
| after (PR)      | 78.66     | 1:22.79   | 6336584 |

# With 4 jobs

|                 | user time | wall time | max rss |
| --------------- | --------- | --------- | ------- |
| before (master) | 121.33    | 1:22.33   | 6293804 |
| after (PR)      | 96.55     | 1:18.78   | 6293640 |

