### PR TITLE
 Batch suggest in ensemble backends

### DIFF
--- a/annif/backend/ensemble.py
+++ b/annif/backend/ensemble.py
@@ -103,8 +103,16 @@ class EnsembleOptimizer(hyperopt.HyperparameterOptimizer):
                 self._source_hits.extend(self._hit_sets_to_list(hit_sets))
 
     def _hit_sets_to_list(self, hit_sets):
-        """Convert a dict of lists of hits to a list of dicts of hits"""
-        return [dict(zip(hit_sets.keys(), hit)) for hit in zip(*hit_sets.values())]
+        """Convert a dict of lists of hits to a list of dicts of hits, e.g.
+        {"proj-1": [p-1-doc-1-hits, p-1-doc-2-hits]
+         "proj-2": [p-2-doc-1-hits, p-2-doc-2-hits]}
+        to
+        [{"proj-1": p-1-doc-1-hits, "proj-2": p-2-doc-1-hits},
+         {"proj-1": p-1-doc-2-hits, "proj-2": p-2-doc-2-hits}]
+        """
+        return [
+            dict(zip(hit_sets.keys(), doc_hits)) for doc_hits in zip(*hit_sets.values())
+        ]
 
     def _normalize(self, hps):
         total = sum(hps.values())

--- a/annif/backend/ensemble.py
+++ b/annif/backend/ensemble.py
@@ -96,11 +96,15 @@ class EnsembleOptimizer(hyperopt.HyperparameterOptimizer):
         jobs, pool_class = annif.parallel.get_pool(n_jobs)
 
         with pool_class(jobs) as pool:
-            for hits, subject_set in pool.imap_unordered(
-                psmap.suggest, self._corpus.documents
+            for hit_sets, subject_sets in pool.imap_unordered(
+                psmap.suggest_batch, self._corpus.doc_batches
             ):
-                self._gold_subjects.append(subject_set)
-                self._source_hits.append(hits)
+                self._gold_subjects.extend(subject_sets)
+                self._source_hits.extend(self._hit_sets_to_list(hit_sets))
+
+    def _hit_sets_to_list(self, hit_sets):
+        """Convert a dict of lists of hits to a list of dicts of hits"""
+        return [dict(zip(hit_sets.keys(), hit)) for hit in zip(*hit_sets.values())]
 
     def _normalize(self, hps):
         total = sum(hps.values())

--- a/annif/backend/nn_ensemble.py
+++ b/annif/backend/nn_ensemble.py
@@ -137,9 +137,9 @@ class NNEnsembleBackend(backend.AnnifLearningBackend, ensemble.BaseEnsembleBacke
                     np.sqrt(hits.as_vector(len(subjects)))
                     * weight
                     * len(hit_sets_from_sources)
-                    for hits, weight, subjects in hits_from_sources
+                    for hits in proj_hit_set
                 ]
-                for hits_from_sources in hit_sets_from_sources
+                for proj_hit_set, weight, subjects in hit_sets_from_sources
             ],
             dtype=np.float32,
         ).transpose(1, 2, 0)

--- a/annif/backend/nn_ensemble.py
+++ b/annif/backend/nn_ensemble.py
@@ -130,6 +130,24 @@ class NNEnsembleBackend(backend.AnnifLearningBackend, ensemble.BaseEnsembleBacke
             model_filename, custom_objects={"MeanLayer": MeanLayer}
         )
 
+    def _suggest_batch_with_sources(self, texts, sources):
+        hit_sets_from_sources = []
+        for project_id, weight in sources:
+            source_project = self.project.registry.get_project(project_id)
+            hit_sets = source_project.suggest(texts)
+            norm_hit_sets = [
+                self._normalize_hits(hits, source_project) for hits in hit_sets
+            ]
+            hit_sets_from_sources.append(
+                [
+                    annif.suggestion.WeightedSuggestion(
+                        hits=norm_hits, weight=weight, subjects=source_project.subjects
+                    )
+                    for norm_hits in norm_hit_sets
+                ]
+            )
+        return hit_sets_from_sources
+
     def _merge_hits_from_sources(self, hit_sets_from_sources, params):
         score_vectors = np.array(
             [
@@ -142,15 +160,13 @@ class NNEnsembleBackend(backend.AnnifLearningBackend, ensemble.BaseEnsembleBacke
                 for hits_from_sources in hit_sets_from_sources
             ],
             dtype=np.float32,
-        ).transpose(0, 2, 1)
+        ).transpose(1, 2, 0)
         results = self._model(score_vectors).numpy()
         return [VectorSuggestionResult(res) for res in results]
 
     def _suggest_batch(self, texts, params):
         sources = annif.util.parse_sources(params["sources"])
-        hit_sets_from_sources = [
-            self._suggest_with_sources(text, sources) for text in texts
-        ]
+        hit_sets_from_sources = self._suggest_batch_with_sources(texts, sources)
         merged_hits = self._merge_hits_from_sources(hit_sets_from_sources, params)
         return merged_hits
 

