### PR TITLE
Refactor and cleanup CLI module

### DIFF
--- a/annif/cli.py
+++ b/annif/cli.py
@@ -20,6 +20,7 @@ import annif.registry
 from annif.cli_util import (
     backend_param_option,
     common_options,
+    docs_limit_option,
     generate_filter_batches,
     get_project,
     get_vocab,
@@ -169,18 +170,12 @@ def run_load_vocab(vocab_id, language, force, subjectfile):
     help="Reuse preprocessed training data from previous run",
 )
 @click.option(
-    "--docs-limit",
-    "-d",
-    default=None,
-    type=click.IntRange(0, None),
-    help="Maximum number of documents to use",
-)
-@click.option(
     "--jobs",
     "-j",
     default=0,
     help="Number of parallel jobs (0 means choose automatically)",
 )
+@docs_limit_option
 @backend_param_option
 @common_options
 def run_train(project_id, paths, cached, docs_limit, jobs, backend_param):
@@ -210,13 +205,7 @@ def run_train(project_id, paths, cached, docs_limit, jobs, backend_param):
 @cli.command("learn")
 @click.argument("project_id")
 @click.argument("paths", type=click.Path(exists=True), nargs=-1)
-@click.option(
-    "--docs-limit",
-    "-d",
-    default=None,
-    type=click.IntRange(0, None),
-    help="Maximum number of documents to use",
-)
+@docs_limit_option
 @backend_param_option
 @common_options
 def run_learn(project_id, paths, docs_limit, backend_param):
@@ -241,13 +230,7 @@ def run_learn(project_id, paths, docs_limit, backend_param):
 @click.option("--limit", "-l", default=10, help="Maximum number of subjects")
 @click.option("--threshold", "-t", default=0.0, help="Minimum score threshold")
 @click.option("--language", "-L", help="Language of subject labels")
