### PR TITLE
Add log message indicating finishing projects initialization

### DIFF
--- a/annif/__init__.py
+++ b/annif/__init__.py
@@ -7,7 +7,9 @@ import os.path
 import connexion
 from flask_cors import CORS
 
+logging.basicConfig()
 logger = logging.getLogger("annif")
+logger.setLevel(level=logging.INFO)
 
 import annif.backend  # noqa
 
@@ -36,6 +38,7 @@ def create_app(config_name=None):
 
     if cxapp.app.config["INITIALIZE_PROJECTS"]:
         annif.registry.initialize_projects(cxapp.app)
+        logger.info("finished initializing projects")
 
     # register the views via blueprints
     from annif.views import bp

--- a/tests/test_backend_fasttext.py
+++ b/tests/test_backend_fasttext.py
@@ -104,7 +104,7 @@ def test_train_fasttext_params(document_corpus, project, caplog):
     )
     params = {"dim": 1, "lr": 42.1, "epoch": 0}
 
-    with caplog.at_level(logging.DEBUG):
+    with caplog.at_level(logging.DEBUG, logger="annif"):
         fasttext.train(document_corpus, params)
     parameters_heading = "Backend fasttext: Model parameters:"
     assert parameters_heading in caplog.text


### PR DESCRIPTION
By looking at the logs from e.g. OpenShift environment it can be hard to see if Annif pod/container has booted or models are still being loaded. In error situations while Annif is in boot loop (or it seems so) it would be good to easily know from the logs if/when Annif has started.

This PR adds an info level message `finished initializing projects` to log stream for addressing the mentioned concern. For this, it was necessary to also do the [basic configuration](https://docs.python.org/dev/library/logging.html#logging.basicConfig) for the root logger and set log level to "info" (was "unset") for "annif" logger. This makes all log messages from Annif to show also the level and the logger name.

For example:
```
[2023-02-07 16:12:22 +0200] [460823] [INFO] Starting gunicorn 20.1.0
[2023-02-07 16:12:22 +0200] [460823] [INFO] Listening at: http://0.0.0.0:8000 (460823)
[2023-02-07 16:12:22 +0200] [460823] [INFO] Using worker: sync
[2023-02-07 16:12:22 +0200] [460825] [INFO] Booting worker with pid: 460825
2023-02-07T14:12:26.030Z INFO [omikuji::model] Loading model from data/projects/omikuji-parabel-fi/omikuji-model...
2023-02-07T14:12:26.030Z INFO [omikuji::model] Loading model settings from data/projects/omikuji-parabel-fi/omikuji-model/settings.json...
2023-02-07T14:12:26.030Z INFO [omikuji::model] Loaded model settings Settings { n_features: 329277, classifier_loss_type: Hinge }...
2023-02-07T14:12:26.030Z INFO [omikuji::model] Loading tree from data/projects/omikuji-parabel-fi/omikuji-model/tree2.cbor...
2023-02-07T14:12:28.830Z INFO [omikuji::model] Loading tree from data/projects/omikuji-parabel-fi/omikuji-model/tree0.cbor...
2023-02-07T14:12:31.534Z INFO [omikuji::model] Loading tree from data/projects/omikuji-parabel-fi/omikuji-model/tree1.cbor...
2023-02-07T14:12:34.281Z INFO [omikuji::model] Loaded model with 3 trees; it took 8.25s
WARNING:annif:Couldn't initialize backend 'omikuji': vectorizer file 'data/projects/omikuji-parabel-sv/vectorizer' not found
WARNING:annif:Couldn't initialize backend 'omikuji': vectorizer file 'data/projects/omikuji-parabel-en/vectorizer' not found
INFO:annif:finished initializing projects

```
The gunicorn and Omikuji log messages have also timestamps, but they are actually more distracting than helpful when logs are read in Kibana (especially), because there is a dedicated timestamp field for every message.
