### PR TITLE
Fix slow CI/CD runs for Python 3.10

### DIFF
--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -1,0 +1,28 @@
+name: Prepare
+description:
+inputs:
+  python-version:
+    required: true
+  poetry-version:
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - name: Load cached Poetry installation and its repo info & venvs
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cache/pipx/venvs
+          ~/.local/bin
+          ~/.cache/pypoetry/{cache/repositories,virtualenvs}
+        key: poetry-installation-and-repos-${{ inputs.python-version }}-${{ inputs.poetry-version }}-${{ github.job }}
+    - name: Install Poetry
+      shell: bash
+      run: |
+        pipx install poetry==${{ inputs.poetry-version }}
+    - name: Set up Python ${{ inputs.python-version }}
+      uses: actions/setup-python@5ccb29d8773c3f3f653e1705f474dfaa8a06a912  # v4.4.0
+      with:
+        python-version: ${{ inputs.python-version }}
+        cache: 'poetry'
+        cache-dependency-path: 'pyproject.toml'

--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -5,10 +5,14 @@ inputs:
     required: true
   poetry-version:
     required: true
+outputs:
+  cache-matched-key:
+    value: ${{ steps.restore-cache.outputs.cache-matched-key }}
 runs:
   using: "composite"
   steps:
     - name: Restore cached Poetry installation and its cache
+      id: restore-cache
       uses: actions/cache/restore@v3
       with:
         path: |

--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -16,7 +16,8 @@ runs:
           ~/.cache/pipx/venvs
           ~/.local/bin
           ~/.cache/pypoetry/
-        key: poetry-installation-and-cache-${{ inputs.python-version }}-${{ inputs.poetry-version }}
+        key: poetry-installation-and-cache-${{ inputs.python-version }}-${{ inputs.poetry-version }}-${{ hashFiles('pyproject.toml') }}
+
     - name: Install Poetry
       shell: bash
       run: |
@@ -25,5 +26,3 @@ runs:
       uses: actions/setup-python@5ccb29d8773c3f3f653e1705f474dfaa8a06a912  # v4.4.0
       with:
         python-version: ${{ inputs.python-version }}
-        cache: 'poetry'
-        cache-dependency-path: 'pyproject.toml'

--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -8,14 +8,15 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Load cached Poetry installation and its all cache
-      uses: actions/cache@v3
+    - name: Restore cached Poetry installation and its cache
+      id: restore-cache
+      uses: actions/cache/restore@v3
       with:
         path: |
           ~/.cache/pipx/venvs
           ~/.local/bin
           ~/.cache/pypoetry/
-        key: poetry-installation-and-repos-${{ inputs.python-version }}-${{ inputs.poetry-version }}-${{ github.job }}
+        key: poetry-installation-and-cache-${{ inputs.python-version }}-${{ inputs.poetry-version }}
     - name: Install Poetry
       shell: bash
       run: |

--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -5,6 +5,9 @@ inputs:
     required: true
   poetry-version:
     required: true
+outputs:
+  cache-key:
+    value: ${{ steps.restore-cache.outputs.cache-primary-key }}
 runs:
   using: "composite"
   steps:

--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -5,22 +5,19 @@ inputs:
     required: true
   poetry-version:
     required: true
-outputs:
-  cache-key:
-    value: ${{ steps.restore-cache.outputs.cache-primary-key }}
 runs:
   using: "composite"
   steps:
     - name: Restore cached Poetry installation and its cache
-      id: restore-cache
       uses: actions/cache/restore@v3
       with:
         path: |
           ~/.cache/pipx/venvs
           ~/.local/bin
           ~/.cache/pypoetry/
-        key: poetry-installation-and-cache-${{ inputs.python-version }}-${{ inputs.poetry-version }}-${{ hashFiles('pyproject.toml') }}
-
+        key: ignore-me
+        restore-keys: |
+          poetry-installation-and-cache-${{ inputs.python-version }}-${{ inputs.poetry-version }}-
     - name: Install Poetry
       shell: bash
       run: |

--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -8,13 +8,13 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Load cached Poetry installation and its repo info & venvs
+    - name: Load cached Poetry installation and its all cache
       uses: actions/cache@v3
       with:
         path: |
           ~/.cache/pipx/venvs
           ~/.local/bin