-@click.option(
-    "--docs-limit",
-    "-d",
-    default=None,
-    type=click.IntRange(0, None),
-    help="Maximum number of documents to use",
-)
+@docs_limit_option
 @backend_param_option
 @common_options
 def run_suggest(
@@ -338,13 +321,6 @@ def run_index(
 @click.option("--limit", "-l", default=10, help="Maximum number of subjects")
 @click.option("--threshold", "-t", default=0.0, help="Minimum score threshold")
 @click.option(
-    "--docs-limit",
-    "-d",
-    default=None,
-    type=click.IntRange(0, None),
-    help="Maximum number of documents to use",
-)
-@click.option(
     "--metric",
     "-m",
     default=[],
@@ -368,6 +344,7 @@ def run_index(
 @click.option(
     "--jobs", "-j", default=1, help="Number of parallel jobs (0 means all CPUs)"
 )
+@docs_limit_option
 @backend_param_option
 @common_options
 def run_eval(
@@ -449,13 +426,7 @@ FILTER_BATCH_MAX_LIMIT = 15
 @cli.command("optimize")
 @click.argument("project_id")
 @click.argument("paths", type=click.Path(exists=True), nargs=-1)
-@click.option(
-    "--docs-limit",
-    "-d",
-    default=None,
-    type=click.IntRange(0, None),
-    help="Maximum number of documents to use",
-)
+@docs_limit_option
 @backend_param_option
 @common_options
 def run_optimize(project_id, paths, docs_limit, backend_param):
@@ -536,13 +507,6 @@ def run_optimize(project_id, paths, docs_limit, backend_param):
 @cli.command("hyperopt")
 @click.argument("project_id")
 @click.argument("paths", type=click.Path(exists=True), nargs=-1)
-@click.option(
-    "--docs-limit",
-    "-d",
-    default=None,
-    type=click.IntRange(0, None),
-    help="Maximum number of documents to use",
-)
 @click.option("--trials", "-T", default=10, help="Number of trials")
 @click.option(
     "--jobs", "-j", default=1, help="Number of parallel runs (0 means all CPUs)"
@@ -557,6 +521,7 @@ def run_optimize(project_id, paths, docs_limit, backend_param):
     help="""Specify file path to write trial results as CSV.
     File directory must exist, existing file will be overwritten.""",
 )
+@docs_limit_option
 @common_options
 def run_hyperopt(project_id, paths, docs_limit, trials, jobs, metric, results_file):
     """

--- a/annif/cli.py
+++ b/annif/cli.py
@@ -130,7 +130,7 @@ def run_list_vocabs():
     "-f",
     default=False,
     is_flag=True,
-    help="Replace existing vocabulary completely " + "instead of updating it",
+    help="Replace existing vocabulary completely instead of updating it",
 )
 @common_options
 def run_load_vocab(vocab_id, language, force, subjectfile):
@@ -150,8 +150,7 @@ def run_load_vocab(vocab_id, language, force, subjectfile):
         # probably a TSV file - we need to know its language
         if not language:
             click.echo(
-                "Please use --language option to set the language of "
-                + "a TSV vocabulary.",
+                "Please use --language option to set the language of a TSV vocabulary.",
                 err=True,
             )
             sys.exit(1)

--- a/annif/cli.py
+++ b/annif/cli.py
@@ -10,19 +10,25 @@ import sys
 
 import click
 import click_log
-from flask import current_app
-from flask.cli import FlaskGroup, ScriptInfo
+from flask.cli import FlaskGroup
 
 import annif
 import annif.corpus
 import annif.parallel
 import annif.project
 import annif.registry
-from annif.exception import (
-    ConfigurationException,
-    NotInitializedException,
-    NotSupportedException,
+from annif.cli_util import (
+    backend_param_option,
+    common_options,
+    generate_filter_batches,
+    get_project,
+    get_vocab,
+    open_documents,
+    open_text_documents,
+    parse_backend_params,
+    show_hits,
 )
+from annif.exception import NotInitializedException, NotSupportedException
 from annif.project import Access
 from annif.suggestion import ListSuggestionResult, SuggestionFilter
 from annif.util import metric_code
@@ -32,146 +38,6 @@ click_log.basic_config(logger)
 
 cli = FlaskGroup(create_app=annif.create_app, add_version_option=False)
 cli = click.version_option(message="%(version)s")(cli)
-
-
-def get_project(project_id):
-    """
-    Helper function to get a project by ID and bail out if it doesn't exist"""
-    try:
-        return annif.registry.get_project(project_id, min_access=Access.private)
-    except ValueError:
-        click.echo("No projects found with id '{0}'.".format(project_id), err=True)
-        sys.exit(1)
-
-
-def get_vocab(vocab_id):
-    """
-    Helper function to get a vocabulary by ID and bail out if it doesn't
-    exist"""
-    try:
-        return annif.registry.get_vocab(vocab_id, min_access=Access.private)
-    except ValueError:
-        click.echo(f"No vocabularies found with the id '{vocab_id}'.", err=True)
-        sys.exit(1)
-
-
-def open_documents(paths, subject_index, vocab_lang, docs_limit):
-    """Helper function to open a document corpus from a list of pathnames,
-    each of which is either a TSV file or a directory of TXT files. For
-    directories with subjects in TSV files, the given vocabulary language
-    will be used to convert subject labels into URIs. The corpus will be
-    returned as an instance of DocumentCorpus or LimitingDocumentCorpus."""
-
-    def open_doc_path(path, subject_index):
-        """open a single path and return it as a DocumentCorpus"""
-        if os.path.isdir(path):
-            return annif.corpus.DocumentDirectory(
-                path, subject_index, vocab_lang, require_subjects=True
-            )
-        return annif.corpus.DocumentFile(path, subject_index)
-
-    if len(paths) == 0:
-        logger.warning("Reading empty file")
-        docs = open_doc_path(os.path.devnull, subject_index)
-    elif len(paths) == 1:
-        docs = open_doc_path(paths[0], subject_index)
-    else:
-        corpora = [open_doc_path(path, subject_index) for path in paths]
-        docs = annif.corpus.CombinedCorpus(corpora)
-    if docs_limit is not None:
-        docs = annif.corpus.LimitingDocumentCorpus(docs, docs_limit)
-    return docs
-
-
-def open_text_documents(paths, docs_limit):
-    def _docs(paths):
-        for path in paths:
-            if path == "-":
-                doc = annif.corpus.Document(text=sys.stdin.read(), subject_set=None)
-            else:
-                with open(path, errors="replace", encoding="utf-8-sig") as docfile:
-                    doc = annif.corpus.Document(text=docfile.read(), subject_set=None)
-            yield doc
-
-    return annif.corpus.DocumentList(_docs(paths[:docs_limit]))
-
-
-def show_hits(hits, project, lang, file=None):
-    for hit in hits.as_list():
-        subj = project.subjects[hit.subject_id]
-        line = "<{}>\t{}\t{}".format(
-            subj.uri,
-            "\t".join(filter(None, (subj.labels[lang], subj.notation))),
-            hit.score,
-        )
-        click.echo(line, file=file)
-
-
-def parse_backend_params(backend_param, project):
-    """Parse a list of backend parameters given with the --backend-param
-    option into a nested dict structure"""
-    backend_params = collections.defaultdict(dict)
-    for beparam in backend_param:
-        backend, param = beparam.split(".", 1)
-        key, val = param.split("=", 1)
-        validate_backend_params(backend, beparam, project)
-        backend_params[backend][key] = val
-    return backend_params
-
-
-def validate_backend_params(backend, beparam, project):
-    if backend != project.config["backend"]:
-        raise ConfigurationException(
-            'The backend {} in CLI option "-b {}" not matching the project'
-            " backend {}.".format(backend, beparam, project.config["backend"])
-        )
-
-
-FILTER_BATCH_MAX_LIMIT = 15
-
-
-def generate_filter_batches(subjects):
-    import annif.eval
-
-    filter_batches = collections.OrderedDict()
-    for limit in range(1, FILTER_BATCH_MAX_LIMIT + 1):
-        for threshold in [i * 0.05 for i in range(20)]:
-            hit_filter = SuggestionFilter(subjects, limit, threshold)
-            batch = annif.eval.EvaluationBatch(subjects)
-            filter_batches[(limit, threshold)] = (hit_filter, batch)
-    return filter_batches
-
-
-def set_project_config_file_path(ctx, param, value):
-    """Override the default path or the path given in env by CLI option"""
-    with ctx.ensure_object(ScriptInfo).load_app().app_context():
-        if value:
-            current_app.config["PROJECTS_CONFIG_PATH"] = value
-
-
-def common_options(f):
-    """Decorator to add common options for all CLI commands"""
-    f = click.option(
-        "-p",
-        "--projects",
-        help="Set path to project configuration file or directory",
-        type=click.Path(dir_okay=True, exists=True),
-        callback=set_project_config_file_path,
-        expose_value=False,
-        is_eager=True,
-    )(f)
-    return click_log.simple_verbosity_option(logger)(f)
-
-
-def backend_param_option(f):
-    """Decorator to add an option for CLI commands to override BE parameters"""
-    return click.option(
-        "--backend-param",
-        "-b",
-        multiple=True,
-        help="Override backend parameter of the config file. "
-        + "Syntax: `-b <backend>.<parameter>=<value>`.",
-    )(f)
 
 
 @cli.command("list-projects")
@@ -577,6 +443,9 @@ def run_eval(
         )
 
 
+FILTER_BATCH_MAX_LIMIT = 15
+
+
 @cli.command("optimize")
 @click.argument("project_id")
 @click.argument("paths", type=click.Path(exists=True), nargs=-1)
@@ -603,7 +472,7 @@ def run_optimize(project_id, paths, docs_limit, backend_param):
     project = get_project(project_id)
     backend_params = parse_backend_params(backend_param, project)
 
-    filter_batches = generate_filter_batches(project.subjects)
+    filter_batches = generate_filter_batches(project.subjects, FILTER_BATCH_MAX_LIMIT)
 
     ndocs = 0
     corpus = open_documents(paths, project.subjects, project.vocab_lang, docs_limit)

--- a/annif/cli_util.py
+++ b/annif/cli_util.py
@@ -97,6 +97,13 @@ def open_documents(paths, subject_index, vocab_lang, docs_limit):
 
 
 def open_text_documents(paths, docs_limit):
+    """
+    Helper function to read text documents from the given file paths. Returns a
+    DocumentList object with Documents having no subjects. If a path is "-", the
+    document text is read from standard input. The maximum number of documents to read
+    is set by docs_limit parameter.
+    """
+
     def _docs(paths):
         for path in paths:
             if path == "-":
@@ -110,6 +117,11 @@ def open_text_documents(paths, docs_limit):
 
 
 def show_hits(hits, project, lang, file=None):
+    """
+    Print subject suggestions to the console or a file. The suggestions are displayed as
+    a table, with one row per hit. Each row contains the URI, label, possible notation,
+    and score of the suggestion. The label is given in the specified language.
+    """
     for hit in hits.as_list():
         subj = project.subjects[hit.subject_id]
         line = "<{}>\t{}\t{}".format(

--- a/annif/cli_util.py
+++ b/annif/cli_util.py
@@ -15,7 +15,7 @@ from annif.suggestion import SuggestionFilter
 logger = annif.logger
 
 
-def set_project_config_file_path(ctx, param, value):
+def _set_project_config_file_path(ctx, param, value):
     """Override the default path or the path given in env by CLI option"""
     with ctx.ensure_object(ScriptInfo).load_app().app_context():
         if value:
@@ -29,7 +29,7 @@ def common_options(f):
         "--projects",
         help="Set path to project configuration file or directory",
         type=click.Path(dir_okay=True, exists=True),
-        callback=set_project_config_file_path,
+        callback=_set_project_config_file_path,
         expose_value=False,
         is_eager=True,
     )(f)
@@ -151,12 +151,12 @@ def parse_backend_params(backend_param, project):
     for beparam in backend_param:
         backend, param = beparam.split(".", 1)
         key, val = param.split("=", 1)
-        validate_backend_params(backend, beparam, project)
+        _validate_backend_params(backend, beparam, project)
         backend_params[backend][key] = val
     return backend_params
 
 
-def validate_backend_params(backend, beparam, project):
+def _validate_backend_params(backend, beparam, project):
     if backend != project.config["backend"]:
         raise ConfigurationException(
             'The backend {} in CLI option "-b {}" not matching the project'

--- a/annif/cli_util.py
+++ b/annif/cli_util.py
@@ -1,0 +1,152 @@
+import collections
+import os
+import sys
+
+import click
+import click_log
+from flask import current_app
+from flask.cli import ScriptInfo
+
+import annif
+from annif.exception import ConfigurationException
+from annif.project import Access
+from annif.suggestion import SuggestionFilter
+
+logger = annif.logger
+
+
+def set_project_config_file_path(ctx, param, value):
+    """Override the default path or the path given in env by CLI option"""
+    with ctx.ensure_object(ScriptInfo).load_app().app_context():
+        if value:
+            current_app.config["PROJECTS_CONFIG_PATH"] = value
+
+
+def common_options(f):
+    """Decorator to add common options for all CLI commands"""
+    f = click.option(
+        "-p",
+        "--projects",
+        help="Set path to project configuration file or directory",
+        type=click.Path(dir_okay=True, exists=True),
+        callback=set_project_config_file_path,
+        expose_value=False,
+        is_eager=True,
+    )(f)
+    return click_log.simple_verbosity_option(logger)(f)
+
+
+def backend_param_option(f):
+    """Decorator to add an option for CLI commands to override BE parameters"""
+    return click.option(
+        "--backend-param",
+        "-b",
+        multiple=True,
+        help="Override backend parameter of the config file. "
+        + "Syntax: `-b <backend>.<parameter>=<value>`.",
+    )(f)
+
+
+def get_project(project_id):
+    """
+    Helper function to get a project by ID and bail out if it doesn't exist"""
+    try:
+        return annif.registry.get_project(project_id, min_access=Access.private)
+    except ValueError:
+        click.echo("No projects found with id '{0}'.".format(project_id), err=True)
+        sys.exit(1)
+
+
+def get_vocab(vocab_id):
+    """
+    Helper function to get a vocabulary by ID and bail out if it doesn't
+    exist"""
+    try:
+        return annif.registry.get_vocab(vocab_id, min_access=Access.private)
+    except ValueError:
+        click.echo(f"No vocabularies found with the id '{vocab_id}'.", err=True)
+        sys.exit(1)
+
+
+def open_documents(paths, subject_index, vocab_lang, docs_limit):
+    """Helper function to open a document corpus from a list of pathnames,
+    each of which is either a TSV file or a directory of TXT files. For
+    directories with subjects in TSV files, the given vocabulary language
+    will be used to convert subject labels into URIs. The corpus will be
+    returned as an instance of DocumentCorpus or LimitingDocumentCorpus."""
+
+    def open_doc_path(path, subject_index):
+        """open a single path and return it as a DocumentCorpus"""
+        if os.path.isdir(path):
+            return annif.corpus.DocumentDirectory(
+                path, subject_index, vocab_lang, require_subjects=True
+            )
+        return annif.corpus.DocumentFile(path, subject_index)
+
+    if len(paths) == 0:
+        logger.warning("Reading empty file")
+        docs = open_doc_path(os.path.devnull, subject_index)
+    elif len(paths) == 1:
+        docs = open_doc_path(paths[0], subject_index)
+    else:
+        corpora = [open_doc_path(path, subject_index) for path in paths]
+        docs = annif.corpus.CombinedCorpus(corpora)
+    if docs_limit is not None:
+        docs = annif.corpus.LimitingDocumentCorpus(docs, docs_limit)
+    return docs
+
+
+def open_text_documents(paths, docs_limit):
+    def _docs(paths):
+        for path in paths:
+            if path == "-":
+                doc = annif.corpus.Document(text=sys.stdin.read(), subject_set=None)
+            else:
+                with open(path, errors="replace", encoding="utf-8-sig") as docfile:
+                    doc = annif.corpus.Document(text=docfile.read(), subject_set=None)
+            yield doc
+
+    return annif.corpus.DocumentList(_docs(paths[:docs_limit]))
+
+
+def show_hits(hits, project, lang, file=None):
+    for hit in hits.as_list():
+        subj = project.subjects[hit.subject_id]
+        line = "<{}>\t{}\t{}".format(
+            subj.uri,
+            "\t".join(filter(None, (subj.labels[lang], subj.notation))),
+            hit.score,
+        )
+        click.echo(line, file=file)
+
+
+def parse_backend_params(backend_param, project):
+    """Parse a list of backend parameters given with the --backend-param
+    option into a nested dict structure"""
+    backend_params = collections.defaultdict(dict)
+    for beparam in backend_param:
+        backend, param = beparam.split(".", 1)
+        key, val = param.split("=", 1)
+        validate_backend_params(backend, beparam, project)
+        backend_params[backend][key] = val
+    return backend_params
+
+
+def validate_backend_params(backend, beparam, project):
+    if backend != project.config["backend"]:
+        raise ConfigurationException(
+            'The backend {} in CLI option "-b {}" not matching the project'
+            " backend {}.".format(backend, beparam, project.config["backend"])
+        )
+
+
+def generate_filter_batches(subjects, filter_batch_max_limit):
+    import annif.eval
+
+    filter_batches = collections.OrderedDict()
+    for limit in range(1, filter_batch_max_limit + 1):
+        for threshold in [i * 0.05 for i in range(20)]:
+            hit_filter = SuggestionFilter(subjects, limit, threshold)
+            batch = annif.eval.EvaluationBatch(subjects)
+            filter_batches[(limit, threshold)] = (hit_filter, batch)
+    return filter_batches

--- a/annif/cli_util.py
+++ b/annif/cli_util.py
@@ -143,7 +143,7 @@ def validate_backend_params(backend, beparam, project):
 def generate_filter_batches(subjects, filter_batch_max_limit):
     import annif.eval
 
-    filter_batches = collections.OrderedDict()
+    filter_batches = {}
     for limit in range(1, filter_batch_max_limit + 1):
         for threshold in [i * 0.05 for i in range(20)]:
             hit_filter = SuggestionFilter(subjects, limit, threshold)

--- a/annif/cli_util.py
+++ b/annif/cli_util.py
@@ -47,6 +47,18 @@ def backend_param_option(f):
     )(f)
 
 
+def docs_limit_option(f):
+    """Decorator to add an option for CLI commands to limit the number of documents to
+    use"""
+    return click.option(
+        "--docs-limit",
+        "-d",
+        default=None,
+        type=click.IntRange(0, None),
+        help="Maximum number of documents to use",
+    )(f)
+
+
 def get_project(project_id):
     """
     Helper function to get a project by ID and bail out if it doesn't exist"""

--- a/annif/cli_util.py
+++ b/annif/cli_util.py
@@ -5,7 +5,6 @@ import sys
 import click
 import click_log
 from flask import current_app
-from flask.cli import ScriptInfo
 
 import annif
 from annif.exception import ConfigurationException
@@ -17,7 +16,7 @@ logger = annif.logger
 
 def _set_project_config_file_path(ctx, param, value):
     """Override the default path or the path given in env by CLI option"""
-    with ctx.ensure_object(ScriptInfo).load_app().app_context():
+    with ctx.obj.load_app().app_context():
         if value:
             current_app.config["PROJECTS_CONFIG_PATH"] = value
 


### PR DESCRIPTION
Changes:
- [Move the helper functions & decorators to a new `cli_util.py` module](https://github.com/NatLibFi/Annif/commit/1ccb061ee94e21affe42e0da22372213dae48ee2) (as commented in https://github.com/NatLibFi/Annif/pull/663#discussion_r1095437426)
- [Use dict instead of collections.OrderedDict](https://github.com/NatLibFi/Annif/commit/c01846ac2550d06987d2519d3a0405bd3792248c)
- [Make docs-limit option a common decorator](https://github.com/NatLibFi/Annif/commit/87e42cf1c5e62947ddbdf97ae110bc1fce5208f5)
- [Add a few docstrings to helper functions](https://github.com/NatLibFi/Annif/commit/4d17c89edb53dbaa22c2fe66e05bd509a6ad512c)
- [Cosmetic fix for unnecessarily split strings](https://github.com/NatLibFi/Annif/commit/2e215ab2e991e898cb000accaf57e1a235ea4804)
- [Mark internal helper functions of `cli_util.py` as private with underscore](https://github.com/NatLibFi/Annif/pull/675/commits/a2f7af2fe7dfb881a44b11373f4687e599450bd5)
- [Simplify helper function to set the project config file path](https://github.com/NatLibFi/Annif/pull/675/commits/d1a5043f5aad07c98b5285205e3b0d42895c0dfa)