### PR TITLE
Batch processing in training of NN ensemble - base project suggest calls

### DIFF
--- a/annif/parallel.py
+++ b/annif/parallel.py
@@ -39,16 +39,6 @@ class ProjectSuggestMap:
         self.limit = limit
         self.threshold = threshold
 
-    def suggest(self, doc):
-        filtered_hits = {}
-        for project_id in self.project_ids:
-            project = self.registry.get_project(project_id)
-            hits = project.suggest([doc.text], self.backend_params)[0]
-            filtered_hits[project_id] = hits.filter(
-                project.subjects, self.limit, self.threshold
-            )
-        return (filtered_hits, doc.subject_set)
-
     def suggest_batch(self, batch):
         filtered_hit_sets = defaultdict(list)
         texts, subject_sets = zip(*[(doc.text, doc.subject_set) for doc in batch])

--- a/tests/test_backend_nn_ensemble.py
+++ b/tests/test_backend_nn_ensemble.py
@@ -144,6 +144,30 @@ def test_nn_ensemble_train_cached(registry):
     assert datadir.join("nn-model.h5").size() > 0
 
 
+def test_nn_ensemble_train_two_sources(registry, tmpdir):
+    project = registry.get_project("dummy-en")
+    nn_ensemble_type = annif.backend.get_backend("nn_ensemble")
+    nn_ensemble = nn_ensemble_type(
+        backend_id="nn_ensemble",
+        config_params={"sources": "dummy-en,dummy-fi", "epochs": 1},
+        project=project,
+    )
+
+    tmpfile = tmpdir.join("document.tsv")
+    tmpfile.write(
+        "dummy\thttp://example.org/dummy\n"
+        + "another\thttp://example.org/dummy\n"
+        + "none\thttp://example.org/none\n" * 40
+    )
+    document_corpus = annif.corpus.DocumentFile(str(tmpfile), project.subjects)
+
+    nn_ensemble.train(document_corpus)
+
+    datadir = py.path.local(project.datadir)
+    assert datadir.join("nn-model.h5").exists()
+    assert datadir.join("nn-model.h5").size() > 0
+
+
 def test_nn_ensemble_train_and_learn_params(registry, tmpdir, capfd):
     project = registry.get_project("dummy-en")
     nn_ensemble_type = annif.backend.get_backend("nn_ensemble")


### PR DESCRIPTION
This PR experiments with implementing batched suggest calls for the base projects in NN ensemble backend.

Unfortunately there is no notable performance gain in real use, at least with MLLM, fastText, and Omikuji base projects (as in YSO projects of Finto AI), but actually a performance regression.  Performance gain is seen when using only Omikuji as the base project, which is  [the only one of the backends in Finto AI YSO base models having the batch suggest method implemented](https://github.com/NatLibFi/Annif/pull/669).

Below results are from for runs at kj-kk using 16 jobs training on `corpora/fulltext-train/fi/*/`.

# MLLM, fastText, and Omikuji base projects
##  1000 docs, 1 epoch

|                 | user time | wall time | max rss |
| --------------- | --------- | --------- | ------- |
| before (master) | 1268.63     | 2:25.07   | 14863072  |
| after (PR)      | 1260.37     | 2:24.00   | 14791464  |

## 2000 docs, 10 epochs

|                 | user time | wall time | max rss |
| --------------- | --------- | --------- | ------- |
| before (master) | 4205.64     | 4:41.01   | 15718876  |
| after (PR)      | 4152.09     | 4:58.89   | 15712064  |


# Omikuji base project only
## 2000 docs, 1 epoch

|                 | user time | wall time | max rss |
| --------------- | --------- | --------- | ------- |
| before (master) | 511.38     | 1:23.13  | 7827672  |
| after (PR)      | 336.72     | 1:13.68   | 7612384  |