-          ~/.cache/pypoetry/{cache/repositories,virtualenvs}
+          ~/.cache/pypoetry/
         key: poetry-installation-and-repos-${{ inputs.python-version }}-${{ inputs.poetry-version }}-${{ github.job }}
     - name: Install Poetry
       shell: bash

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -21,13 +21,13 @@ jobs:
     steps:
 
     - uses: actions/checkout@v3
-    - name: Load cached Poetry installation and repositories info
+    - name: Load cached Poetry installation and its cache
       uses: actions/cache@v3
       with:
         path: |
           ~/.cache/pipx/venvs
           ~/.local/bin
-          ~/.cache/pypoetry/cache/repositories
+          ~/.cache/pypoetry
         key: poetry-installation-and-repos-${{ env.PYTHON_VERSION }}-${{env.POETRY_VERSION }}-${{ github.job }}
     - name: Install Poetry
       run: |
@@ -67,13 +67,13 @@ jobs:
         sudo apt-get install \
           libvoikko1 \
           voikko-fi
-    - name: Load cached Poetry installation and repositories info
+    - name: Load cached Poetry installation and its cache
       uses: actions/cache@v3
       with:
         path: |
           ~/.cache/pipx/venvs
           ~/.local/bin
-          ~/.cache/pypoetry/cache/repositories
+          ~/.cache/pypoetry
         key: poetry-installation-and-repos-${{ matrix.python-version }}-${{env.POETRY_VERSION }}-${{ github.job }}
     - name: Install Poetry
       run: |
@@ -143,13 +143,13 @@ jobs:
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
     steps:
     - uses: actions/checkout@v3
-    - name: Load cached Poetry installation and repositories info
+    - name: Load cached Poetry installation and its cache
       uses: actions/cache@v3
       with:
         path: |
           ~/.cache/pipx/venvs
           ~/.local/bin
-          ~/.cache/pypoetry/cache/repositories
+          ~/.cache/pypoetry
         key: poetry-installation-and-repos-${{ matrix.python-version }}-${{env.POETRY_VERSION }}-${{ github.job }}
     - name: Install Poetry
       run: |

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -16,14 +16,13 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     name: lint with isort, Black & flake8
-    env:
-      PYTHON_VERSION: "3.10"
     steps:
     - uses: actions/checkout@v3
     - name: Load caches, install Poetry, Set up Python
       uses: ./.github/actions/prepare
       with:
-        python-version: ${{ env.PYTHON_VERSION }}
+        # Use different (patch) version than the test job to avoid reserved cache key error:
+        python-version: "3.10.8"
         poetry-version: ${{ env.POETRY_VERSION }}
     - name: Install Python dev dependencies
       run: |

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -86,7 +86,8 @@ jobs:
           ~/.cache/pipx/venvs
           ~/.local/bin
           ~/.cache/pypoetry/
-        key: ${{ steps.prepare.outputs.cache-key }}
+        # A new key is created to update the cache if some dependency has been updated
+        key:  poetry-installation-and-cache-${{ matrix.python-version }}-${{ env.POETRY_VERSION }}-${{ hashFiles('**/poetry.lock') }}
 
   publish-docker-latest:
     name: publish latest Docker image

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -85,7 +85,7 @@ jobs:
           ~/.cache/pipx/venvs
           ~/.local/bin
           ~/.cache/pypoetry/
-        key: ${{ steps.restore-cache.outputs.cache-primary-key }}
+        key: poetry-installation-and-cache-${{ matrix.python-version }}-${{ env.POETRY_VERSION }}
 
   publish-docker-latest:
     name: publish latest Docker image

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -19,25 +19,12 @@ jobs:
     env:
       PYTHON_VERSION: "3.10"
     steps:
-
     - uses: actions/checkout@v3
-    - name: Load cached Poetry installation and its repo info & venvs
-      uses: actions/cache@v3
+    - name: Load caches, install Poetry, Set up Python
+      uses: ./.github/actions/prepare
       with:
-        path: |
-          ~/.cache/pipx/venvs
-          ~/.local/bin
-          ~/.cache/pypoetry/{cache/repositories,virtualenvs}
-        key: poetry-installation-and-repos-${{ env.PYTHON_VERSION }}-${{env.POETRY_VERSION }}-${{ github.job }}
-    - name: Install Poetry
-      run: |
-        pipx install poetry==$POETRY_VERSION
-    - name: Set up Python ${{ env.python-version }}
-      uses: actions/setup-python@5ccb29d8773c3f3f653e1705f474dfaa8a06a912  # v4.4.0
-      with:
-        python-version: "${{ env.PYTHON_VERSION }}"
-        cache: 'poetry'
-        cache-dependency-path: 'pyproject.toml'
+        python-version: ${{ env.PYTHON_VERSION }}
+        poetry-version: ${{ env.POETRY_VERSION }}
     - name: Install Python dev dependencies
       run: |
         poetry install --only dev
@@ -62,28 +49,15 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Install system packages
-
       run: |
         sudo apt-get install \
           libvoikko1 \
           voikko-fi
-    - name: Load cached Poetry installation and its repo info & venvs
-      uses: actions/cache@v3
-      with:
-        path: |
-          ~/.cache/pipx/venvs
-          ~/.local/bin
-          ~/.cache/pypoetry/{cache/repositories,virtualenvs}
-        key: poetry-installation-and-repos-${{ matrix.python-version }}-${{env.POETRY_VERSION }}-${{ github.job }}
-    - name: Install Poetry
-      run: |
-        pipx install poetry==$POETRY_VERSION
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@5ccb29d8773c3f3f653e1705f474dfaa8a06a912  # v4.4.0
+    - name: Load caches, install Poetry, Set up Python
+      uses: ./.github/actions/prepare
       with:
         python-version: ${{ matrix.python-version }}
-        cache: 'poetry'
-        cache-dependency-path: 'pyproject.toml'
+        poetry-version: ${{ env.POETRY_VERSION }}
     - name: Install Python dependencies
       run: |
         # Selectively install the optional dependencies for some Python versions
@@ -143,23 +117,11 @@ jobs:
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
     steps:
     - uses: actions/checkout@v3
-    - name: Load cached Poetry installation and its repo info & venvs
-      uses: actions/cache@v3
-      with:
-        path: |
-          ~/.cache/pipx/venvs
-          ~/.local/bin
-          ~/.cache/pypoetry/{cache/repositories,virtualenvs}
-        key: poetry-installation-and-repos-${{ matrix.python-version }}-${{env.POETRY_VERSION }}-${{ github.job }}
-    - name: Install Poetry
-      run: |
-        pipx install poetry==$POETRY_VERSION
-    - name: Set up Python 3.9
-      uses: actions/setup-python@5ccb29d8773c3f3f653e1705f474dfaa8a06a912  # v4.4.0
+    - name: Load caches, install Poetry, Set up Python
+      uses: ./.github/actions/prepare
       with:
         python-version: '3.9'
-        cache: 'poetry'
-        cache-dependency-path: 'pyproject.toml'
+        poetry-version: ${{ env.POETRY_VERSION }}
     - name: Build and publish distribution to PyPI
       env:
         POETRY_HTTP_BASIC_PYPI_USERNAME: __token__

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -21,13 +21,13 @@ jobs:
     steps:
 
     - uses: actions/checkout@v3
-    - name: Load cached Poetry installation and its cache
+    - name: Load cached Poetry installation and its repo info & venvs
       uses: actions/cache@v3
       with:
         path: |
           ~/.cache/pipx/venvs
           ~/.local/bin
-          ~/.cache/pypoetry
+          ~/.cache/pypoetry/{cache/repositories,virtualenvs}
         key: poetry-installation-and-repos-${{ env.PYTHON_VERSION }}-${{env.POETRY_VERSION }}-${{ github.job }}
     - name: Install Poetry
       run: |
@@ -67,13 +67,13 @@ jobs:
         sudo apt-get install \
           libvoikko1 \
           voikko-fi
-    - name: Load cached Poetry installation and its cache
+    - name: Load cached Poetry installation and its repo info & venvs
       uses: actions/cache@v3
       with:
         path: |
           ~/.cache/pipx/venvs
           ~/.local/bin
-          ~/.cache/pypoetry
+          ~/.cache/pypoetry/{cache/repositories,virtualenvs}
         key: poetry-installation-and-repos-${{ matrix.python-version }}-${{env.POETRY_VERSION }}-${{ github.job }}
     - name: Install Poetry
       run: |
@@ -143,13 +143,13 @@ jobs:
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
     steps:
     - uses: actions/checkout@v3
