### PR TITLE
Change references to default branch: master -> main

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -2,7 +2,7 @@ name: CI/CD
 on:
   push:
     branches:
-    - master
+    - main
     tags:
     - '*'
   pull_request:
@@ -95,7 +95,7 @@ jobs:
     needs: [lint, test]
     runs-on: ubuntu-20.04
     timeout-minutes: 15
-    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
     - name: Login to Quay.io
       uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a  # v2.1.0

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,9 +2,9 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "main" ]
   pull_request:
-    branches: [ "master" ]
+    branches: [ "main" ]
   schedule:
     - cron: "22 11 * * 6"
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ already working on it.
 
 ### Installation for development
 See [Development install in
-README.md](https://github.com/NatLibFi/Annif/blob/master/README.md#development-install)
+README.md](https://github.com/NatLibFi/Annif/blob/main/README.md#development-install)
 or use the [Docker image for
 development](https://github.com/NatLibFi/Annif/wiki/Usage-with-Docker#using-docker-in-annif-development).
 
@@ -51,8 +51,8 @@ flow](https://guides.github.com/introduction/flow/). Feel free to [fork the
 Annif-repository](https://docs.github.com/en/get-started/quickstart/contributing-to-projects)
 for your changes. Some basic principles:
 
-1. The `master` branch is always a working, deployable version of Annif. The code on the
-   `master` branch will eventually be released as the next release.
+1. The `main` branch is always a working, deployable version of Annif. The code on the
+   `main` branch will eventually be released as the next release.
 2. All development happens on feature branches, whether branched from NatLibFi's origin
    or from a fork. Feature branches are normally named according to the issue they are
    addressing: e.g. `issue267-cli-analyze-to-suggest` which implements the change
@@ -71,7 +71,7 @@ for your changes. Some basic principles:
    targeting an issue when applicable, so when the PR is merged, the issue is
    automatically closed.
 5. Feature branches should be deleted after the pull request has been merged.
-6. A new release is made whenever some important changes have landed in `master`.
+6. A new release is made whenever some important changes have landed in `main`.
    Releases are intended to be frequent. See [Release
    process](https://github.com/NatLibFi/Annif/wiki/Release-process) for the details of
    making a release.
@@ -84,7 +84,7 @@ See commit best practices e.g. in
 #### Branches
 
 At any time, these branches typically exist:
-* the `master` branch
+* the `main` branch
 * feature branches under development
 * experimental branches that are not under active development but which we don't want to delete in case the code is later needed
 
@@ -95,7 +95,7 @@ process](https://github.com/NatLibFi/Annif/wiki/Release-process) for details.
 
 ### Unit tests
 Generally, the aim is to cover every line of the codebase with the [unit
-tests](https://github.com/NatLibFi/Annif/tree/master/tests). If you've added new
+tests](https://github.com/NatLibFi/Annif/tree/main/tests). If you've added new
 functionality or you've found out that the existing tests are lacking, we'd be happy if
 you could provide additional tests to cover it. The development dependencies include
 [`pytest`](https://docs.pytest.org/), which you can execute in the project root to run the unit tests:
@@ -110,7 +110,7 @@ When a (draft) PR is opened or new commits are pushed to a branch belonging to a
 unit tests for the code are run in the [GitHub Actions CI/CD pipeline](https://github.com/NatLibFi/Annif/actions/workflows/cicd.yml). The tests are run
 on all the minor versions of Python that Annif aims to support with varying
 configurations of the optional dependencies, see the
-[cicd.yaml](https://github.com/NatLibFi/Annif/blob/master/.github/workflows/cicd.yml)
+[cicd.yaml](https://github.com/NatLibFi/Annif/blob/main/.github/workflows/cicd.yml)
 for the pipeline setup.
 
 ### Code style
@@ -152,7 +152,7 @@ documentation](https://annif.readthedocs.io/en/latest/source/annif.html).
 
 ## Creating a new backend
 Annif backend code is in the
-[annif/backend](https://github.com/NatLibFi/Annif/tree/master/annif/backend) module.
+[annif/backend](https://github.com/NatLibFi/Annif/tree/main/annif/backend) module.
 Each backend is implemented as a subclass of `AnnifBackend`, or its more specific
 subclass `AnnifLearningBackend` (for backends that support online learning) or
 `BaseEnsembleBackend` (for backends that combine results from multiple projects).

--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
 [![DOI](https://zenodo.org/badge/100936800.svg)](https://zenodo.org/badge/latestdoi/100936800)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![CI/CD](https://github.com/NatLibFi/Annif/actions/workflows/cicd.yml/badge.svg)](https://github.com/NatLibFi/Annif/actions/workflows/cicd.yml)
-[![codecov](https://codecov.io/gh/NatLibFi/Annif/branch/master/graph/badge.svg)](https://codecov.io/gh/NatLibFi/Annif)
+[![codecov](https://codecov.io/gh/NatLibFi/Annif/branch/main/graph/badge.svg)](https://codecov.io/gh/NatLibFi/Annif)
 [![Code Climate](https://codeclimate.com/github/NatLibFi/Annif/badges/gpa.svg)](https://codeclimate.com/github/NatLibFi/Annif)
-[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/NatLibFi/Annif/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/NatLibFi/Annif/?branch=master)
-[![codebeat badge](https://codebeat.co/badges/e496f151-93db-4f0e-9e30-bc3339e58ca4)](https://codebeat.co/projects/github-com-natlibfi-annif-master)
+[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/NatLibFi/Annif/badges/quality-score.png?b=main)](https://scrutinizer-ci.com/g/NatLibFi/Annif/?branch=main)
+[![codebeat badge](https://codebeat.co/badges/e496f151-93db-4f0e-9e30-bc3339e58ca4)](https://codebeat.co/projects/github-com-natlibfi-annif-main)
 [![CodeQL](https://github.com/NatLibFi/Annif/actions/workflows/codeql.yml/badge.svg)](https://github.com/NatLibFi/Annif/actions/workflows/codeql.yml)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=NatLibFi_Annif&metric=alert_status)](https://sonarcloud.io/dashboard?id=NatLibFi_Annif)
 [![docs](https://readthedocs.org/projects/annif/badge/?version=latest)](https://annif.readthedocs.io/en/latest/index.html)
@@ -48,7 +48,7 @@ in the wiki for more details.
 
 # Docker install
 
-You can use Annif as a pre-built Docker container. Please see the 
+You can use Annif as a pre-built Docker container. Please see the
 [wiki documentation](https://github.com/NatLibFi/Annif/wiki/Usage-with-Docker)
 for details.
 
@@ -71,11 +71,11 @@ Install [pipx](https://pypa.github.io/pipx/) and Poetry if you don't have them. 
     python3 -m pip install --user pipx
     python3 -m pipx ensurepath
 
-Open a new shell, and then install Poetry: 
+Open a new shell, and then install Poetry:
 
     pipx install poetry
 
-Poetry can be installed also without pipx: check the [Poetry documentation](https://python-poetry.org/docs/master/#installation). 
+Poetry can be installed also without pipx: check the [Poetry documentation](https://python-poetry.org/docs/master/#installation).
 
 Create a virtual environment and install dependencies:
 
@@ -117,14 +117,14 @@ See "Cite this repository" in the details of the repository.
 
 ## Annif articles
 <ul>
-<li> 
-Suominen, O.; Inkinen, J.; Lehtinen, M., 2022. 
+<li>
+Suominen, O.; Inkinen, J.; Lehtinen, M., 2022.
 Annif and Finto AI: Developing and Implementing Automated Subject Indexing.
 JLIS.It, 13(1), pp. 265–282. URL:
 https://www.jlis.it/index.php/jlis/article/view/437
 <details>
 <summary>See BibTex</summary>
-    
+
     @article{suominen2022annif,
       title={Annif and Finto AI: Developing and Implementing Automated Subject Indexing},
       author={Suominen, Osma and Inkinen, Juho and Lehtinen, Mona},
@@ -137,8 +137,8 @@ https://www.jlis.it/index.php/jlis/article/view/437
       url={https://www.jlis.it/index.php/jlis/article/view/437},
     }
 </details>
-</li> 
-<li> 
+</li>
+<li>
 Suominen, O.; Koskenniemi, I, 2022.
 Annif Analyzer Shootout: Comparing text lemmatization methods for automated subject indexing.
 Code4Lib Journal, (54). URL:
@@ -155,8 +155,8 @@ https://journal.code4lib.org/articles/16719
       url={https://journal.code4lib.org/articles/16719},
     }
 </details>
-</li> 
-<li> 
+</li>
+<li>
 Suominen, O., 2019. Annif: DIY automated subject indexing using multiple
 algorithms. LIBER Quarterly, 29(1), pp.1–25. DOI:
 https://doi.org/10.18352/lq.10285

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,7 +6,7 @@
 Welcome to Annif's API documentation!
 =====================================
 
-See `installation instructions <https://github.com/NatLibFi/Annif/blob/master/README.md>`_  and `Wiki pages <https://github.com/NatLibFi/Annif/wiki>`_ in GitHub, and also http://annif.org/.
+See `installation instructions <https://github.com/NatLibFi/Annif/blob/main/README.md>`_  and `Wiki pages <https://github.com/NatLibFi/Annif/wiki>`_ in GitHub, and also http://annif.org/.
 
 You are reading documentation for version |version|.
 


### PR DESCRIPTION
Changes in:
- GH Actions 
  - CI/CD workflow
  - CodeQL workflow
- README.md
- CONTRIBUTING.md
- docs/index.rst (for ReadTheDocs content)

Related to #679.