--- a/annif/backend/nn_ensemble.py
+++ b/annif/backend/nn_ensemble.py
@@ -143,7 +143,7 @@ class NNEnsembleBackend(backend.AnnifLearningBackend, ensemble.BaseEnsembleBacke
             ],
             dtype=np.float32,
         ).transpose(0, 2, 1)
-        results = self._model.predict(score_vectors, verbose=0)
+        results = self._model(score_vectors).numpy()
         return [VectorSuggestionResult(res) for res in results]
 
     def _suggest_batch(self, texts, params):

--- a/annif/backend/nn_ensemble.py
+++ b/annif/backend/nn_ensemble.py
@@ -130,7 +130,7 @@ class NNEnsembleBackend(backend.AnnifLearningBackend, ensemble.BaseEnsembleBacke
             model_filename, custom_objects={"MeanLayer": MeanLayer}
         )
 
-    def _merge_hits_from_sources(self, hit_sets_from_sources, params):
+    def _merge_hit_sets_from_sources(self, hit_sets_from_sources, params):
         score_vectors = np.array(
             [
                 [

--- a/annif/suggestion.py
+++ b/annif/suggestion.py
@@ -7,8 +7,8 @@ import itertools
 import numpy as np
 
 SubjectSuggestion = collections.namedtuple("SubjectSuggestion", "subject_id score")
-WeightedSuggestion = collections.namedtuple(
-    "WeightedSuggestion", "hits weight subjects"
+WeightedSuggestionsBatch = collections.namedtuple(
+    "WeightedSuggestionsBatch", "hit_sets weight subjects"
 )
 
 

--- a/annif/util.py
+++ b/annif/util.py
@@ -54,15 +54,20 @@ def cleanup_uri(uri):
     return uri
 
 
-def merge_hits(weighted_hits, size):
-    """Merge hits from multiple sources. Input is a sequence of WeightedSuggestion
-    objects. The size parameter determines the length of the subject vector.
-    Returns an SuggestionResult object."""
+def merge_hits(weighted_hits_batches, size):
+    """Merge hit sets from multiple sources. Input is a sequence of
+    WeightedSuggestionsBatch objects. The size parameter determines the length of the
+    subject vector. Returns a list of SuggestionResult objects."""
 
-    weights = [whit.weight for whit in weighted_hits]
-    scores = [whit.hits.as_vector(size) for whit in weighted_hits]
-    result = np.average(scores, axis=0, weights=weights)
-    return VectorSuggestionResult(result)
+    weights = [batch.weight for batch in weighted_hits_batches]
+    score_vectors = np.array(
+        [
+            [whits.as_vector(size) for whits in batch.hit_sets]
+            for batch in weighted_hits_batches
+        ]
+    )
+    results = np.average(score_vectors, axis=0, weights=weights)
+    return [VectorSuggestionResult(res) for res in results]
 
 
 def parse_sources(sourcedef):


### PR DESCRIPTION
This adds the `_suggest_batch` method to ensemble backends. 

In all ensemble backends (simple, PAV, NN) the suggestions from the source projects are fetched by using batched suggest calls (this is on project level, so whether a backend actually uses batched suggest depends on the backend).

In case of NN ensemble the prediction (now via `_merge_hit_sets_from_sources`) is performed on the whole batch of the base suggestions in one call of the NN model. The prediction is made using the model's `__call__()` method instead of `predict()` as it is the [recommended way for "small numbers of inputs that fit in one batch"](https://www.tensorflow.org/api_docs/python/tf/keras/Model#predict) and it should offer better performance; this should also fix #674.

Also the [EnsembleOptimizer is made to use batched suggest](https://github.com/NatLibFi/Annif/pull/677/commits/5e392564edd179355d61039cf7e86cecfbe4f7b2). Quickly testing the `hyperopt` command on an ensemble project gives very similar weights and best NDCG scores before and after this PR.

This PR improves somewhat the performance of NN ensemble suggest functionality while the results remain (only nearly?) identical (I think there were small differences in suggestion scores on my laptop). I think most of the increase comes from using `__call__` of the model instead of `predict`.

The below results are from runs at kj-kk using the current Finto AI YSO NN ensemble model (having MLLM, fastText and Omikuji base projects).
# suggest
Targeting 6 times `tests/corpora/archaeology/fulltext/*.txt`:

|                 | user time | wall time | max rss |
| --------------- | --------- | --------- | ------- |
| before (master) | 152.59  |2:35.10   | 13755484 |
| after (PR)      |  135.19  |  2:17.27 | 13757912 |

# eval
Targeting 200 documents from `kirjaesittelyt2021/yso/fin/test`:
## With 1 job
|                 | user time | wall time | max rss |F1@5 |
| --------------- | --------- | --------- | ------- |------- |
| before (master) |  174.79   |2:57.70  | 13816688 | 0.4431|
| after (PR)      | 156.12 |  2:36.77 | 13796932 |0.4431 |

## With 4 jobs
|                 | user time | wall time | max rss |F1@5 |
| --------------- | --------- | --------- | ------- |------- |
| before (master) |  188.21  | 1:45.61 | 13639148 |0.4431 |
| after (PR)      |  172.5   | 1:43.78  | 13606508 |  0.4431|