-    - name: Load cached Poetry installation and its cache
+    - name: Load cached Poetry installation and its repo info & venvs
       uses: actions/cache@v3
       with:
         path: |
           ~/.cache/pipx/venvs
           ~/.local/bin
-          ~/.cache/pypoetry
+          ~/.cache/pypoetry/{cache/repositories,virtualenvs}
         key: poetry-installation-and-repos-${{ matrix.python-version }}-${{env.POETRY_VERSION }}-${{ github.job }}
     - name: Install Poetry
       run: |

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -85,7 +85,8 @@ jobs:
           ~/.cache/pipx/venvs
           ~/.local/bin
           ~/.cache/pypoetry/
-        key: poetry-installation-and-cache-${{ matrix.python-version }}-${{ env.POETRY_VERSION }}
+        key: poetry-installation-and-cache-${{ inputs.python-version }}-${{ inputs.poetry-version }}-${{ hashFiles('pyproject.toml') }}
+
 
   publish-docker-latest:
     name: publish latest Docker image

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -51,6 +51,7 @@ jobs:
           libvoikko1 \
           voikko-fi
     - name: "Prepare: restore caches, install Poetry, set up Python"
+      id: prepare
       uses: ./.github/actions/prepare
       with:
         python-version: ${{ matrix.python-version }}
@@ -85,8 +86,7 @@ jobs:
           ~/.cache/pipx/venvs
           ~/.local/bin
           ~/.cache/pypoetry/
-        key: poetry-installation-and-cache-${{ inputs.python-version }}-${{ inputs.poetry-version }}-${{ hashFiles('pyproject.toml') }}
-
+        key: ${{ steps.prepare.outputs.cache-key }}
 
   publish-docker-latest:
     name: publish latest Docker image

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -18,11 +18,10 @@ jobs:
     name: lint with isort, Black & flake8
     steps:
     - uses: actions/checkout@v3
-    - name: Load caches, install Poetry, Set up Python
+    - name: "Prepare: restore caches, install Poetry, set up Python"
       uses: ./.github/actions/prepare
       with:
-        # Use different (patch) version than the test job to avoid reserved cache key error:
-        python-version: "3.10.8"
+        python-version: "3.10"
         poetry-version: ${{ env.POETRY_VERSION }}
     - name: Install Python dev dependencies
       run: |
@@ -44,7 +43,6 @@ jobs:
       matrix:
         python-version: ["3.8", "3.9", "3.10"]
     name: test on Python ${{ matrix.python-version }}
-
     steps:
     - uses: actions/checkout@v3
     - name: Install system packages
@@ -52,7 +50,7 @@ jobs:
         sudo apt-get install \
           libvoikko1 \
           voikko-fi
-    - name: Load caches, install Poetry, Set up Python
+    - name: "Prepare: restore caches, install Poetry, set up Python"
       uses: ./.github/actions/prepare
       with:
         python-version: ${{ matrix.python-version }}
@@ -75,12 +73,19 @@ jobs:
           poetry install -E "nn omikuji yake";
         fi
         poetry run python -m nltk.downloader punkt
-
     - name: Test with pytest
       run: |
         poetry run pytest --cov=./ --cov-report xml
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@81cd2dc8148241f03f5839d295e000b8f761e378  # v3.1.0
+    - name: Save cache
+      uses: actions/cache/save@v3
+      with:
+        path: |
+          ~/.cache/pipx/venvs
+          ~/.local/bin
+          ~/.cache/pypoetry/
+        key: ${{ steps.restore-cache.outputs.cache-primary-key }}
 
   publish-docker-latest:
     name: publish latest Docker image
@@ -116,7 +121,7 @@ jobs:
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
     steps:
     - uses: actions/checkout@v3
-    - name: Load caches, install Poetry, Set up Python
+    - name: "Prepare: restore caches, install Poetry, set up Python"
       uses: ./.github/actions/prepare
       with:
         python-version: '3.9'

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -28,14 +28,14 @@ jobs:
           ~/.cache/pipx/venvs
           ~/.local/bin
           ~/.cache/pypoetry/cache/repositories
-        key: poetry-installation-and-repos-${{ env.PYTHON_VERSION }}-${{ env.POETRY_VERSION }}
+        key: poetry-installation-and-repos-${{ env.PYTHON_VERSION }}-${{env.POETRY_VERSION }}-${{ github.job }}
     - name: Install Poetry
       run: |
         pipx install poetry==$POETRY_VERSION
     - name: Set up Python ${{ env.python-version }}
       uses: actions/setup-python@5ccb29d8773c3f3f653e1705f474dfaa8a06a912  # v4.4.0
       with:
-        python-version: ${{ env.PYTHON_VERSION }}
+        python-version: "${{ env.PYTHON_VERSION }}"
         cache: 'poetry'
         cache-dependency-path: 'pyproject.toml'
     - name: Install Python dev dependencies
@@ -74,7 +74,7 @@ jobs:
           ~/.cache/pipx/venvs
           ~/.local/bin
           ~/.cache/pypoetry/cache/repositories
-        key: poetry-installation-and-repos-${{ matrix.python-version }}-${{ env.POETRY_VERSION }}
+        key: poetry-installation-and-repos-${{ matrix.python-version }}-${{env.POETRY_VERSION }}-${{ github.job }}
     - name: Install Poetry
       run: |
         pipx install poetry==$POETRY_VERSION
@@ -150,7 +150,7 @@ jobs:
           ~/.cache/pipx/venvs
           ~/.local/bin
           ~/.cache/pypoetry/cache/repositories
-        key: poetry-installation-and-repos-${{ matrix.python-version }}-${{ env.POETRY_VERSION }}
+        key: poetry-installation-and-repos-${{ matrix.python-version }}-${{env.POETRY_VERSION }}-${{ github.job }}
     - name: Install Poetry
       run: |
         pipx install poetry==$POETRY_VERSION

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -80,6 +80,7 @@ jobs:
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@81cd2dc8148241f03f5839d295e000b8f761e378  # v3.1.0
     - name: Save cache
+      if: steps.prepare.outputs.cache-matched-key != format('poetry-installation-and-cache-{0}-{1}-{2}', matrix.python-version, env.POETRY_VERSION, hashFiles('**/poetry.lock'))
       uses: actions/cache/save@v3
       with:
         path: |


### PR DESCRIPTION
Lately the Python 3.10 test CI/CD jobs have been slow (~7 mins), because the Python dependencies have not been available from cache. First occurrence is in the [CI/CD job #308](https://github.com/NatLibFi/Annif/actions/runs/3875121566/jobs/6607220782), however it seems that the reason for the slow-down is introducing the linting job in PR #656, because this job has shared the cache keys with the Python 3.10 test job. This has prevented (re)creating/updating the cache by the test job (with the necessary optional dependencies); the "Post" steps for setup-python and caching steps in the test jobs have had errors like:
```
Failed to save: Unable to reserve cache with key setup-python-Linux-python-3.10.9-poetry-6025e512699131453ed16a5ae9a4be9139ae85329e34f47f750e6fb7af36d308, another job may be creating this cache. More details: Cache already exists.
```

~~To avoid this in the caching step the cache key is appended with `-${{ github.job }}` so the keys are now clearly different in lint and test jobs (`poetry-installation-and-repos-3.10.8-1.2.0-lint` vs. `poetry-installation-and-repos-3.10-1.2.0-test`). In the setup-python action the key cannot be specified, so the fix (for now) is to to pin the Python version to 3.10.8 in the linting job, but in the test job to more relaxed 3.10, which makes the keys different by the patch version (`setup-python-Linux-python-3.10.8-poetry-<hash>` vs. `setup-python-Linux-python-3.10.9-poetry-<hash>`).~~

Now restoring and saving cache is more controlled by using separate [cache/restore](https://github.com/actions/cache/tree/main/restore) and [cache/save](https://github.com/actions/cache/tree/main/save) actions: restoring is performed before every job, but saving only after the test jobs that have various optional dependencies installed.

Also now the cache should be updated/recreated if some dependency has been updated, as the cache key includes hash of the `poetry.lock`. The cache restoration is based on "closest matching" key by using [`restore-keys`](https://github.com/actions/cache/blob/main/caching-strategies.md#using-restore-keys-to-download-the-closest-matching-cache) (the plain `key` is not used at all).

The cache/save step is conditional: it is skipped if there are no changes in dependencies.
        
To make the workflow setup more manageable, the caching, Poetry install and Python setup steps are gathered in one composite action in `.github/actions/prepare/action.yml` file.

