### PR TITLE
Refactor: Represent suggestion results as sparse arrays

### DIFF
--- a/annif/backend/backend.py
+++ b/annif/backend/backend.py
@@ -85,7 +85,9 @@ class AnnifBackend(metaclass=abc.ABCMeta):
         their operations. This default implementation uses the regular suggest
         functionality."""
         return SuggestionBatch.from_sequence(
-            [self._suggest(text, params) for text in texts], len(self.project.subjects)
+            [self._suggest(text, params) for text in texts],
+            len(self.project.subjects),
+            limit=int(params.get("limit")),
         )
 
     def suggest(self, texts, params=None):

--- a/annif/backend/backend.py
+++ b/annif/backend/backend.py
@@ -86,7 +86,7 @@ class AnnifBackend(metaclass=abc.ABCMeta):
         functionality."""
         return SuggestionBatch.from_sequence(
             [self._suggest(text, params) for text in texts],
-            len(self.project.subjects),
+            self.project.subjects,
             limit=int(params.get("limit")),
         )
 

--- a/annif/backend/backend.py
+++ b/annif/backend/backend.py
@@ -6,6 +6,7 @@ from datetime import datetime, timezone
 from glob import glob
 
 from annif import logger
+from annif.suggestion import SuggestionBatch
 
 
 class AnnifBackend(metaclass=abc.ABCMeta):
@@ -83,7 +84,9 @@ class AnnifBackend(metaclass=abc.ABCMeta):
         """This method can be implemented by backends to use batching of documents in
         their operations. This default implementation uses the regular suggest
         functionality."""
-        return [self._suggest(text, params) for text in texts]
+        return SuggestionBatch(
+            [self._suggest(text, params) for text in texts], len(self.project.subjects)
+        )
 
     def suggest(self, texts, params=None):
         """Suggest subjects for the input documents and return a list of subject sets

--- a/annif/backend/backend.py
+++ b/annif/backend/backend.py
@@ -84,7 +84,7 @@ class AnnifBackend(metaclass=abc.ABCMeta):
         """This method can be implemented by backends to use batching of documents in
         their operations. This default implementation uses the regular suggest
         functionality."""
-        return SuggestionBatch(
+        return SuggestionBatch.from_sequence(
             [self._suggest(text, params) for text in texts], len(self.project.subjects)
         )
 

--- a/annif/backend/dummy.py
+++ b/annif/backend/dummy.py
@@ -1,7 +1,7 @@
 """Dummy backend for testing basic interaction of projects and backends"""
 
 
-from annif.suggestion import ListSuggestionResult, SubjectSuggestion
+from annif.suggestion import SubjectSuggestion
 
 from . import backend
 
@@ -27,7 +27,7 @@ class DummyBackend(backend.AnnifLearningBackend):
 
         # Give no hits for no text
         if len(text) == 0:
-            return ListSuggestionResult([])
+            return []
 
         # allow overriding returned subject via uri parameter
         if "uri" in params:
@@ -35,9 +35,7 @@ class DummyBackend(backend.AnnifLearningBackend):
         else:
             subject_id = self.subject_id
 
-        return ListSuggestionResult(
-            [SubjectSuggestion(subject_id=subject_id, score=score)]
-        )
+        return [SubjectSuggestion(subject_id=subject_id, score=score)]
 
     def _learn(self, corpus, params):
         # in this dummy backend we "learn" by picking up the subject ID

--- a/annif/backend/ensemble.py
+++ b/annif/backend/ensemble.py
@@ -60,7 +60,7 @@ class BaseEnsembleBackend(backend.AnnifBackend):
         hit_sets_from_sources = self._suggest_with_sources(texts, sources)
         return annif.suggestion.SuggestionBatch.from_sequence(
             self._merge_hit_sets_from_sources(hit_sets_from_sources, params),
-            len(self.project.subjects),
+            self.project.subjects,
         )
 
 

--- a/annif/backend/ensemble.py
+++ b/annif/backend/ensemble.py
@@ -43,13 +43,14 @@ class BaseEnsembleBackend(backend.AnnifBackend):
 
         batches = [batch_by_source[project_id] for project_id, _ in sources]
         weights = [weight for _, weight in sources]
-        return SuggestionBatch.from_averaged(batches, weights)
+        return SuggestionBatch.from_averaged(batches, weights).filter(
+            limit=int(params["limit"])
+        )
 
     def _suggest_batch(self, texts, params):
         sources = annif.util.parse_sources(params["sources"])
         batch_by_source = self._suggest_with_sources(texts, sources)
-        merged = self._merge_source_batches(batch_by_source, sources, params)
-        return merged.filter(limit=int(params["limit"]))
+        return self._merge_source_batches(batch_by_source, sources, params)
 
 
 class EnsembleOptimizer(hyperopt.HyperparameterOptimizer):

--- a/annif/backend/ensemble.py
+++ b/annif/backend/ensemble.py
@@ -3,7 +3,6 @@
 
 import annif.eval
 import annif.parallel
-import annif.suggestion
 import annif.util
 from annif.exception import NotSupportedException
 from annif.suggestion import SuggestionBatch

--- a/annif/backend/ensemble.py
+++ b/annif/backend/ensemble.py
@@ -51,7 +51,7 @@ class BaseEnsembleBackend(backend.AnnifBackend):
     def _merge_hit_sets_from_sources(self, hit_sets_from_sources, params):
         """Hook for merging hit sets from sources. Can be overridden by
         subclasses."""
-        return annif.util.merge_hits(hit_sets_from_sources, len(self.project.subjects))
+        return annif.util.merge_hits(hit_sets_from_sources)
 
     def _suggest_batch(self, texts, params):
         sources = annif.util.parse_sources(params["sources"])
@@ -137,9 +137,7 @@ class EnsembleOptimizer(hyperopt.HyperparameterOptimizer):
                     )
                 )
             batch.evaluate_many(
-                annif.util.merge_hits(
-                    weighted_hits, len(self._backend.project.subjects)
-                ),
+                annif.util.merge_hits(weighted_hits),
                 [goldsubj],
             )
         results = batch.results(metrics=[self._metric])

--- a/annif/backend/ensemble.py
+++ b/annif/backend/ensemble.py
@@ -58,7 +58,7 @@ class BaseEnsembleBackend(backend.AnnifBackend):
     def _suggest_batch(self, texts, params):
         sources = annif.util.parse_sources(params["sources"])
         hit_sets_from_sources = self._suggest_with_sources(texts, sources)
-        return annif.suggestion.SuggestionBatch(
+        return annif.suggestion.SuggestionBatch.from_sequence(
             self._merge_hit_sets_from_sources(hit_sets_from_sources, params),
             len(self.project.subjects),
         )

--- a/annif/backend/ensemble.py
+++ b/annif/backend/ensemble.py
@@ -135,11 +135,11 @@ class EnsembleOptimizer(hyperopt.HyperparameterOptimizer):
                         subjects=self._backend.project.subjects,
                     )
                 )
-            batch.evaluate(
+            batch.evaluate_many(
                 annif.util.merge_hits(
                     weighted_hits, len(self._backend.project.subjects)
-                )[0],
-                goldsubj,
+                ),
+                [goldsubj],
             )
         results = batch.results(metrics=[self._metric])
         return results[self._metric]

--- a/annif/backend/ensemble.py
+++ b/annif/backend/ensemble.py
@@ -6,7 +6,7 @@ import annif.parallel
 import annif.suggestion
 import annif.util
 from annif.exception import NotSupportedException
-from annif.suggestion import SuggestionBatch, vector_to_suggestions
+from annif.suggestion import SuggestionBatch
 
 from . import backend, hyperopt
 

--- a/annif/backend/ensemble.py
+++ b/annif/backend/ensemble.py
@@ -28,27 +28,25 @@ class BaseEnsembleBackend(backend.AnnifBackend):
             project = self.project.registry.get_project(project_id)
             project.initialize(parallel)
 
-    def _normalize_hits(self, hits, source_project):
-        """Hook for processing hits from backends. Intended to be overridden
-        by subclasses."""
-        return hits
+    def _normalize_suggestion_batch(self, batch, source_project):
+        """Hook for processing a batch of suggestions from backends.
+        Intended to be overridden by subclasses."""
+        return batch
 
     def _suggest_with_sources(self, texts, sources):
-        hit_sets_from_sources = []
+        batches_from_sources = []
         for project_id, weight in sources:
             source_project = self.project.registry.get_project(project_id)
-            hit_sets = source_project.suggest(texts)
-            norm_hit_sets = [
-                self._normalize_hits(hits, source_project) for hits in hit_sets
-            ]
-            hit_sets_from_sources.append(
+            batch = source_project.suggest(texts)
+            norm_batch = self._normalize_suggestion_batch(batch, source_project)
+            batches_from_sources.append(
                 annif.suggestion.WeightedSuggestionsBatch(
-                    hit_sets=norm_hit_sets,
+                    hit_sets=norm_batch,
                     weight=weight,
                     subjects=source_project.subjects,
                 )
             )
-        return hit_sets_from_sources
+        return batches_from_sources
 
     def _merge_hit_sets_from_sources(self, hit_sets_from_sources, params):
         """Hook for merging hit sets from sources. Can be overridden by

--- a/annif/backend/ensemble.py
+++ b/annif/backend/ensemble.py
@@ -58,7 +58,10 @@ class BaseEnsembleBackend(backend.AnnifBackend):
     def _suggest_batch(self, texts, params):
         sources = annif.util.parse_sources(params["sources"])
         hit_sets_from_sources = self._suggest_with_sources(texts, sources)
-        return self._merge_hit_sets_from_sources(hit_sets_from_sources, params)
+        return annif.suggestion.SuggestionBatch(
+            self._merge_hit_sets_from_sources(hit_sets_from_sources, params),
+            len(self.project.subjects),
+        )
 
 
 class EnsembleOptimizer(hyperopt.HyperparameterOptimizer):

--- a/annif/backend/fasttext.py
+++ b/annif/backend/fasttext.py
@@ -7,7 +7,7 @@ import fasttext
 
 import annif.util
 from annif.exception import NotInitializedException, NotSupportedException
-from annif.suggestion import ListSuggestionResult, SubjectSuggestion
+from annif.suggestion import SubjectSuggestion
 
 from . import backend, mixins
 
@@ -163,4 +163,4 @@ class FastTextBackend(mixins.ChunkingBackend, backend.AnnifBackend):
                     score=score / len(chunktexts),
                 )
             )
-        return ListSuggestionResult(results)
+        return results

--- a/annif/backend/http.py
+++ b/annif/backend/http.py
@@ -9,7 +9,7 @@ import requests
 import requests.exceptions
 
 from annif.exception import OperationFailedException
-from annif.suggestion import ListSuggestionResult, SubjectSuggestion
+from annif.suggestion import SubjectSuggestion
 
 from . import backend
 
@@ -69,13 +69,13 @@ class HTTPBackend(backend.AnnifBackend):
             req.raise_for_status()
         except requests.exceptions.RequestException as err:
             self.warning("HTTP request failed: {}".format(err))
-            return ListSuggestionResult([])
+            return []
 
         try:
             response = req.json()
         except ValueError as err:
             self.warning("JSON decode failed: {}".format(err))
-            return ListSuggestionResult([])
+            return []
 
         if "results" in response:
             results = response["results"]
@@ -93,6 +93,6 @@ class HTTPBackend(backend.AnnifBackend):
             ]
         except (TypeError, ValueError) as err:
             self.warning("Problem interpreting JSON data: {}".format(err))
-            return ListSuggestionResult([])
+            return []
 
-        return ListSuggestionResult(subject_suggestions)
+        return subject_suggestions

--- a/annif/backend/mixins.py
+++ b/annif/backend/mixins.py
@@ -9,7 +9,6 @@ from sklearn.feature_extraction.text import TfidfVectorizer
 
 import annif.util
 from annif.exception import NotInitializedException
-from annif.suggestion import ListSuggestionResult
 
 
 class ChunkingBackend(metaclass=abc.ABCMeta):
@@ -39,7 +38,7 @@ class ChunkingBackend(metaclass=abc.ABCMeta):
             chunktexts.append(" ".join(sentences[i : i + chunksize]))
         self.debug("Split sentences into {} chunks".format(len(chunktexts)))
         if len(chunktexts) == 0:  # no input, empty result
-            return ListSuggestionResult([])
+            return []
         return self._suggest_chunks(chunktexts, params)
 
 

--- a/annif/backend/mllm.py
+++ b/annif/backend/mllm.py
@@ -9,6 +9,7 @@ import annif.eval
 import annif.util
 from annif.exception import NotInitializedException, NotSupportedException
 from annif.lexical.mllm import MLLMModel
+from annif.suggestion import vector_to_suggestions
 
 from . import backend, hyperopt
 
@@ -143,7 +144,7 @@ class MLLMBackend(hyperopt.AnnifHyperoptBackend):
         vector = np.zeros(len(self.project.subjects), dtype=np.float32)
         for score, subject_id in prediction:
             vector[subject_id] = score
-        return vector
+        return vector_to_suggestions(vector, int(params["limit"]))
 
     def _suggest(self, text, params):
         candidates = self._generate_candidates(text)

--- a/annif/backend/mllm.py
+++ b/annif/backend/mllm.py
@@ -9,7 +9,6 @@ import annif.eval
 import annif.util
 from annif.exception import NotInitializedException, NotSupportedException
 from annif.lexical.mllm import MLLMModel
-from annif.suggestion import VectorSuggestionResult
 
 from . import backend, hyperopt
 
@@ -144,7 +143,7 @@ class MLLMBackend(hyperopt.AnnifHyperoptBackend):
         vector = np.zeros(len(self.project.subjects), dtype=np.float32)
         for score, subject_id in prediction:
             vector[subject_id] = score
-        return VectorSuggestionResult(vector)
+        return vector
 
     def _suggest(self, text, params):
         candidates = self._generate_candidates(text)

--- a/annif/backend/mllm.py
+++ b/annif/backend/mllm.py
@@ -48,7 +48,7 @@ class MLLMOptimizer(hyperopt.HyperparameterOptimizer):
             else:
                 ranking = []
             results = self._backend._prediction_to_result(ranking, params)
-            batch.evaluate(results, goldsubj)
+            batch.evaluate_many([results], [goldsubj])
         results = batch.results(metrics=[self._metric])
         return results[self._metric]
 

--- a/annif/backend/mllm.py
+++ b/annif/backend/mllm.py
@@ -144,8 +144,7 @@ class MLLMBackend(hyperopt.AnnifHyperoptBackend):
         vector = np.zeros(len(self.project.subjects), dtype=np.float32)
         for score, subject_id in prediction:
             vector[subject_id] = score
-        result = VectorSuggestionResult(vector)
-        return result.filter(self.project.subjects, limit=int(params["limit"]))
+        return VectorSuggestionResult(vector)
 
     def _suggest(self, text, params):
         candidates = self._generate_candidates(text)

--- a/annif/backend/nn_ensemble.py
+++ b/annif/backend/nn_ensemble.py
@@ -19,7 +19,6 @@ import annif.corpus
 import annif.parallel
 import annif.util
 from annif.exception import NotInitializedException, NotSupportedException
-from annif.suggestion import VectorSuggestionResult
 
 from . import backend, ensemble
 
@@ -143,8 +142,7 @@ class NNEnsembleBackend(backend.AnnifLearningBackend, ensemble.BaseEnsembleBacke
             ],
             dtype=np.float32,
         ).transpose(1, 2, 0)
-        results = self._model(score_vectors).numpy()
-        return [VectorSuggestionResult(res) for res in results]
+        return self._model(score_vectors).numpy()
 
     def _create_model(self, sources):
         self.info("creating NN ensemble model")

--- a/annif/backend/nn_ensemble.py
+++ b/annif/backend/nn_ensemble.py
@@ -133,9 +133,7 @@ class NNEnsembleBackend(backend.AnnifLearningBackend, ensemble.BaseEnsembleBacke
         score_vectors = np.array(
             [
                 [
-                    np.sqrt(hits.as_vector(len(subjects)))
-                    * weight
-                    * len(hit_sets_from_sources)
+                    np.sqrt(hits.as_vector()) * weight * len(hit_sets_from_sources)
                     for hits in proj_hit_set
                 ]
                 for proj_hit_set, weight, subjects in hit_sets_from_sources
@@ -213,7 +211,7 @@ class NNEnsembleBackend(backend.AnnifLearningBackend, ensemble.BaseEnsembleBacke
             ):
                 doc_scores = []
                 for project_id, p_hits in hits.items():
-                    vector = p_hits.as_vector(len(self.project.subjects))
+                    vector = p_hits.as_vector()
                     doc_scores.append(
                         np.sqrt(vector) * sources[project_id] * len(sources)
                     )

--- a/annif/backend/nn_ensemble.py
+++ b/annif/backend/nn_ensemble.py
@@ -19,6 +19,7 @@ import annif.corpus
 import annif.parallel
 import annif.util
 from annif.exception import NotInitializedException, NotSupportedException
+from annif.suggestion import SuggestionBatch, vector_to_suggestions
 
 from . import backend, ensemble
 
@@ -129,18 +130,28 @@ class NNEnsembleBackend(backend.AnnifLearningBackend, ensemble.BaseEnsembleBacke
             model_filename, custom_objects={"MeanLayer": MeanLayer}
         )
 
-    def _merge_hit_sets_from_sources(self, hit_sets_from_sources, params):
+    def _merge_source_batches(self, batch_by_source, sources, params):
+        src_weight = dict(sources)
         score_vectors = np.array(
             [
                 [
-                    np.sqrt(hits.as_vector()) * weight * len(hit_sets_from_sources)
-                    for hits in proj_hit_set
+                    np.sqrt(suggestions.as_vector())
+                    * src_weight[project_id]
+                    * len(batch_by_source)
+                    for suggestions in batch
                 ]
-                for proj_hit_set, weight, subjects in hit_sets_from_sources
+                for project_id, batch in batch_by_source.items()
             ],
             dtype=np.float32,
         ).transpose(1, 2, 0)
-        return self._model(score_vectors).numpy()
+        prediction = self._model(score_vectors).numpy()
+        return SuggestionBatch.from_sequence(
+            [
+                vector_to_suggestions(row, limit=int(params["limit"]))
+                for row in prediction
+            ],
+            self.project.subjects,
+        )
 
     def _create_model(self, sources):
         self.info("creating NN ensemble model")

--- a/annif/backend/omikuji.py
+++ b/annif/backend/omikuji.py
@@ -11,7 +11,7 @@ from annif.exception import (
     NotSupportedException,
     OperationFailedException,
 )
-from annif.suggestion import ListSuggestionResult, SubjectSuggestion, SuggestionBatch
+from annif.suggestion import SubjectSuggestion, SuggestionBatch
 
 from . import backend, mixins
 
@@ -129,11 +129,11 @@ class OmikujiBackend(mixins.TfidfVectorizerMixin, backend.AnnifBackend):
         batch_results = []
         for row in vector:
             if row.nnz == 0:  # All zero vector, empty result
-                batch_results.append(ListSuggestionResult([]))
+                batch_results.append([])
                 continue
             feature_values = [(col, row[0, col]) for col in row.nonzero()[1]]
             results = []
             for subj_id, score in self._model.predict(feature_values, top_k=limit):
                 results.append(SubjectSuggestion(subject_id=subj_id, score=score))
-            batch_results.append(ListSuggestionResult(results))
+            batch_results.append(results)
         return SuggestionBatch.from_sequence(batch_results, self.project.subjects)

--- a/annif/backend/omikuji.py
+++ b/annif/backend/omikuji.py
@@ -136,4 +136,4 @@ class OmikujiBackend(mixins.TfidfVectorizerMixin, backend.AnnifBackend):
             for subj_id, score in self._model.predict(feature_values, top_k=limit):
                 results.append(SubjectSuggestion(subject_id=subj_id, score=score))
             batch_results.append(ListSuggestionResult(results))
-        return SuggestionBatch(batch_results, len(self.project.subjects))
+        return SuggestionBatch.from_sequence(batch_results, len(self.project.subjects))

--- a/annif/backend/omikuji.py
+++ b/annif/backend/omikuji.py
@@ -136,4 +136,4 @@ class OmikujiBackend(mixins.TfidfVectorizerMixin, backend.AnnifBackend):
             for subj_id, score in self._model.predict(feature_values, top_k=limit):
                 results.append(SubjectSuggestion(subject_id=subj_id, score=score))
             batch_results.append(ListSuggestionResult(results))
-        return SuggestionBatch.from_sequence(batch_results, len(self.project.subjects))
+        return SuggestionBatch.from_sequence(batch_results, self.project.subjects)

--- a/annif/backend/omikuji.py
+++ b/annif/backend/omikuji.py
@@ -11,7 +11,7 @@ from annif.exception import (
     NotSupportedException,
     OperationFailedException,
 )
-from annif.suggestion import ListSuggestionResult, SubjectSuggestion
+from annif.suggestion import ListSuggestionResult, SubjectSuggestion, SuggestionBatch
 
 from . import backend, mixins
 
@@ -136,4 +136,4 @@ class OmikujiBackend(mixins.TfidfVectorizerMixin, backend.AnnifBackend):
             for subj_id, score in self._model.predict(feature_values, top_k=limit):
                 results.append(SubjectSuggestion(subject_id=subj_id, score=score))
             batch_results.append(ListSuggestionResult(results))
-        return batch_results
+        return SuggestionBatch(batch_results, len(self.project.subjects))

--- a/annif/backend/pav.py
+++ b/annif/backend/pav.py
@@ -84,7 +84,7 @@ class PAVBackend(ensemble.BaseEnsembleBackend):
         ndocs = 0
         for docid, doc in enumerate(corpus.documents):
             hits = source_project.suggest([doc.text])[0]
-            vector = hits.as_vector(len(source_project.subjects))
+            vector = hits.as_vector()
             for cid in np.flatnonzero(vector):
                 data.append(vector[cid])
                 row.append(docid)

--- a/annif/backend/pav.py
+++ b/annif/backend/pav.py
@@ -60,7 +60,7 @@ class PAVBackend(ensemble.BaseEnsembleBackend):
     def _normalize_hits(self, hits, source_project):
         reg_models = self._get_model(source_project.project_id)
         pav_result = []
-        for hit in hits.as_list():
+        for hit in hits:
             if hit.subject_id in reg_models:
                 score = reg_models[hit.subject_id].predict([hit.score])[0]
             else:  # default to raw score

--- a/annif/backend/stwfsa.py
+++ b/annif/backend/stwfsa.py
@@ -3,7 +3,7 @@ import os
 from stwfsapy.predictor import StwfsapyPredictor
 
 from annif.exception import NotInitializedException, NotSupportedException
-from annif.suggestion import ListSuggestionResult, SubjectSuggestion
+from annif.suggestion import SubjectSuggestion
 from annif.util import atomic_save, boolean
 
 from . import backend
@@ -124,4 +124,4 @@ class StwfsaBackend(backend.AnnifBackend):
                 suggestions.append(
                     SubjectSuggestion(subject_id=subject_id, score=score)
                 )
-        return ListSuggestionResult(suggestions)
+        return suggestions

--- a/annif/backend/svc.py
+++ b/annif/backend/svc.py
@@ -9,7 +9,7 @@ from sklearn.svm import LinearSVC
 
 import annif.util
 from annif.exception import NotInitializedException, NotSupportedException
-from annif.suggestion import ListSuggestionResult, SubjectSuggestion, SuggestionBatch
+from annif.suggestion import SubjectSuggestion, SuggestionBatch
 
 from . import backend, mixins
 
@@ -94,7 +94,7 @@ class SVCBackend(mixins.TfidfVectorizerMixin, backend.AnnifBackend):
                 results.append(
                     SubjectSuggestion(subject_id=subject_id, score=scores[class_id])
                 )
-        return ListSuggestionResult(results)
+        return results
 
     def _suggest_batch(self, texts, params):
         vector = self.vectorizer.transform(texts)
@@ -103,9 +103,7 @@ class SVCBackend(mixins.TfidfVectorizerMixin, backend.AnnifBackend):
         scores_list = scipy.special.expit(confidences)
         return SuggestionBatch.from_sequence(
             [
-                ListSuggestionResult([])
-                if row.nnz == 0
-                else self._scores_to_suggestions(scores, params)
+                [] if row.nnz == 0 else self._scores_to_suggestions(scores, params)
                 for scores, row in zip(scores_list, vector)
             ],
             self.project.subjects,

--- a/annif/backend/svc.py
+++ b/annif/backend/svc.py
@@ -101,7 +101,7 @@ class SVCBackend(mixins.TfidfVectorizerMixin, backend.AnnifBackend):
         confidences = self._model.decision_function(vector)
         # convert to 0..1 score range using logistic function
         scores_list = scipy.special.expit(confidences)
-        return SuggestionBatch(
+        return SuggestionBatch.from_sequence(
             [
                 ListSuggestionResult([])
                 if row.nnz == 0

--- a/annif/backend/svc.py
+++ b/annif/backend/svc.py
@@ -9,7 +9,7 @@ from sklearn.svm import LinearSVC
 
 import annif.util
 from annif.exception import NotInitializedException, NotSupportedException
-from annif.suggestion import ListSuggestionResult, SubjectSuggestion
+from annif.suggestion import ListSuggestionResult, SubjectSuggestion, SuggestionBatch
 
 from . import backend, mixins
 
@@ -101,9 +101,12 @@ class SVCBackend(mixins.TfidfVectorizerMixin, backend.AnnifBackend):
         confidences = self._model.decision_function(vector)
         # convert to 0..1 score range using logistic function
         scores_list = scipy.special.expit(confidences)
-        return [
-            ListSuggestionResult([])
-            if row.nnz == 0
-            else self._scores_to_suggestions(scores, params)
-            for scores, row in zip(scores_list, vector)
-        ]
+        return SuggestionBatch(
+            [
+                ListSuggestionResult([])
+                if row.nnz == 0
+                else self._scores_to_suggestions(scores, params)
+                for scores, row in zip(scores_list, vector)
+            ],
+            len(self.project.subjects),
+        )

--- a/annif/backend/svc.py
+++ b/annif/backend/svc.py
@@ -108,5 +108,5 @@ class SVCBackend(mixins.TfidfVectorizerMixin, backend.AnnifBackend):
                 else self._scores_to_suggestions(scores, params)
                 for scores, row in zip(scores_list, vector)
             ],
-            len(self.project.subjects),
+            self.project.subjects,
         )

--- a/annif/backend/tfidf.py
+++ b/annif/backend/tfidf.py
@@ -9,7 +9,6 @@ from gensim.matutils import Sparse2Corpus
 
 import annif.util
 from annif.exception import NotInitializedException, NotSupportedException
-from annif.suggestion import VectorSuggestionResult
 
 from . import backend, mixins
 
@@ -118,5 +117,4 @@ class TFIDFBackend(mixins.TfidfVectorizerMixin, backend.AnnifBackend):
         )
         tokens = self.project.analyzer.tokenize_words(text)
         vectors = self.vectorizer.transform([" ".join(tokens)])
-        docsim = self._index[vectors[0]]
-        return VectorSuggestionResult(docsim)
+        return self._index[vectors[0]]

--- a/annif/backend/tfidf.py
+++ b/annif/backend/tfidf.py
@@ -9,6 +9,7 @@ from gensim.matutils import Sparse2Corpus
 
 import annif.util
 from annif.exception import NotInitializedException, NotSupportedException
+from annif.suggestion import vector_to_suggestions
 
 from . import backend, mixins
 
@@ -117,4 +118,4 @@ class TFIDFBackend(mixins.TfidfVectorizerMixin, backend.AnnifBackend):
         )
         tokens = self.project.analyzer.tokenize_words(text)
         vectors = self.vectorizer.transform([" ".join(tokens)])
-        return self._index[vectors[0]]
+        return vector_to_suggestions(self._index[vectors[0]], int(params["limit"]))

--- a/annif/backend/tfidf.py
+++ b/annif/backend/tfidf.py
@@ -119,5 +119,4 @@ class TFIDFBackend(mixins.TfidfVectorizerMixin, backend.AnnifBackend):
         tokens = self.project.analyzer.tokenize_words(text)
         vectors = self.vectorizer.transform([" ".join(tokens)])
         docsim = self._index[vectors[0]]
-        fullresult = VectorSuggestionResult(docsim)
-        return fullresult.filter(self.project.subjects, limit=int(params["limit"]))
+        return VectorSuggestionResult(docsim)

--- a/annif/backend/yake.py
+++ b/annif/backend/yake.py
@@ -12,7 +12,7 @@ from rdflib.namespace import SKOS
 
 import annif.util
 from annif.exception import ConfigurationException, NotSupportedException
-from annif.suggestion import ListSuggestionResult, SubjectSuggestion
+from annif.suggestion import SubjectSuggestion
 
 from . import backend
 
@@ -130,7 +130,7 @@ class YakeBackend(backend.AnnifBackend):
             for uri, score in suggestions[:limit]
             if score > 0.0
         ]
-        return ListSuggestionResult(subject_suggestions)
+        return subject_suggestions
 
     def _keyphrases2suggestions(self, keyphrases):
         suggestions = []

--- a/annif/cli.py
+++ b/annif/cli.py
@@ -20,7 +20,6 @@ import annif.registry
 from annif import cli_util
 from annif.exception import NotInitializedException, NotSupportedException
 from annif.project import Access
-from annif.suggestion import SuggestionResults
 from annif.util import metric_code
 
 logger = annif.logger
@@ -467,6 +466,8 @@ def run_optimize(project_id, paths, jobs, docs_limit, backend_param):
             ndocs += len(suggestion_batch[project_id])
             suggestion_batches.append(suggestion_batch[project_id])
             subject_set_batches.append(subject_sets)
+
+    from annif.suggestion import SuggestionResults
 
     orig_suggestion_results = SuggestionResults(suggestion_batches)
 

--- a/annif/cli_util.py
+++ b/annif/cli_util.py
@@ -133,7 +133,7 @@ def show_hits(hits, project, lang, file=None):
     a table, with one row per hit. Each row contains the URI, label, possible notation,
     and score of the suggestion. The label is given in the specified language.
     """
-    for hit in hits.as_list():
+    for hit in hits:
         subj = project.subjects[hit.subject_id]
         line = "<{}>\t{}\t{}".format(
             subj.uri,

--- a/annif/cli_util.py
+++ b/annif/cli_util.py
@@ -1,4 +1,5 @@
 import collections
+import itertools
 import os
 import sys
 
@@ -9,7 +10,6 @@ from flask import current_app
 import annif
 from annif.exception import ConfigurationException
 from annif.project import Access
-from annif.suggestion import SuggestionFilter
 
 logger = annif.logger
 
@@ -163,13 +163,7 @@ def _validate_backend_params(backend, beparam, project):
         )
 
 
-def generate_filter_batches(subjects, filter_batch_max_limit):
-    import annif.eval
-
-    filter_batches = {}
-    for limit in range(1, filter_batch_max_limit + 1):
-        for threshold in [i * 0.05 for i in range(20)]:
-            hit_filter = SuggestionFilter(subjects, limit, threshold)
-            batch = annif.eval.EvaluationBatch(subjects)
-            filter_batches[(limit, threshold)] = (hit_filter, batch)
-    return filter_batches
+def generate_filter_params(filter_batch_max_limit):
+    limits = range(1, filter_batch_max_limit + 1)
+    thresholds = [i * 0.05 for i in range(20)]
+    return list(itertools.product(limits, thresholds))

--- a/annif/corpus/subject.py
+++ b/annif/corpus/subject.py
@@ -273,6 +273,7 @@ class SubjectSet:
         None), otherwise create and return a new one of the given size."""
 
         if destination is None:
+            assert size is not None and size > 0
             destination = np.zeros(size, dtype=bool)
 
         destination[list(self._subject_ids)] = True

--- a/annif/eval.py
+++ b/annif/eval.py
@@ -188,9 +188,11 @@ class EvaluationBatch:
         true_pos = y_true.multiply(y_pred).sum(axis=1)
         false_pos = (y_true < y_pred).sum(axis=1)
         false_neg = (y_true > y_pred).sum(axis=1)
-        precision = np.nan_to_num(true_pos / (true_pos + false_pos))
-        recall = np.nan_to_num(true_pos / (true_pos + false_neg))
-        f1_score = np.nan_to_num(2 * (precision * recall) / (precision + recall))
+
+        with np.errstate(invalid="ignore"):
+            precision = np.nan_to_num(true_pos / (true_pos + false_pos))
+            recall = np.nan_to_num(true_pos / (true_pos + false_neg))
+            f1_score = np.nan_to_num(2 * (precision * recall) / (precision + recall))
 
         zipped = zip(
             [subj.uri for subj in self._subject_index],  # URI

--- a/annif/eval.py
+++ b/annif/eval.py
@@ -73,7 +73,7 @@ class EvaluationBatch:
 
     def evaluate_many(self, suggestion_batch, gold_subject_batch):
         if not isinstance(suggestion_batch, SuggestionBatch):
-            suggestion_batch = SuggestionBatch(
+            suggestion_batch = SuggestionBatch.from_sequence(
                 suggestion_batch, len(self._subject_index)
             )
         self._suggestion_arrays.append(suggestion_batch.array)

--- a/annif/eval.py
+++ b/annif/eval.py
@@ -100,9 +100,6 @@ class EvaluationBatch:
         self._subject_index = subject_index
         self._samples = []
 
-    def evaluate(self, hits, gold_subjects):
-        self._samples.append((hits, gold_subjects))
-
     def evaluate_many(self, hit_sets, gold_subject_sets):
         for hits, gold_subjects in zip(hit_sets, gold_subject_sets):
             self._samples.append((hits, gold_subjects))

--- a/annif/eval.py
+++ b/annif/eval.py
@@ -1,6 +1,5 @@
 """Evaluation metrics for Annif"""
 
-import statistics
 import warnings
 
 import numpy as np

--- a/annif/eval.py
+++ b/annif/eval.py
@@ -73,7 +73,7 @@ class EvaluationBatch:
     def evaluate_many(self, suggestion_batch, gold_subject_batch):
         if not isinstance(suggestion_batch, SuggestionBatch):
             suggestion_batch = SuggestionBatch.from_sequence(
-                suggestion_batch, len(self._subject_index)
+                suggestion_batch, self._subject_index
             )
         self._suggestion_arrays.append(suggestion_batch.array)
 

--- a/annif/eval.py
+++ b/annif/eval.py
@@ -32,19 +32,19 @@ def filter_pred_top_k(preds, limit):
 def true_positives(y_true, y_pred):
     """calculate the number of true positives using bitwise operations,
     emulating the way sklearn evaluation metric functions work"""
-    return int((y_true & y_pred).sum())
+    return int((y_true.multiply(y_pred)).sum())
 
 
 def false_positives(y_true, y_pred):
     """calculate the number of false positives using bitwise operations,
     emulating the way sklearn evaluation metric functions work"""
-    return int((~y_true & y_pred).sum())
+    return int((y_true < y_pred).sum())
 
 
 def false_negatives(y_true, y_pred):
     """calculate the number of false negatives using bitwise operations,
     emulating the way sklearn evaluation metric functions work"""
-    return int((y_true & ~y_pred).sum())
+    return int((y_true > y_pred).sum())
 
 
 def precision_at_k_score(y_true, y_pred, limit):
@@ -122,7 +122,6 @@ class EvaluationBatch:
         y_pred_binary = y_pred > 0.0
         # dense versions of sparse arrays, for functions that need them
         # FIXME: conversion to dense arrays should be avoided
-        y_pred_binary_dense = y_pred_binary.toarray()
         y_pred_dense = y_pred.toarray()
         y_true_dense = y_true.toarray()
 
@@ -181,13 +180,9 @@ class EvaluationBatch:
                 y_true_dense, y_pred_dense, limit=5
             ),
             "LRAP": lambda: label_ranking_average_precision_score(y_true, y_pred_dense),
-            "True positives": lambda: true_positives(y_true_dense, y_pred_binary_dense),
-            "False positives": lambda: false_positives(
-                y_true_dense, y_pred_binary_dense
-            ),
-            "False negatives": lambda: false_negatives(
-                y_true_dense, y_pred_binary_dense
-            ),
+            "True positives": lambda: true_positives(y_true, y_pred_binary),
+            "False positives": lambda: false_positives(y_true, y_pred_binary),
+            "False negatives": lambda: false_negatives(y_true, y_pred_binary),
         }
 
         if not metrics:

--- a/annif/eval.py
+++ b/annif/eval.py
@@ -5,12 +5,7 @@ import warnings
 
 import numpy as np
 import scipy.sparse
-from sklearn.metrics import (
-    f1_score,
-    label_ranking_average_precision_score,
-    precision_score,
-    recall_score,
-)
+from sklearn.metrics import f1_score, precision_score, recall_score
 
 from annif.exception import NotSupportedException
 from annif.suggestion import SuggestionBatch
@@ -107,10 +102,6 @@ class EvaluationBatch:
 
     def _evaluate_samples(self, y_true, y_pred, metrics=[]):
         y_pred_binary = y_pred > 0.0
-        # dense versions of sparse arrays, for functions that need them
-        # FIXME: conversion to dense arrays should be avoided
-        y_pred_dense = y_pred.toarray()
-        y_true_dense = y_true.toarray()
 
         # define the available metrics as lazy lambda functions
         # so we can execute only the ones actually requested
@@ -166,7 +157,6 @@ class EvaluationBatch:
             "Precision@5": lambda: precision_score(
                 y_true, filter_pred_top_k(y_pred, 5) > 0.0, average="samples"
             ),
-            "LRAP": lambda: label_ranking_average_precision_score(y_true, y_pred_dense),
             "True positives": lambda: true_positives(y_true, y_pred_binary),
             "False positives": lambda: false_positives(y_true, y_pred_binary),
             "False negatives": lambda: false_negatives(y_true, y_pred_binary),

--- a/annif/eval.py
+++ b/annif/eval.py
@@ -47,22 +47,6 @@ def false_negatives(y_true, y_pred):
     return int((y_true > y_pred).sum())
 
 
-def precision_at_k_score(y_true, y_pred, limit):
-    """calculate the precision at K, i.e. the number of relevant items
-    among the top K predicted ones"""
-    scores = []
-    for true, pred in zip(y_true, y_pred):
-        order = pred.argsort()[::-1]
-        orderlimit = min(limit, np.count_nonzero(pred))
-        order = order[:orderlimit]
-        gain = true[order]
-        if orderlimit > 0:
-            scores.append(gain.sum() / orderlimit)
-        else:
-            scores.append(0.0)
-    return statistics.mean(scores)
-
-
 def dcg_score(y_true, y_pred, limit=None):
     """return the discounted cumulative gain (DCG) score for the selected
     labels vs. relevant labels"""
@@ -170,14 +154,14 @@ class EvaluationBatch:
             "NDCG": lambda: ndcg_score(y_true_dense, y_pred_dense),
             "NDCG@5": lambda: ndcg_score(y_true_dense, y_pred_dense, limit=5),
             "NDCG@10": lambda: ndcg_score(y_true_dense, y_pred_dense, limit=10),
-            "Precision@1": lambda: precision_at_k_score(
-                y_true_dense, y_pred_dense, limit=1
+            "Precision@1": lambda: precision_score(
+                y_true, filter_pred_top_k(y_pred, 1) > 0.0, average="samples"
             ),
-            "Precision@3": lambda: precision_at_k_score(
-                y_true_dense, y_pred_dense, limit=3
+            "Precision@3": lambda: precision_score(
+                y_true, filter_pred_top_k(y_pred, 3) > 0.0, average="samples"
             ),
-            "Precision@5": lambda: precision_at_k_score(
-                y_true_dense, y_pred_dense, limit=5
+            "Precision@5": lambda: precision_score(
+                y_true, filter_pred_top_k(y_pred, 5) > 0.0, average="samples"
             ),
             "LRAP": lambda: label_ranking_average_precision_score(y_true, y_pred_dense),
             "True positives": lambda: true_positives(y_true, y_pred_binary),

--- a/annif/eval.py
+++ b/annif/eval.py
@@ -8,25 +8,7 @@ from sklearn.metrics import f1_score, precision_score, recall_score
 
 from annif.exception import NotSupportedException
 from annif.suggestion import SuggestionBatch
-
-
-def filter_pred_top_k(preds, limit=None, threshold=0.0):
-    """filter a 2D prediction vector, retaining only the top K suggestions
-    with a score above or equal to the threshold for each individual
-    prediction; the rest will be left as zeros"""
-
-    filtered = scipy.sparse.dok_array(preds.shape, dtype=np.float32)
-    for row in range(preds.shape[0]):
-        arow = preds.getrow(row)
-        top_k = arow.data.argsort()[::-1]
-        if limit is not None:
-            top_k = top_k[:limit]
-        for idx in top_k:
-            val = arow.data[idx]
-            if val < threshold:
-                break
-            filtered[row, arow.indices[idx]] = val
-    return filtered.tocsr()
+from annif.util import filter_suggestion
 
 
 def true_positives(y_true, y_pred):
@@ -148,19 +130,19 @@ class EvaluationBatch:
                 y_true, y_pred_binary, average="micro"
             ),
             "F1@5": lambda: f1_score(
-                y_true, filter_pred_top_k(y_pred, 5) > 0.0, average="samples"
+                y_true, filter_suggestion(y_pred, 5) > 0.0, average="samples"
             ),
             "NDCG": lambda: ndcg_score(y_true, y_pred),
             "NDCG@5": lambda: ndcg_score(y_true, y_pred, limit=5),
             "NDCG@10": lambda: ndcg_score(y_true, y_pred, limit=10),
             "Precision@1": lambda: precision_score(
-                y_true, filter_pred_top_k(y_pred, 1) > 0.0, average="samples"
+                y_true, filter_suggestion(y_pred, 1) > 0.0, average="samples"
             ),
             "Precision@3": lambda: precision_score(
-                y_true, filter_pred_top_k(y_pred, 3) > 0.0, average="samples"
+                y_true, filter_suggestion(y_pred, 3) > 0.0, average="samples"
             ),
             "Precision@5": lambda: precision_score(
-                y_true, filter_pred_top_k(y_pred, 5) > 0.0, average="samples"
+                y_true, filter_suggestion(y_pred, 5) > 0.0, average="samples"
             ),
             "True positives": lambda: true_positives(y_true, y_pred_binary),
             "False positives": lambda: false_positives(y_true, y_pred_binary),

--- a/annif/eval.py
+++ b/annif/eval.py
@@ -7,8 +7,7 @@ import scipy.sparse
 from sklearn.metrics import f1_score, precision_score, recall_score
 
 from annif.exception import NotSupportedException
-from annif.suggestion import SuggestionBatch
-from annif.util import filter_suggestion
+from annif.suggestion import SuggestionBatch, filter_suggestion
 
 
 def true_positives(y_true, y_pred):

--- a/annif/parallel.py
+++ b/annif/parallel.py
@@ -3,7 +3,6 @@
 
 import multiprocessing
 import multiprocessing.dummy
-from collections import defaultdict
 
 # Start method for processes created by the multiprocessing module.
 # A value of None means using the platform-specific default.
@@ -43,23 +42,18 @@ class ProjectSuggestMap:
         filtered_hits = {}
         for project_id in self.project_ids:
             project = self.registry.get_project(project_id)
-            hits = project.suggest([doc.text], self.backend_params)[0]
-            filtered_hits[project_id] = hits.filter(
-                project.subjects, self.limit, self.threshold
-            )
+            batch = project.suggest([doc.text], self.backend_params)
+            filtered_hits[project_id] = batch.filter(self.limit, self.threshold)[0]
         return (filtered_hits, doc.subject_set)
 
     def suggest_batch(self, batch):
-        filtered_hit_sets = defaultdict(list)
+        filtered_hit_sets = {}
         texts, subject_sets = zip(*[(doc.text, doc.subject_set) for doc in batch])
 
         for project_id in self.project_ids:
             project = self.registry.get_project(project_id)
-            hit_sets = project.suggest(texts, self.backend_params)
-            for hits in hit_sets:
-                filtered_hit_sets[project_id].append(
-                    hits.filter(project.subjects, self.limit, self.threshold)
-                )
+            batch = project.suggest(texts, self.backend_params)
+            filtered_hit_sets[project_id] = batch.filter(self.limit, self.threshold)
         return (filtered_hit_sets, subject_sets)
 
 

--- a/annif/project.py
+++ b/annif/project.py
@@ -214,7 +214,8 @@ class AnnifProject(DatadirMixin):
             else:
                 raise NotInitializedException("Project is not trained.")
         texts = [self.transform.transform_text(text) for text in texts]
-        return self._suggest_with_backend(texts, backend_params)
+        suggestions = self._suggest_with_backend(texts, backend_params)
+        return annif.suggestion.SuggestionBatch(suggestions, len(self.subjects))
 
     def train(self, corpus, backend_params=None, jobs=0):
         """train the project using documents from a metadata source"""

--- a/annif/project.py
+++ b/annif/project.py
@@ -214,8 +214,7 @@ class AnnifProject(DatadirMixin):
             else:
                 raise NotInitializedException("Project is not trained.")
         texts = [self.transform.transform_text(text) for text in texts]
-        suggestions = self._suggest_with_backend(texts, backend_params)
-        return annif.suggestion.SuggestionBatch(suggestions, len(self.subjects))
+        return self._suggest_with_backend(texts, backend_params)
 
     def train(self, corpus, backend_params=None, jobs=0):
         """train the project using documents from a metadata source"""

--- a/annif/project.py
+++ b/annif/project.py
@@ -8,7 +8,6 @@ import annif
 import annif.analyzer
 import annif.backend
 import annif.corpus
-import annif.suggestion
 import annif.transform
 from annif.datadir import DatadirMixin
 from annif.exception import (
@@ -203,6 +202,8 @@ class AnnifProject(DatadirMixin):
             self.suggest([doc.text for doc in doc_batch], backend_params)
             for doc_batch in corpus.doc_batches
         )
+        import annif.suggestion
+
         return annif.suggestion.SuggestionResults(suggestions)
 
     def suggest(self, texts, backend_params=None):

--- a/annif/project.py
+++ b/annif/project.py
@@ -1,7 +1,6 @@
 """Project management functionality for Annif"""
 
 import enum
-import itertools
 import os.path
 from shutil import rmtree
 
@@ -204,7 +203,7 @@ class AnnifProject(DatadirMixin):
             self.suggest([doc.text for doc in doc_batch], backend_params)
             for doc_batch in corpus.doc_batches
         )
-        return itertools.chain.from_iterable(suggestions)
+        return annif.suggestion.SuggestionResults(suggestions)
 
     def suggest(self, texts, backend_params=None):
         """Suggest subjects for the given documents batch."""

--- a/annif/rest.py
+++ b/annif/rest.py
@@ -97,9 +97,7 @@ def suggest(project_id, body):
         return server_error(err)
 
     return {
-        "results": [
-            _suggestion_to_dict(hit, project.subjects, lang) for hit in hits.as_list()
-        ]
+        "results": [_suggestion_to_dict(hit, project.subjects, lang) for hit in hits]
     }
 
 

--- a/annif/rest.py
+++ b/annif/rest.py
@@ -9,7 +9,6 @@ import annif.registry
 from annif.corpus import Document, DocumentList, SubjectSet
 from annif.exception import AnnifException
 from annif.project import Access
-from annif.suggestion import SuggestionFilter
 
 
 def project_not_found_error(project_id):
@@ -93,14 +92,14 @@ def suggest(project_id, body):
     threshold = body.get("threshold", 0.0)
 
     try:
-        hit_filter = SuggestionFilter(project.subjects, limit, threshold)
-        result = project.suggest([body["text"]])[0]
+        hits = project.suggest([body["text"]]).filter(limit, threshold)[0]
     except AnnifException as err:
         return server_error(err)
 
-    hits = hit_filter(result).as_list()
     return {
-        "results": [_suggestion_to_dict(hit, project.subjects, lang) for hit in hits]
+        "results": [
+            _suggestion_to_dict(hit, project.subjects, lang) for hit in hits.as_list()
+        ]
     }
 
 

--- a/annif/suggestion.py
+++ b/annif/suggestion.py
@@ -13,20 +13,6 @@ WeightedSuggestionsBatch = collections.namedtuple(
 )
 
 
-class SuggestionFilter:
-    """A reusable filter for filtering SubjectSuggestion objects."""
-
-    def __init__(self, subject_index, limit=None, threshold=0.0):
-        self._subject_index = subject_index
-        self._limit = limit
-        self._threshold = threshold
-
-    def __call__(self, orighits):
-        return LazySuggestionResult(
-            lambda: orighits.filter(self._subject_index, self._limit, self._threshold)
-        )
-
-
 class SuggestionResult(metaclass=abc.ABCMeta):
     """Abstract base class for a set of hits returned by an analysis
     operation."""

--- a/annif/suggestion.py
+++ b/annif/suggestion.py
@@ -43,13 +43,6 @@ class SuggestionResult(metaclass=abc.ABCMeta):
         pass  # pragma: no cover
 
     @abc.abstractmethod
-    def as_vector(self, size, destination=None):
-        """Return the hits as a one-dimensional score vector of given size.
-        If destination array is given (not None) it will be used, otherwise a
-        new array will be created."""
-        pass  # pragma: no cover
-
-    @abc.abstractmethod
     def __len__(self):
         """Return the number of hits with non-zero scores."""
         pass  # pragma: no cover
@@ -85,12 +78,6 @@ class VectorSuggestionResult(SuggestionResult):
             self._lsr = self._vector_to_list_suggestion()
         return iter(self._lsr)
 
-    def as_vector(self, size, destination=None):
-        if destination is not None:
-            np.copyto(destination, self._vector)
-            return destination
-        return self._vector
-
     def __len__(self):
         return (self._vector > 0.0).sum()
 
@@ -112,10 +99,7 @@ class SparseSuggestionResult(SuggestionResult):
             sorted(suggestions, key=lambda suggestion: suggestion.score, reverse=True)
         )
 
-    def as_vector(self, size, destination=None):
-        if destination is not None:
-            print("as_vector called with destination not None")
-            return None
+    def as_vector(self, size):
         return self._array[[self._idx], :].toarray()[0]
 
     def __len__(self):

--- a/annif/suggestion.py
+++ b/annif/suggestion.py
@@ -72,7 +72,7 @@ class VectorSuggestionResult(SuggestionResult):
             if score <= 0.0:
                 break  # we can skip the remaining ones
             hits.append(SubjectSuggestion(subject_id=subject_id, score=float(score)))
-        return ListSuggestionResult(hits)
+        return hits
 
     @property
     def subject_order(self):
@@ -93,40 +93,6 @@ class VectorSuggestionResult(SuggestionResult):
 
     def __len__(self):
         return (self._vector > 0.0).sum()
-
-
-class ListSuggestionResult(SuggestionResult):
-    """SuggestionResult implementation based primarily on lists of hits."""
-
-    def __init__(self, hits):
-        self._list = [self._enforce_score_range(hit) for hit in hits if hit.score > 0.0]
-        self._vector = None
-
-    @staticmethod
-    def _enforce_score_range(hit):
-        if hit.score > 1.0:
-            return hit._replace(score=1.0)
-        return hit
-
-    def _list_to_vector(self, size, destination):
-        if destination is None:
-            destination = np.zeros(size, dtype=np.float32)
-
-        for hit in self._list:
-            if hit.subject_id is not None:
-                destination[hit.subject_id] = hit.score
-        return destination
-
-    def __iter__(self):
-        return iter(self._list)
-
-    def as_vector(self, size, destination=None):
-        if self._vector is None:
-            self._vector = self._list_to_vector(size, destination)
-        return self._vector
-
-    def __len__(self):
-        return len(self._list)
 
 
 class SparseSuggestionResult(SuggestionResult):

--- a/annif/suggestion.py
+++ b/annif/suggestion.py
@@ -140,9 +140,9 @@ class SuggestionBatch:
         ar = dok_array((len(suggestion_results), len(subject_index)), dtype=np.float32)
         for idx, result in enumerate(suggestion_results):
             for suggestion in itertools.islice(result, limit):
-                if suggestion.subject_id in deprecated:
+                if suggestion.subject_id in deprecated or suggestion.score < 0.0:
                     continue
-                ar[idx, suggestion.subject_id] = suggestion.score
+                ar[idx, suggestion.subject_id] = min(suggestion.score, 1.0)
         return cls(ar.tocsr())
 
     def filter(self, limit=None, threshold=0.0):

--- a/annif/suggestion.py
+++ b/annif/suggestion.py
@@ -205,13 +205,13 @@ class SuggestionBatch:
         self.array = array
 
     @classmethod
-    def from_sequence(cls, suggestion_results, vocab_size):
+    def from_sequence(cls, suggestion_results, vocab_size, limit=None):
         """Create a new SuggestionBatch from a sequence of SuggestionResult objects."""
 
         # create a dok_array for fast construction
         ar = dok_array((len(suggestion_results), vocab_size), dtype=np.float32)
         for idx, result in enumerate(suggestion_results):
-            for suggestion in result:
+            for suggestion in itertools.islice(result, limit):
                 ar[idx, suggestion.subject_id] = suggestion.score
         return cls(ar.tocsr())
 

--- a/annif/suggestion.py
+++ b/annif/suggestion.py
@@ -165,13 +165,17 @@ class SuggestionBatch:
         self.array = array
 
     @classmethod
-    def from_sequence(cls, suggestion_results, vocab_size, limit=None):
+    def from_sequence(cls, suggestion_results, subject_index, limit=None):
         """Create a new SuggestionBatch from a sequence of SuggestionResult objects."""
 
+        deprecated = set(subject_index.deprecated_ids())
+
         # create a dok_array for fast construction
-        ar = dok_array((len(suggestion_results), vocab_size), dtype=np.float32)
+        ar = dok_array((len(suggestion_results), len(subject_index)), dtype=np.float32)
         for idx, result in enumerate(suggestion_results):
             for suggestion in itertools.islice(result, limit):
+                if suggestion.subject_id in deprecated:
+                    continue
                 ar[idx, suggestion.subject_id] = suggestion.score
         return cls(ar.tocsr())
 

--- a/annif/suggestion.py
+++ b/annif/suggestion.py
@@ -48,7 +48,7 @@ class SuggestionResult:
             sorted(suggestions, key=lambda suggestion: suggestion.score, reverse=True)
         )
 
-    def as_vector(self, size):
+    def as_vector(self):
         return self._array[[self._idx], :].toarray()[0]
 
     def __len__(self):

--- a/annif/suggestion.py
+++ b/annif/suggestion.py
@@ -242,7 +242,7 @@ class SuggestionBatch:
                 ar[idx, suggestion.subject_id] = suggestion.score
         return cls(ar.tocsr())
 
-    def filter(self, subject_index, limit=None, threshold=0.0):
+    def filter(self, limit=None, threshold=0.0):
         """Return a subset of the hits, filtered by the given limit and
         score threshold, as another SuggestionBatch object."""
 

--- a/annif/suggestion.py
+++ b/annif/suggestion.py
@@ -32,8 +32,8 @@ def filter_suggestion(preds, limit=None, threshold=0.0):
     return filtered.tocsr()
 
 
-class SparseSuggestionResult:
-    """SuggestionResult implementation backed by a single row of a sparse array."""
+class SuggestionResult:
+    """Suggestions for a single document, backed by a row of a sparse array."""
 
     def __init__(self, array, idx):
         self._array = array
@@ -100,7 +100,7 @@ class SuggestionBatch:
     def __getitem__(self, idx):
         if idx < 0 or idx >= len(self):
             raise IndexError
-        return SparseSuggestionResult(self.array, idx)
+        return SuggestionResult(self.array, idx)
 
     def __len__(self):
         return self.array.shape[0]

--- a/annif/suggestion.py
+++ b/annif/suggestion.py
@@ -7,9 +7,6 @@ import numpy as np
 from scipy.sparse import csr_array, dok_array
 
 SubjectSuggestion = collections.namedtuple("SubjectSuggestion", "subject_id score")
-WeightedSuggestionsBatch = collections.namedtuple(
-    "WeightedSuggestionsBatch", "hit_sets weight subjects"
-)
 
 
 def vector_to_suggestions(vector, limit):

--- a/annif/suggestion.py
+++ b/annif/suggestion.py
@@ -5,7 +5,7 @@ import collections
 import itertools
 
 import numpy as np
-from scipy.sparse import csr_array, dok_array
+from scipy.sparse import dok_array
 
 SubjectSuggestion = collections.namedtuple("SubjectSuggestion", "subject_id score")
 WeightedSuggestionsBatch = collections.namedtuple(
@@ -257,3 +257,24 @@ class SuggestionBatch:
 
     def __len__(self):
         return self.array.shape[0]
+
+
+class SuggestionResults:
+    """Subject suggestions for a potentially very large number of documents."""
+
+    def __init__(self, batches):
+        """Initialize a new SuggestionResults from an iterable that provides
+        SuggestionBatch objects."""
+
+        self.batches = batches
+
+    def filter(self, limit=None, threshold=0.0):
+        """Return a view of these suggestions, filtered by the given limit
+        and/or threshold, as another SuggestionResults object."""
+
+        return SuggestionResults(
+            (batch.filter(limit, threshold) for batch in self.batches)
+        )
+
+    def __iter__(self):
+        return iter(itertools.chain.from_iterable(self.batches))

--- a/annif/suggestion.py
+++ b/annif/suggestion.py
@@ -1,6 +1,5 @@
 """Representing suggested subjects."""
 
-import abc
 import collections
 import itertools
 

--- a/annif/suggestion.py
+++ b/annif/suggestion.py
@@ -13,13 +13,11 @@ WeightedSuggestionsBatch = collections.namedtuple(
 
 
 def vector_to_suggestions(vector, limit):
-    hits = []
-    for subject_id in np.argsort(vector)[::-1][:limit]:
-        score = vector[subject_id]
-        if score <= 0.0:
-            break  # we can skip the remaining ones
-        hits.append(SubjectSuggestion(subject_id=subject_id, score=float(score)))
-    return hits
+    limit = min(len(vector), limit)
+    topk_idx = np.argpartition(vector, -limit)[-limit:]
+    return (
+        SubjectSuggestion(subject_id=idx, score=float(vector[idx])) for idx in topk_idx
+    )
 
 
 def filter_suggestion(preds, limit=None, threshold=0.0):

--- a/annif/suggestion.py
+++ b/annif/suggestion.py
@@ -42,38 +42,6 @@ class SuggestionResult(metaclass=abc.ABCMeta):
         pass  # pragma: no cover
 
 
-class LazySuggestionResult(SuggestionResult):
-    """SuggestionResult implementation that wraps another SuggestionResult which
-    is initialized lazily only when it is actually accessed. Method calls
-    will be proxied to the wrapped SuggestionResult."""
-
-    def __init__(self, construct):
-        """Create the proxy object. The given construct function will be
-        called to create the actual SuggestionResult when it is needed."""
-        self._construct = construct
-        self._object = None
-
-    def _initialize(self):
-        if self._object is None:
-            self._object = self._construct()
-
-    def as_list(self):
-        self._initialize()
-        return self._object.as_list()
-
-    def as_vector(self, size, destination=None):
-        self._initialize()
-        return self._object.as_vector(size, destination)
-
-    def filter(self, subject_index, limit=None, threshold=0.0):
-        self._initialize()
-        return self._object.filter(subject_index, limit, threshold)
-
-    def __len__(self):
-        self._initialize()
-        return len(self._object)
-
-
 class VectorSuggestionResult(SuggestionResult):
     """SuggestionResult implementation based primarily on NumPy vectors."""
 

--- a/annif/suggestion.py
+++ b/annif/suggestion.py
@@ -87,6 +87,16 @@ class SuggestionBatch:
                 ar[idx, suggestion.subject_id] = min(suggestion.score, 1.0)
         return cls(ar.tocsr())
 
+    @classmethod
+    def from_averaged(cls, batches, weights):
+        """Create a new SuggestionBatch where the subject scores are the
+        weighted average of scores in several SuggestionBatches"""
+
+        avg_array = sum(
+            [batch.array * weight for batch, weight in zip(batches, weights)]
+        ) / sum(weights)
+        return SuggestionBatch(avg_array)
+
     def filter(self, limit=None, threshold=0.0):
         """Return a subset of the hits, filtered by the given limit and
         score threshold, as another SuggestionBatch object."""

--- a/annif/util.py
+++ b/annif/util.py
@@ -7,7 +7,6 @@ import os.path
 import tempfile
 
 import numpy as np
-import scipy.sparse
 
 from annif import logger
 from annif.suggestion import VectorSuggestionResult
@@ -123,22 +122,3 @@ def identity(x):
 def metric_code(metric):
     """Convert a human-readable metric name into an alphanumeric string"""
     return metric.translate(metric.maketrans(" ", "_", "()"))
-
-
-def filter_suggestion(preds, limit=None, threshold=0.0):
-    """filter a 2D sparse suggestion array (csr_array), retaining only the
-    top K suggestions with a score above or equal to the threshold for each
-    individual prediction; the rest will be left as zeros"""
-
-    filtered = scipy.sparse.dok_array(preds.shape, dtype=np.float32)
-    for row in range(preds.shape[0]):
-        arow = preds.getrow(row)
-        top_k = arow.data.argsort()[::-1]
-        if limit is not None:
-            top_k = top_k[:limit]
-        for idx in top_k:
-            val = arow.data[idx]
-            if val < threshold:
-                break
-            filtered[row, arow.indices[idx]] = val
-    return filtered.tocsr()

--- a/annif/util.py
+++ b/annif/util.py
@@ -53,15 +53,14 @@ def cleanup_uri(uri):
     return uri
 
 
-def merge_hits(weighted_hits_batches, size):
+def merge_hits(weighted_hits_batches):
     """Merge hit sets from multiple sources. Input is a sequence of
-    WeightedSuggestionsBatch objects. The size parameter determines the length of the
-    subject vector. Returns a list of SuggestionResult objects."""
+    WeightedSuggestionsBatch objects. Returns a NumPy array."""
 
     weights = [batch.weight for batch in weighted_hits_batches]
     score_vectors = np.array(
         [
-            [whits.as_vector(size) for whits in batch.hit_sets]
+            [whits.as_vector() for whits in batch.hit_sets]
             for batch in weighted_hits_batches
         ]
     )

--- a/annif/util.py
+++ b/annif/util.py
@@ -6,8 +6,6 @@ import os
 import os.path
 import tempfile
 
-import numpy as np
-
 from annif import logger
 
 
@@ -51,20 +49,6 @@ def cleanup_uri(uri):
     if uri.startswith("<") and uri.endswith(">"):
         return uri[1:-1]
     return uri
-
-
-def merge_hits(weighted_hits_batches):
-    """Merge hit sets from multiple sources. Input is a sequence of
-    WeightedSuggestionsBatch objects. Returns a NumPy array."""
-
-    weights = [batch.weight for batch in weighted_hits_batches]
-    score_vectors = np.array(
-        [
-            [whits.as_vector() for whits in batch.hit_sets]
-            for batch in weighted_hits_batches
-        ]
-    )
-    return np.average(score_vectors, axis=0, weights=weights)
 
 
 def parse_sources(sourcedef):

--- a/annif/util.py
+++ b/annif/util.py
@@ -9,7 +9,6 @@ import tempfile
 import numpy as np
 
 from annif import logger
-from annif.suggestion import VectorSuggestionResult
 
 
 class DuplicateFilter(logging.Filter):
@@ -66,8 +65,7 @@ def merge_hits(weighted_hits_batches, size):
             for batch in weighted_hits_batches
         ]
     )
-    results = np.average(score_vectors, axis=0, weights=weights)
-    return [VectorSuggestionResult(res) for res in results]
+    return np.average(score_vectors, axis=0, weights=weights)
 
 
 def parse_sources(sourcedef):

--- a/annif/util.py
+++ b/annif/util.py
@@ -7,6 +7,7 @@ import os.path
 import tempfile
 
 import numpy as np
+import scipy.sparse
 
 from annif import logger
 from annif.suggestion import VectorSuggestionResult
@@ -122,3 +123,22 @@ def identity(x):
 def metric_code(metric):
     """Convert a human-readable metric name into an alphanumeric string"""
     return metric.translate(metric.maketrans(" ", "_", "()"))
+
+
+def filter_suggestion(preds, limit=None, threshold=0.0):
+    """filter a 2D sparse suggestion array (csr_array), retaining only the
+    top K suggestions with a score above or equal to the threshold for each
+    individual prediction; the rest will be left as zeros"""
+
+    filtered = scipy.sparse.dok_array(preds.shape, dtype=np.float32)
+    for row in range(preds.shape[0]):
+        arow = preds.getrow(row)
+        top_k = arow.data.argsort()[::-1]
+        if limit is not None:
+            top_k = top_k[:limit]
+        for idx in top_k:
+            val = arow.data[idx]
+            if val < threshold:
+                break
+            filtered[row, arow.indices[idx]] = val
+    return filtered.tocsr()

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -19,7 +19,7 @@ def test_get_backend_dummy(project, dummy_subject_index):
     dummy = dummy_type(backend_id="dummy", config_params={}, project=project)
     result = dummy.suggest(["this is some text"])[0]
     assert len(result) == 1
-    hits = result.as_list()
+    hits = list(result)
     assert hits[0].subject_id == dummy_subject_index.by_uri("http://example.org/dummy")
     assert hits[0].score == 1.0
 
@@ -38,7 +38,7 @@ def test_learn_dummy(project, tmpdir):
 
     result = dummy.suggest(["this is some text"])[0]
     assert len(result) == 1
-    hits = result.as_list()
+    hits = list(result)
     assert hits[0].subject_id is not None
     assert hits[0].subject_id == project.subjects.by_uri(
         "http://www.yso.fi/onto/yso/p10849"

--- a/tests/test_backend_fasttext.py
+++ b/tests/test_backend_fasttext.py
@@ -193,6 +193,5 @@ def test_fasttext_suggest(project):
     )[0]
 
     assert len(results) > 0
-    hits = results.as_list()
     archaeology = project.subjects.by_uri("http://www.yso.fi/onto/yso/p1265")
-    assert archaeology in [result.subject_id for result in hits]
+    assert archaeology in [result.subject_id for result in results]

--- a/tests/test_backend_fasttext.py
+++ b/tests/test_backend_fasttext.py
@@ -195,3 +195,23 @@ def test_fasttext_suggest(project):
     assert len(results) > 0
     archaeology = project.subjects.by_uri("http://www.yso.fi/onto/yso/p1265")
     assert archaeology in [result.subject_id for result in results]
+
+
+def test_fasttext_suggest_empty_chunks(project):
+    fasttext_type = annif.backend.get_backend("fasttext")
+    fasttext = fasttext_type(
+        backend_id="fasttext",
+        config_params={
+            "limit": 50,
+            "chunksize": 1,
+            "dim": 100,
+            "lr": 0.25,
+            "epoch": 20,
+            "loss": "hs",
+        },
+        project=project,
+    )
+
+    results = fasttext.suggest([""])[0]
+
+    assert len(results) == 0

--- a/tests/test_backend_http.py
+++ b/tests/test_backend_http.py
@@ -33,7 +33,7 @@ def test_http_suggest(app_project):
         )
         result = http.suggest(["this is some text"])[0]
         assert len(result) == 1
-        hits = result.as_list()
+        hits = list(result)
         assert hits[0].subject_id is not None
         assert hits[0].subject_id == app_project.subjects.by_uri(
             "http://example.org/dummy"
@@ -76,7 +76,7 @@ def test_http_suggest_with_results(app_project):
 
         result = http.suggest(["this is some text"])[0]
         assert len(result) == 1
-        hits = result.as_list()
+        hits = list(result)
         assert hits[0].subject_id is not None
         assert hits[0].subject_id == http.project.subjects.by_uri(
             "http://example.org/dummy-with-notation"

--- a/tests/test_backend_mllm.py
+++ b/tests/test_backend_mllm.py
@@ -91,9 +91,8 @@ def test_mllm_suggest(project):
 
     assert len(results) > 0
     assert len(results) <= 8
-    hits = results.as_list()
     archaeology = project.subjects.by_uri("http://www.yso.fi/onto/yso/p1265")
-    assert archaeology in [result.subject_id for result in hits]
+    assert archaeology in [result.subject_id for result in results]
 
 
 def test_mllm_suggest_no_matches(project):

--- a/tests/test_backend_omikuji.py
+++ b/tests/test_backend_omikuji.py
@@ -134,9 +134,8 @@ def test_omikuji_suggest(project):
 
     assert len(results) > 0
     assert len(results) <= 8
-    hits = results.as_list()
     archaeology = project.subjects.by_uri("http://www.yso.fi/onto/yso/p1265")
-    assert archaeology in [result.subject_id for result in hits]
+    assert archaeology in [result.subject_id for result in results]
 
 
 def test_omikuji_suggest_no_input(project):

--- a/tests/test_backend_stwfsa.py
+++ b/tests/test_backend_stwfsa.py
@@ -108,6 +108,5 @@ def test_stwfsa_suggest(project, datadir):
         ]
     )[0]
     assert len(results) == 10
-    hits = results.as_list()
     labyrinths = project.subjects.by_uri("http://www.yso.fi/onto/yso/p14174")
-    assert labyrinths in [result.subject_id for result in hits]
+    assert labyrinths in [result.subject_id for result in results]

--- a/tests/test_backend_stwfsa.py
+++ b/tests/test_backend_stwfsa.py
@@ -60,7 +60,7 @@ def test_empty_corpus(project):
     corpus = annif.corpus.DocumentList([])
     stwfsa_type = get_backend(StwfsaBackend.name)
     stwfsa = stwfsa_type(
-        backend_id=StwfsaBackend.name, config_params=dict(), project=project
+        backend_id=StwfsaBackend.name, config_params={"limit": 10}, project=project
     )
     with pytest.raises(NotSupportedException):
         stwfsa.train(corpus)
@@ -70,7 +70,7 @@ def test_cached_corpus(project):
     corpus = "cached"
     stwfsa_type = get_backend(StwfsaBackend.name)
     stwfsa = stwfsa_type(
-        backend_id=StwfsaBackend.name, config_params=dict(), project=project
+        backend_id=StwfsaBackend.name, config_params={"limit": 10}, project=project
     )
     with pytest.raises(NotSupportedException):
         stwfsa.train(corpus)
@@ -79,7 +79,7 @@ def test_cached_corpus(project):
 def test_stwfsa_suggest_unknown(project):
     stwfsa_type = get_backend(StwfsaBackend.name)
     stwfsa = stwfsa_type(
-        backend_id=StwfsaBackend.name, config_params=dict(), project=project
+        backend_id=StwfsaBackend.name, config_params={"limit": 10}, project=project
     )
     results = stwfsa.suggest(["1234"])[0]
     assert len(results) == 0
@@ -88,7 +88,7 @@ def test_stwfsa_suggest_unknown(project):
 def test_stwfsa_suggest(project, datadir):
     stwfsa_type = get_backend(StwfsaBackend.name)
     stwfsa = stwfsa_type(
-        backend_id=StwfsaBackend.name, config_params=dict(), project=project
+        backend_id=StwfsaBackend.name, config_params={"limit": 10}, project=project
     )
     # Just some randomly selected words, taken from YSO archaeology group.
     # And "random" words between them

--- a/tests/test_backend_svc.py
+++ b/tests/test_backend_svc.py
@@ -75,9 +75,8 @@ def test_svc_suggest(project):
 
     assert len(results) > 0
     assert len(results) <= 20
-    hits = results.as_list()
     archaeologists = project.subjects.by_uri("http://www.yso.fi/onto/yso/p10849")
-    assert archaeologists in [result.subject_id for result in hits]
+    assert archaeologists in [result.subject_id for result in results]
 
 
 def test_svc_suggest_no_input(project):

--- a/tests/test_backend_tfidf.py
+++ b/tests/test_backend_tfidf.py
@@ -41,9 +41,8 @@ def test_tfidf_suggest(project):
     )[0]
 
     assert len(results) == 10
-    hits = results.as_list()
     archaeology = project.subjects.by_uri("http://www.yso.fi/onto/yso/p1265")
-    assert archaeology in [result.subject_id for result in hits]
+    assert archaeology in [result.subject_id for result in results]
 
 
 def test_suggest_params(project):

--- a/tests/test_backend_yake.py
+++ b/tests/test_backend_yake.py
@@ -39,9 +39,8 @@ def test_yake_suggest(project):
 
     assert len(results) > 0
     assert len(results) <= 8
-    hits = results.as_list()
     archaeology = project.subjects.by_uri("http://www.yso.fi/onto/yso/p1265")
-    assert archaeology in [result.subject_id for result in hits]
+    assert archaeology in [result.subject_id for result in results]
 
 
 def test_yake_suggest_no_input(project):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -436,7 +436,7 @@ def test_suggest_param():
         input="kissa",
     )
     assert not result.exception
-    assert result.output == "<http://example.org/dummy>\tdummy-fi\t0.8\n"
+    assert result.output.startswith("<http://example.org/dummy>\tdummy-fi\t0.8")
     assert result.exit_code == 0
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -640,8 +640,6 @@ def test_eval_label(tmpdir):
     assert float(precision3.group(1)) == 0.5
     precision5 = re.search(r"Precision@5:\s+(\d.\d+)", result.output)
     assert float(precision5.group(1)) == 0.5
-    lrap = re.search(r"LRAP:\s+(\d.\d+)", result.output)
-    assert float(lrap.group(1)) == 0.75
     true_positives = re.search(r"True positives:\s+(\d+)", result.output)
     assert int(true_positives.group(1)) == 1
     false_positives = re.search(r"False positives:\s+(\d+)", result.output)
@@ -675,8 +673,6 @@ def test_eval_uri(tmpdir):
     assert float(precision3.group(1)) == 0.5
     precision5 = re.search(r"Precision@5:\s+(\d.\d+)", result.output)
     assert float(precision5.group(1)) == 0.5
-    lrap = re.search(r"LRAP:\s+(\d.\d+)", result.output)
-    assert float(lrap.group(1)) == 0.75
     true_positives = re.search(r"True positives:\s+(\d+)", result.output)
     assert int(true_positives.group(1)) == 1
     false_positives = re.search(r"False positives:\s+(\d+)", result.output)

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -7,10 +7,22 @@ import annif.eval
 import annif.suggestion
 
 
-def test_filter_pred_top_k():
+def test_filter_pred_top_k_limit():
     pred = csr_array([[0, 1, 3, 2], [1, 4, 3, 0]])
-    filtered = annif.eval.filter_pred_top_k(pred, 2)
+    filtered = annif.eval.filter_pred_top_k(pred, limit=2)
     assert filtered.toarray().tolist() == [[0, 0, 3, 2], [0, 4, 3, 0]]
+
+
+def test_filter_pred_top_k_threshold():
+    pred = csr_array([[0, 1, 3, 2], [1, 4, 3, 0]])
+    filtered = annif.eval.filter_pred_top_k(pred, threshold=2)
+    assert filtered.toarray().tolist() == [[0, 0, 3, 2], [0, 4, 3, 0]]
+
+
+def test_filter_pred_top_k_limit_and_threshold():
+    pred = csr_array([[0, 1, 3, 2], [1, 4, 3, 0]])
+    filtered = annif.eval.filter_pred_top_k(pred, limit=2, threshold=3)
+    assert filtered.toarray().tolist() == [[0, 0, 3, 0], [0, 4, 3, 0]]
 
 
 def test_true_positives():

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -145,8 +145,6 @@ def test_evaluation_batch(subject_index, tmpdir):
     results = batch.results(results_file=outfile.open("w"), language="en")
     assert results["Precision (doc avg)"] == 0.5
     assert results["Recall (doc avg)"] == 0.5
-    assert results["LRAP"] >= 0.50
-    assert results["LRAP"] <= 0.51
     assert results["True positives"] == 1
     assert results["False positives"] == 1
     assert results["False negatives"] == 1

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -15,37 +15,37 @@ def test_filter_pred_top_k():
 
 
 def test_true_positives():
-    y_true = np.array([[True, False, True, False, True, False]])
-    y_pred = np.array([[True, True, False, True, True, False]])
+    y_true = csr_array([[True, False, True, False, True, False]])
+    y_pred = csr_array([[True, True, False, True, True, False]])
     tp = annif.eval.true_positives(y_true, y_pred)
     assert tp == 2
 
-    y_true = np.array([[True, True, False, True, True, False]])
-    y_pred = np.array([[True, False, True, True, True, False]])
+    y_true = csr_array([[True, True, False, True, True, False]])
+    y_pred = csr_array([[True, False, True, True, True, False]])
     tp2 = annif.eval.true_positives(y_true, y_pred)
     assert tp2 == 3
 
 
 def test_false_positives():
-    y_true = np.array([[True, False, True, False, True, False]])
-    y_pred = np.array([[True, True, False, True, True, False]])
+    y_true = csr_array([[True, False, True, False, True, False]])
+    y_pred = csr_array([[True, True, False, True, True, False]])
     fp = annif.eval.false_positives(y_true, y_pred)
     assert fp == 2
 
-    y_true = np.array([[True, True, False, True, True, False]])
-    y_pred = np.array([[True, False, True, True, True, False]])
+    y_true = csr_array([[True, True, False, True, True, False]])
+    y_pred = csr_array([[True, False, True, True, True, False]])
     fp2 = annif.eval.false_positives(y_true, y_pred)
     assert fp2 == 1
 
 
 def test_false_negatives():
-    y_true = np.array([[True, False, True, False, True, False]])
-    y_pred = np.array([[True, True, False, True, True, False]])
+    y_true = csr_array([[True, False, True, False, True, False]])
+    y_pred = csr_array([[True, True, False, True, True, False]])
     fn = annif.eval.false_negatives(y_true, y_pred)
     assert fn == 1
 
-    y_true = np.array([[True, True, False, True, True, False]])
-    y_pred = np.array([[True, False, True, True, False, False]])
+    y_true = csr_array([[True, True, False, True, True, False]])
+    y_pred = csr_array([[True, False, True, True, False, False]])
     fn2 = annif.eval.false_negatives(y_true, y_pred)
     assert fn2 == 2
 

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -1,6 +1,7 @@
 """Unit tests for evaluation metrics in Annif"""
 
 import numpy as np
+from scipy.sparse import csr_array
 
 import annif.corpus
 import annif.eval
@@ -8,9 +9,9 @@ import annif.suggestion
 
 
 def test_filter_pred_top_k():
-    pred = np.array([[0, 1, 3, 2], [1, 4, 3, 0]])
+    pred = csr_array([[0, 1, 3, 2], [1, 4, 3, 0]])
     filtered = annif.eval.filter_pred_top_k(pred, 2)
-    assert filtered.tolist() == [[0, 0, 3, 2], [0, 4, 3, 0]]
+    assert filtered.toarray().tolist() == [[0, 0, 3, 2], [0, 4, 3, 0]]
 
 
 def test_precision_at_k():

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -109,7 +109,7 @@ def test_evaluation_batch(subject_index):
             )
         ]
     )
-    batch.evaluate(hits1, gold_set)
+    batch.evaluate_many([hits1], [gold_set])
     hits2 = annif.suggestion.ListSuggestionResult(
         [
             # subject: egyptologists (yso:p1747)
@@ -119,7 +119,7 @@ def test_evaluation_batch(subject_index):
             )
         ]
     )
-    batch.evaluate(hits2, gold_set)
+    batch.evaluate_many([hits2], [gold_set])
     results = batch.results()
     assert results["Precision (doc avg)"] == 0.5
     assert results["Recall (doc avg)"] == 0.5

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -14,6 +14,42 @@ def test_filter_pred_top_k():
     assert filtered.toarray().tolist() == [[0, 0, 3, 2], [0, 4, 3, 0]]
 
 
+def test_true_positives():
+    y_true = np.array([[True, False, True, False, True, False]])
+    y_pred = np.array([[True, True, False, True, True, False]])
+    tp = annif.eval.true_positives(y_true, y_pred)
+    assert tp == 2
+
+    y_true = np.array([[True, True, False, True, True, False]])
+    y_pred = np.array([[True, False, True, True, True, False]])
+    tp2 = annif.eval.true_positives(y_true, y_pred)
+    assert tp2 == 3
+
+
+def test_false_positives():
+    y_true = np.array([[True, False, True, False, True, False]])
+    y_pred = np.array([[True, True, False, True, True, False]])
+    fp = annif.eval.false_positives(y_true, y_pred)
+    assert fp == 2
+
+    y_true = np.array([[True, True, False, True, True, False]])
+    y_pred = np.array([[True, False, True, True, True, False]])
+    fp2 = annif.eval.false_positives(y_true, y_pred)
+    assert fp2 == 1
+
+
+def test_false_negatives():
+    y_true = np.array([[True, False, True, False, True, False]])
+    y_pred = np.array([[True, True, False, True, True, False]])
+    fn = annif.eval.false_negatives(y_true, y_pred)
+    assert fn == 1
+
+    y_true = np.array([[True, True, False, True, True, False]])
+    y_pred = np.array([[True, False, True, True, False, False]])
+    fn2 = annif.eval.false_negatives(y_true, y_pred)
+    assert fn2 == 2
+
+
 def test_precision_at_k():
     y_true = np.array([[1, 0, 1, 0, 1, 0]])
     y_pred = np.array([[6, 5, 4, 3, 2, 1]])

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -7,24 +7,6 @@ import annif.eval
 import annif.suggestion
 
 
-def test_filter_pred_top_k_limit():
-    pred = csr_array([[0, 1, 3, 2], [1, 4, 3, 0]])
-    filtered = annif.eval.filter_pred_top_k(pred, limit=2)
-    assert filtered.toarray().tolist() == [[0, 0, 3, 2], [0, 4, 3, 0]]
-
-
-def test_filter_pred_top_k_threshold():
-    pred = csr_array([[0, 1, 3, 2], [1, 4, 3, 0]])
-    filtered = annif.eval.filter_pred_top_k(pred, threshold=2)
-    assert filtered.toarray().tolist() == [[0, 0, 3, 2], [0, 4, 3, 0]]
-
-
-def test_filter_pred_top_k_limit_and_threshold():
-    pred = csr_array([[0, 1, 3, 2], [1, 4, 3, 0]])
-    filtered = annif.eval.filter_pred_top_k(pred, limit=2, threshold=3)
-    assert filtered.toarray().tolist() == [[0, 0, 3, 0], [0, 4, 3, 0]]
-
-
 def test_true_positives():
     y_true = csr_array([[True, False, True, False, True, False]])
     y_pred = csr_array([[True, True, False, True, True, False]])

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -114,25 +114,21 @@ def test_evaluation_batch(subject_index, tmpdir):
     gold_set = annif.corpus.SubjectSet.from_string(
         "<http://www.yso.fi/onto/yso/p10849>\tarkeologit", subject_index, "fi"
     )
-    hits1 = annif.suggestion.ListSuggestionResult(
-        [
-            # subject: archaeologists (yso:p10849)
-            annif.suggestion.SubjectSuggestion(
-                subject_id=subject_index.by_uri("http://www.yso.fi/onto/yso/p10849"),
-                score=1.0,
-            )
-        ]
-    )
+    hits1 = [
+        # subject: archaeologists (yso:p10849)
+        annif.suggestion.SubjectSuggestion(
+            subject_id=subject_index.by_uri("http://www.yso.fi/onto/yso/p10849"),
+            score=1.0,
+        )
+    ]
     batch.evaluate_many([hits1], [gold_set])
-    hits2 = annif.suggestion.ListSuggestionResult(
-        [
-            # subject: egyptologists (yso:p1747)
-            annif.suggestion.SubjectSuggestion(
-                subject_id=subject_index.by_uri("http://www.yso.fi/onto/yso/p1747"),
-                score=1.0,
-            )
-        ]
-    )
+    hits2 = [
+        # subject: egyptologists (yso:p1747)
+        annif.suggestion.SubjectSuggestion(
+            subject_id=subject_index.by_uri("http://www.yso.fi/onto/yso/p1747"),
+            score=1.0,
+        )
+    ]
     batch.evaluate_many([hits2], [gold_set])
     outfile = tmpdir.join("results.tsv")
     results = batch.results(results_file=outfile.open("w"), language="en")

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -131,7 +131,7 @@ def test_ndcg_empty2():
     assert ndcg == 1.0
 
 
-def test_evaluation_batch(subject_index):
+def test_evaluation_batch(subject_index, tmpdir):
     batch = annif.eval.EvaluationBatch(subject_index)
 
     gold_set = annif.corpus.SubjectSet.from_string(
@@ -157,7 +157,8 @@ def test_evaluation_batch(subject_index):
         ]
     )
     batch.evaluate_many([hits2], [gold_set])
-    results = batch.results()
+    outfile = tmpdir.join("results.tsv")
+    results = batch.results(results_file=outfile.open("w"), language="en")
     assert results["Precision (doc avg)"] == 0.5
     assert results["Recall (doc avg)"] == 0.5
     assert results["LRAP"] >= 0.50
@@ -166,3 +167,23 @@ def test_evaluation_batch(subject_index):
     assert results["False positives"] == 1
     assert results["False negatives"] == 1
     assert results["Documents evaluated"] == 2
+
+    output = outfile.readlines()
+    assert len(output) == 131
+    assert (
+        output[0]
+        == "\t".join(
+            [
+                "URI",
+                "Label",
+                "Support",
+                "True_positives",
+                "False_positives",
+                "False_negatives",
+                "Precision",
+                "Recall",
+                "F1_score",
+            ]
+        )
+        + "\n"
+    )

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -1,6 +1,5 @@
 """Unit tests for evaluation metrics in Annif"""
 
-import numpy as np
 from scipy.sparse import csr_array
 
 import annif.corpus

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -50,22 +50,6 @@ def test_false_negatives():
     assert fn2 == 2
 
 
-def test_precision_at_k():
-    y_true = np.array([[1, 0, 1, 0, 1, 0]])
-    y_pred = np.array([[6, 5, 4, 3, 2, 1]])
-    prec_10 = annif.eval.precision_at_k_score(y_true, y_pred, 10)
-    assert prec_10 == 0.5
-    prec_5 = annif.eval.precision_at_k_score(y_true, y_pred, 5)
-    assert prec_5 == 0.6
-    prec_4 = annif.eval.precision_at_k_score(y_true, y_pred, 4)
-    assert prec_4 == 0.5
-    prec_3 = annif.eval.precision_at_k_score(y_true, y_pred, 3)
-    assert prec_3 > 0.66
-    assert prec_3 < 0.67
-    prec_1 = annif.eval.precision_at_k_score(y_true, y_pred, 1)
-    assert prec_1 == 1.0
-
-
 # DCG@6 example from https://en.wikipedia.org/wiki/Discounted_cumulative_gain
 def test_dcg():
     y_true = np.array([3, 2, 3, 0, 1, 2])

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -52,8 +52,8 @@ def test_false_negatives():
 
 # DCG@6 example from https://en.wikipedia.org/wiki/Discounted_cumulative_gain
 def test_dcg():
-    y_true = np.array([3, 2, 3, 0, 1, 2])
-    y_pred = np.array([6, 5, 4, 3, 2, 1])
+    y_true = csr_array([3, 2, 3, 0, 1, 2])
+    y_pred = csr_array([6, 5, 4, 3, 2, 1])
     dcg = annif.eval.dcg_score(y_true, y_pred, 6)
     assert dcg > 6.86
     assert dcg < 6.87
@@ -61,8 +61,8 @@ def test_dcg():
 
 # iDCG@6 example from https://en.wikipedia.org/wiki/Discounted_cumulative_gain
 def test_dcg_ideal():
-    y_true = np.array([3, 3, 3, 2, 2, 2, 1, 0])
-    y_pred = np.array([8, 7, 6, 5, 4, 3, 2, 1])
+    y_true = csr_array([3, 3, 3, 2, 2, 2, 1, 0])
+    y_pred = csr_array([8, 7, 6, 5, 4, 3, 2, 1])
     dcg = annif.eval.dcg_score(y_true, y_pred, 6)
     assert dcg > 8.74
     assert dcg < 8.75
@@ -70,47 +70,47 @@ def test_dcg_ideal():
 
 # nDCG@6 example from https://en.wikipedia.org/wiki/Discounted_cumulative_gain
 def test_ndcg():
-    y_true = np.array([[3, 2, 3, 0, 1, 2, 3, 2]])
-    y_pred = np.array([[6, 5, 4, 3, 2, 1, 0, 0]])
+    y_true = csr_array([[3, 2, 3, 0, 1, 2, 3, 2]])
+    y_pred = csr_array([[6, 5, 4, 3, 2, 1, 0, 0]])
     ndcg = annif.eval.ndcg_score(y_true, y_pred, 6)
     assert ndcg > 0.78
     assert ndcg < 0.79
 
 
 def test_ndcg_nolimit():
-    y_true = np.array([[1, 1, 1, 0, 1, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1]])
-    y_pred = np.array([[7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 0, 0]])
+    y_true = csr_array([[1, 1, 1, 0, 1, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1]])
+    y_pred = csr_array([[7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 0, 0]])
     ndcg = annif.eval.ndcg_score(y_true, y_pred)
     assert ndcg > 0.49
     assert ndcg < 0.50
 
 
 def test_ndcg_10():
-    y_true = np.array([[1, 1, 1, 0, 1, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1]])
-    y_pred = np.array([[7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 0, 0]])
+    y_true = csr_array([[1, 1, 1, 0, 1, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1]])
+    y_pred = csr_array([[7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 0, 0]])
     ndcg = annif.eval.ndcg_score(y_true, y_pred, 10)
     assert ndcg > 0.55
     assert ndcg < 0.56
 
 
 def test_ndcg_5():
-    y_true = np.array([[1, 1, 1, 0, 1, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1]])
-    y_pred = np.array([[7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 0, 0]])
+    y_true = csr_array([[1, 1, 1, 0, 1, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1]])
+    y_pred = csr_array([[7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 0, 0]])
     ndcg = annif.eval.ndcg_score(y_true, y_pred, 5)
     assert ndcg > 0.85
     assert ndcg < 0.86
 
 
 def test_ndcg_empty():
-    y_true = np.array([[1, 1, 1, 1, 1]])
-    y_pred = np.array([[0, 0, 0, 0, 0]])
+    y_true = csr_array([[1, 1, 1, 1, 1]])
+    y_pred = csr_array([[0, 0, 0, 0, 0]])
     ndcg = annif.eval.ndcg_score(y_true, y_pred)
     assert ndcg == 0
 
 
 def test_ndcg_empty2():
-    y_true = np.array([[0, 0, 0, 0, 0]])
-    y_pred = np.array([[1, 1, 1, 1, 1]])
+    y_true = csr_array([[0, 0, 0, 0, 0]])
+    y_pred = csr_array([[1, 1, 1, 1, 1]])
     ndcg = annif.eval.ndcg_score(y_true, y_pred)
     assert ndcg == 1.0
 

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -187,7 +187,7 @@ def test_project_learn(registry, tmpdir):
     project.learn(docdir)
     result = project.suggest(["this is some text"])[0]
     assert len(result) == 1
-    hits = result.as_list()
+    hits = list(result)
     assert hits[0].subject_id == project.subjects.by_uri("http://example.org/none")
     assert hits[0].score == 1.0
 
@@ -224,7 +224,7 @@ def test_project_suggest(registry):
     project = registry.get_project("dummy-en")
     result = project.suggest(["this is some text"])[0]
     assert len(result) == 1
-    hits = result.as_list()
+    hits = list(result)
     assert hits[0].subject_id == project.subjects.by_uri("http://example.org/dummy")
     assert hits[0].score == 1.0
 
@@ -239,7 +239,7 @@ def test_project_suggest_corpus(registry, fulltext_corpus):
     project = registry.get_project("dummy-en")
     result = list(project.suggest_corpus(fulltext_corpus))
     assert len(result) == 28  # Number of documents
-    first_doc_hits = result[0].as_list()
+    first_doc_hits = list(result[0])
     assert len(first_doc_hits) == 1
     assert first_doc_hits[0].subject_id == project.subjects.by_uri(
         "http://example.org/dummy"
@@ -261,7 +261,7 @@ def test_project_train_state_not_available(registry, caplog):
         result = project.suggest(["this is some text"])[0]
     assert project.is_trained is None
     assert len(result) == 1
-    hits = result.as_list()
+    hits = list(result)
     assert hits[0].subject_id == project.subjects.by_uri("http://example.org/dummy")
     assert hits[0].score == 1.0
     assert "Could not get train state information" in caplog.text

--- a/tests/test_suggestion.py
+++ b/tests/test_suggestion.py
@@ -1,5 +1,6 @@
 """Unit tests for suggestion processing in Annif"""
 
+import numpy as np
 import pytest
 from scipy.sparse import csr_array
 
@@ -51,6 +52,34 @@ def test_suggestionbatch_from_sequence(dummy_subject_index):
         "http://example.org/none"
     )
     assert suggestions[1].score == pytest.approx(0.2)
+
+
+def test_suggestionbatch_from_sequence_vector(dummy_subject_index):
+    vector = np.zeros(len(dummy_subject_index), dtype=np.float32)
+    vector[0] = 0.2
+    vector[1] = 0.8
+
+    sbatch = SuggestionBatch.from_sequence([vector], dummy_subject_index)
+    assert len(sbatch) == 1
+    suggestions = list(sbatch[0])
+    assert len(suggestions) == 2
+    assert suggestions[0].subject_id == 1
+    assert suggestions[0].score == pytest.approx(0.8)
+    assert suggestions[1].subject_id == 0
+    assert suggestions[1].score == pytest.approx(0.2)
+
+
+def test_suggestionbatch_from_sequence_vector_limit(dummy_subject_index):
+    vector = np.zeros(len(dummy_subject_index), dtype=np.float32)
+    vector[0] = 0.2
+    vector[1] = 0.8
+
+    sbatch = SuggestionBatch.from_sequence([vector], dummy_subject_index, limit=1)
+    assert len(sbatch) == 1
+    suggestions = list(sbatch[0])
+    assert len(suggestions) == 1
+    assert suggestions[0].subject_id == 1
+    assert suggestions[0].score == pytest.approx(0.8)
 
 
 def test_suggestionbatch_from_sequence_enforce_score_range(dummy_subject_index):

--- a/tests/test_suggestion.py
+++ b/tests/test_suggestion.py
@@ -18,8 +18,8 @@ def test_vector_to_suggestions():
     vector[2] = 0.2
     vector[5] = 0.8
 
-    suggestions = vector_to_suggestions(vector, 5)
-    assert len(suggestions) == 2
+    suggestions = list(vector_to_suggestions(vector, 5))
+    assert len(suggestions) == 5
     assert [
         sugg
         for sugg in suggestions
@@ -37,7 +37,7 @@ def test_vector_to_suggestions_limit():
     vector[2] = 0.2
     vector[5] = 0.8
 
-    suggestions = vector_to_suggestions(vector, 1)
+    suggestions = list(vector_to_suggestions(vector, 1))
     assert len(suggestions) == 1
     assert [
         sugg

--- a/tests/test_suggestion.py
+++ b/tests/test_suggestion.py
@@ -1,16 +1,10 @@
 """Unit tests for suggestion processing in Annif"""
 
-import numpy as np
 import pytest
 from scipy.sparse import csr_array
 
 from annif.corpus import Subject
-from annif.suggestion import (
-    SubjectSuggestion,
-    SuggestionBatch,
-    VectorSuggestionResult,
-    filter_suggestion,
-)
+from annif.suggestion import SubjectSuggestion, SuggestionBatch, filter_suggestion
 
 
 def generate_suggestions(n, subject_index):
@@ -33,32 +27,6 @@ def test_filter_suggestion_limit_and_threshold():
     pred = csr_array([[0, 1, 3, 2], [1, 4, 3, 0]])
     filtered = filter_suggestion(pred, limit=2, threshold=3)
     assert filtered.toarray().tolist() == [[0, 0, 3, 0], [0, 4, 3, 0]]
-
-
-def test_vector_suggestion_result_as_vector(subject_index):
-    orig_vector = np.ones(len(subject_index), dtype=np.float32)
-    suggestions = VectorSuggestionResult(orig_vector)
-    vector = suggestions.as_vector(len(subject_index))
-    assert (vector == orig_vector).all()
-
-
-def test_vector_suggestions_enforce_score_range(subject_index):
-    orig_vector = np.array([-0.1, 0.0, 0.5, 1.0, 1.5], dtype=np.float32)
-    suggestions = VectorSuggestionResult(orig_vector)
-    vector = suggestions.as_vector(len(subject_index))
-    expected = np.array([0.0, 0.0, 0.5, 1.0, 1.0], dtype=np.float32)
-    assert (vector == expected).all()
-
-
-def test_vector_suggestion_result_as_vector_destination(subject_index):
-    orig_vector = np.ones(len(subject_index), dtype=np.float32)
-    suggestions = VectorSuggestionResult(orig_vector)
-    destination = np.zeros(len(subject_index), dtype=np.float32)
-    assert not (destination == orig_vector).all()  # destination is all zeros
-
-    vector = suggestions.as_vector(len(subject_index), destination=destination)
-    assert vector is destination
-    assert (destination == orig_vector).all()  # destination now all ones
 
 
 def test_suggestionbatch_from_sequence(dummy_subject_index):

--- a/tests/test_suggestion.py
+++ b/tests/test_suggestion.py
@@ -150,3 +150,14 @@ def test_suggestionbatch_from_sequence_with_deprecated(dummy_subject_index):
         "http://example.org/none"
     )
     assert suggestions[1].score == pytest.approx(0.2)
+
+
+def test_suggestionbatch_from_averaged():
+    batch1 = SuggestionBatch(csr_array([[0, 1, 0], [1, 0, 0]]))
+    batch2 = SuggestionBatch(csr_array([[1, 0, 0], [1, 1, 0]]))
+    weights = [1, 3]
+
+    avg_batch = SuggestionBatch.from_averaged([batch1, batch2], weights)
+    assert (
+        avg_batch.array.toarray() == np.array([[0.75, 0.25, 0], [1, 0.75, 0]])
+    ).all()

--- a/tests/test_suggestion.py
+++ b/tests/test_suggestion.py
@@ -89,6 +89,30 @@ def test_suggestionbatch_from_sequence(dummy_subject_index):
     assert suggestions[1].score == pytest.approx(0.2)
 
 
+def test_suggestionbatch_from_sequence_enforce_score_range(dummy_subject_index):
+    orig_suggestions = [
+        [
+            SubjectSuggestion(
+                subject_id=dummy_subject_index.by_uri("http://example.org/dummy"),
+                score=1.2,
+            ),
+            SubjectSuggestion(
+                subject_id=dummy_subject_index.by_uri("http://example.org/none"),
+                score=-0.2,
+            ),
+        ]
+    ]
+
+    sbatch = SuggestionBatch.from_sequence(orig_suggestions, dummy_subject_index)
+    assert len(sbatch) == 1
+    suggestions = list(sbatch[0])
+    assert len(suggestions) == 1
+    assert suggestions[0].subject_id == dummy_subject_index.by_uri(
+        "http://example.org/dummy"
+    )
+    assert suggestions[0].score == pytest.approx(1.0)
+
+
 def test_suggestionbatch_from_sequence_with_deprecated(dummy_subject_index):
     dummy_subject_index.append(
         Subject(uri="http://example.org/deprecated", labels=None, notation=None)

--- a/tests/test_suggestion.py
+++ b/tests/test_suggestion.py
@@ -7,10 +7,6 @@ from annif.corpus import Subject
 from annif.suggestion import SubjectSuggestion, SuggestionBatch, filter_suggestion
 
 
-def generate_suggestions(n, subject_index):
-    return [SubjectSuggestion(subject_id=i, score=1.0 / (i + 1)) for i in range(n)]
-
-
 def test_filter_suggestion_limit():
     pred = csr_array([[0, 1, 3, 2], [1, 4, 3, 0]])
     filtered = filter_suggestion(pred, limit=2)

--- a/tests/test_suggestion.py
+++ b/tests/test_suggestion.py
@@ -3,7 +3,6 @@
 import numpy as np
 
 from annif.suggestion import (
-    LazySuggestionResult,
     ListSuggestionResult,
     SubjectSuggestion,
     VectorSuggestionResult,
@@ -15,18 +14,6 @@ def generate_suggestions(n, subject_index):
     for i in range(n):
         suggestions.append(SubjectSuggestion(subject_id=i, score=1.0 / (i + 1)))
     return ListSuggestionResult(suggestions)
-
-
-def test_lazy_suggestion_result(subject_index):
-    lsr = LazySuggestionResult(lambda: generate_suggestions(10, subject_index))
-    assert lsr._object is None
-    assert len(lsr) == 10
-    assert len(lsr.as_list()) == 10
-    assert lsr.as_vector(len(subject_index)) is not None
-    assert lsr.as_list()[0] is not None
-    filtered = lsr.filter(subject_index, limit=5, threshold=0.0)
-    assert len(filtered) == 5
-    assert lsr._object is not None
 
 
 def test_list_suggestion_result_vector(subject_index):

--- a/tests/test_suggestion.py
+++ b/tests/test_suggestion.py
@@ -52,6 +52,18 @@ def test_filter_suggestion_limit():
     assert filtered.toarray().tolist() == [[0, 0, 3, 2], [0, 4, 3, 0]]
 
 
+def test_filter_suggestion_limit_big():
+    pred = csr_array([[0, 1, 3, 2], [1, 4, 3, 0]])
+    filtered = filter_suggestion(pred, limit=20)
+    assert filtered.toarray().tolist() == [[0, 1, 3, 2], [1, 4, 3, 0]]
+
+
+def test_filter_suggestion_limit_zero():
+    pred = csr_array([[0, 1, 3, 2], [1, 4, 3, 0]])
+    filtered = filter_suggestion(pred, limit=0)
+    assert filtered.toarray().tolist() == [[0, 0, 0, 0], [0, 0, 0, 0]]
+
+
 def test_filter_suggestion_threshold():
     pred = csr_array([[0, 1, 3, 2], [1, 4, 3, 0]])
     filtered = filter_suggestion(pred, threshold=2)

--- a/tests/test_suggestion.py
+++ b/tests/test_suggestion.py
@@ -1,11 +1,13 @@
 """Unit tests for suggestion processing in Annif"""
 
 import numpy as np
+from scipy.sparse import csr_array
 
 from annif.suggestion import (
     ListSuggestionResult,
     SubjectSuggestion,
     VectorSuggestionResult,
+    filter_suggestion,
 )
 
 
@@ -14,6 +16,24 @@ def generate_suggestions(n, subject_index):
     for i in range(n):
         suggestions.append(SubjectSuggestion(subject_id=i, score=1.0 / (i + 1)))
     return ListSuggestionResult(suggestions)
+
+
+def test_filter_suggestion_limit():
+    pred = csr_array([[0, 1, 3, 2], [1, 4, 3, 0]])
+    filtered = filter_suggestion(pred, limit=2)
+    assert filtered.toarray().tolist() == [[0, 0, 3, 2], [0, 4, 3, 0]]
+
+
+def test_filter_suggestion_threshold():
+    pred = csr_array([[0, 1, 3, 2], [1, 4, 3, 0]])
+    filtered = filter_suggestion(pred, threshold=2)
+    assert filtered.toarray().tolist() == [[0, 0, 3, 2], [0, 4, 3, 0]]
+
+
+def test_filter_suggestion_limit_and_threshold():
+    pred = csr_array([[0, 1, 3, 2], [1, 4, 3, 0]])
+    filtered = filter_suggestion(pred, limit=2, threshold=3)
+    assert filtered.toarray().tolist() == [[0, 0, 3, 0], [0, 4, 3, 0]]
 
 
 def test_list_suggestion_result_vector(subject_index):

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,5 +1,7 @@
 """Unit tests for Annif utility functions"""
 
+from scipy.sparse import csr_array
+
 import annif.util
 
 
@@ -17,3 +19,21 @@ def test_metric_code():
 
     for input, output in zip(inputs, outputs):
         assert annif.util.metric_code(input) == output
+
+
+def test_filter_suggestion_limit():
+    pred = csr_array([[0, 1, 3, 2], [1, 4, 3, 0]])
+    filtered = annif.util.filter_suggestion(pred, limit=2)
+    assert filtered.toarray().tolist() == [[0, 0, 3, 2], [0, 4, 3, 0]]
+
+
+def test_filter_suggestion_threshold():
+    pred = csr_array([[0, 1, 3, 2], [1, 4, 3, 0]])
+    filtered = annif.util.filter_suggestion(pred, threshold=2)
+    assert filtered.toarray().tolist() == [[0, 0, 3, 2], [0, 4, 3, 0]]
+
+
+def test_filter_suggestion_limit_and_threshold():
+    pred = csr_array([[0, 1, 3, 2], [1, 4, 3, 0]])
+    filtered = annif.util.filter_suggestion(pred, limit=2, threshold=3)
+    assert filtered.toarray().tolist() == [[0, 0, 3, 0], [0, 4, 3, 0]]

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,7 +1,5 @@
 """Unit tests for Annif utility functions"""
 
-from scipy.sparse import csr_array
-
 import annif.util
 
 
@@ -19,21 +17,3 @@ def test_metric_code():
 
     for input, output in zip(inputs, outputs):
         assert annif.util.metric_code(input) == output
-
-
-def test_filter_suggestion_limit():
-    pred = csr_array([[0, 1, 3, 2], [1, 4, 3, 0]])
-    filtered = annif.util.filter_suggestion(pred, limit=2)
-    assert filtered.toarray().tolist() == [[0, 0, 3, 2], [0, 4, 3, 0]]
-
-
-def test_filter_suggestion_threshold():
-    pred = csr_array([[0, 1, 3, 2], [1, 4, 3, 0]])
-    filtered = annif.util.filter_suggestion(pred, threshold=2)
-    assert filtered.toarray().tolist() == [[0, 0, 3, 2], [0, 4, 3, 0]]
-
-
-def test_filter_suggestion_limit_and_threshold():
-    pred = csr_array([[0, 1, 3, 2], [1, 4, 3, 0]])
-    filtered = annif.util.filter_suggestion(pred, limit=2, threshold=3)
-    assert filtered.toarray().tolist() == [[0, 0, 3, 0], [0, 4, 3, 0]]


### PR DESCRIPTION
This PR reimplements the representation and handling of subject suggestions so that they are represented as sparse arrays that contain the suggestions for a batch of documents. Fixes #678 where the idea was originally proposed.

# Old approach

In the old approach, there was an abstract class `SuggestionResult` and its concrete subclasses `VectorSuggestionResult` and `ListSuggestionResult` (as well as a `LazySuggestionResult` wrapper class). All of these were oriented around representing the results for a single document, so when performing operations on multiple documents (e.g. `annif eval`), there were lots of instances of the `SuggestionResult` classes and operations such as filtering (by limit and threshold) had to be performed separately on each instance, which can be inefficient. Also, `VectorSuggestionResult` stores 1D NumPy arrays which, in the case of a large vocabulary such as YSO, usually contain mostly zeros, which is a waste of memory. There was also extra complexity because of the two alternative representations and the need to convert between them depending on which representation was more appropriate for a given purpose.

# New approach

This PR removes all the above mentioned classes. Instead suggestion results are represented using SciPy sparse arrays that contain the suggestions for a whole batch of documents (up to 32). The new classes in the `annif.suggestion` module are:

- `SuggestionResults`: this represents the suggestions for a whole corpus of documents, which may comprise many batches. This is the return type for `AnnifProject.suggest_corpus`.
- `SuggestionBatch`: this represents the suggestions for a single batch of documents and wraps a sparse array. This is the return type for `AnnifProject.suggest` as well as the backend method `_suggest_batch` for those backends that support batch operations.
- `SuggestionResult`: this represents the suggestions for a single document. It is actually a single row view into the sparse array contained in a `SuggestionBatch`.

Like their predecessors, all of these classes are intended to be immutable (although I guess this could be better enforced in the code). So once created, they will not change; operations such as `.filter()` will return a new instance.

# Notes about sparse arrays

SciPy sparse matrices have been around for a long time, but sparse arrays are relatively new ([introduced](https://docs.scipy.org/doc/scipy/reference/sparse.html#module-scipy.sparse) in SciPy 1.8 released in February 2022). The arrays are very similar to matrices (and currently implemented as a subclass), but their API is closer to that of NumPy arrays. SciPy documentation now [recommends](https://docs.scipy.org/doc/scipy/reference/sparse.html) the use of sparse arrays (instead of matrices) for new code, so I decided to follow that recommendation. However, there are a few cases in this PR where SciPy methods on sparse arrays return matrices instead of arrays, and they have to be explicitly converted to arrays.

# Changes to functionality

The original idea of this PR was to simply refactor without changing any functionality, yet I decided to do a couple of changes:

1. this PR removes the LRAP evaluation metric, because the [implementation](https://scikit-learn.org/stable/modules/generated/sklearn.metrics.label_ranking_average_precision_score.html) in scikit-learn doesn't accept sparse arrays as input; it's not much used anyway, and nDCG is a very similar ranking metric, so I don't think this is a big loss.
2. The reimplemented `annif optimize` command now supports a `--jobs` parameter for parallel processing, just like `annif eval` - this fixes #423 .

# Performance

I had to do extensive benchmarking and many rounds of optimizations before I was happy with the results. The representation of suggestion results is very fundamental and performance-critical; any inefficient operations will easily degrade performance. Despite its flaws, the old implementation was pretty well optimized. I have categorized the benchmark results according to the outcome as measured by wall time: obvious improvement (more than ~5%), obvious slowdown (more than ~5%), and no significant difference (everything in between).

I performed the benchmarks on the 48 CPU physical server. There is sometimes quite a bit of variation in successive runs especially for short operations. In some cases (basic CLI commands) I repeated the operation 5 times and took the best wall time result. For the most part, and unless otherwise noted, I used the Finto AI 2022-11 pretrained Finnish language models and the "kirjastonhoitaja" train, validation or test sets depending on which was most appropriate for the operation.

Memory usage was mostly unchanged, though in a few cases (e.g. MLLM and SVC eval operations) there is a clear improvement, probably due to the use of sparse arrays instead of NumPy vectors which can take up more space. I have commented on memory usage in a few cases below.

## Better performance

<details>
<summary>annif eval (tfidf, omikuji, fasttext, mllm, ensemble, nn_ensemble) - small improvements</summary>

| tfidf eval | before (main) -j1 | after (PR) -j1 | before (main) -j4 | after (PR) -j4 |
| ---------- | ----------------- | -------------- | ----------------- | -------------- |
| user time  | 147.37            | 136.89         | 151.87            | 141.18         |
| wall time  | 2:30.42           | 2:18.74        | 0:49.10           | 0:40.49        |
| max rss    | 621332            | 628936         | 409056            | 428944         |

Here I used the Annif tutorial yso-nlf data set. Clearly faster than before, though memory usage has increased a little bit (but only around 10MB) in this case.

| omikuji eval | before (main) -j1 | after (PR) -j1 | before (main) -j4 | after (PR) -j4 |
| ----------- | ----------------- | -------------- | ----------------- | -------------- |
| user time   | 62.32             | 56.21          | 66.66             | 57.51          |
| wall time   | 1:04.78           | 0:59.01        | 1:01.39           | 0:53.45        |
| max rss     | 6026176           | 5924520        | 6001608           | 5911072        |

A little bit faster, and saving around 100MB memory.

| fasttext eval | before (main) -j1 | after (PR) -j1 | before (main) -j4 | after (PR) -j4 |
| ------------- | ----------------- | -------------- | ----------------- | -------------- |
| user time     | 24.82             | 16.56          | 33.72             | 25.84          |
| wall time     | 0:28.59           | 0:18.81        | 0:22.19           | 0:15.66        |
| max rss       | 7604752           | 7566168        | 7537456           | 7536960        |

Much faster proportionally, but it was already fast, so the absolute difference is only a few seconds. This shows that  the calculation of evaluation metrics has been optimized, as the classifier remains the same. Memory usage 40MB less than before.

| mllm eval | before (main) -j1 | after (PR) -j1 | before (main) -j4 | after (PR) -j4 |
| --------- | ----------------- | -------------- | ----------------- | -------------- |
| user time | 138.03            | 139.61         | 146.27            | 135.36         |
| wall time | 2:17.31           | 2:19.12        | 0:53.92           | 0:45.33        |
| max rss   | 417892            | 327208         | 398172            | 312432         |

Overall execution time remains about the same, but memory usage has decreased by almost 100MB.

| ensemble eval | before (main) -j1 | after (PR) -j1 | before (main) -j4 | after (PR) -j4 |
| ------------- | ----------------- | -------------- | ----------------- | -------------- |
| user time     | 190.05            | 180.34         | 215.69            | 208.61         |
| wall time     | 3:15.67           | 3:06.35        | 1:51.35           | 1:45.40        |
| max rss       | 13304224          | 13248516       | 13171624          | 13176440       |

Again a bit faster and uses 50MB less memory.

| nn_ensemble eval | before (main) -j1 | after (PR) -j1 | before (main) -j4 | after (PR) -j4 |
| ---------------- | ----------------- | -------------- | ----------------- | -------------- |
| user time        | 209.98            | 190.73         | 219.25            | 215.77         |
| wall time        | 3:32.68           | 3:07.38        | 1:53.31           | 1:48.60        |
| max rss          | 13834460          | 13734268       | 13592216          | 13592288       |

Faster, 100MB less memory.

</details>

<details>
<summary>annif optimize (mllm, fasttext, omikuji, nn_ensemble) - much faster, esp. with new -j4 option</summary>

| mllm optimize | before (main) | after (PR) -j1 | after (PR) -j4 |
| ------------- | ------------- | -------------- | -------------- |
| user time     | 398.12        | 133.62         | 131.32         |
| wall time     | 6:40.40       | 2:12.46        | 1:09.95        |
| max rss       | 402928        | 326660         | 312268         |

| fasttext optimize | before (main) | after (PR) -j1 | after (PR) -j4 |
| ----------------- | ------------- | -------------- | -------------- |
| user time         | 310.08        | 51.17          | 61.31          |
| wall time         | 5:17.04       | 0:52.77        | 0:51.56        |
| max rss           | 7569820       | 7565416        | 7537044        |

| omikuji optimize | before (main) | after (PR) -j1 | after (PR) -j4 |
| --------------- | ------------- | -------------- | -------------- |
| user time       | 351.47        | 90.24          | 90.98          |
| wall time       | 5:57.19       | 1:31.88        | 1:29.20        |
| max rss         | 6353648       | 5923684        | 5900328        |

| nn_ensemble optimize | before (main) | after (PR) -j1 | after (PR) -j4 |
| -------------------- | ------------- | -------------- | -------------- |
| user time            | 459.32        | 195.40         | 214.07         |
| wall time            | 7:44.59       | 3:18.16        | 2:14.56        |
| max rss              | 13765600      | 13733652       | 13597472       |

All of these are 2-3x faster than before with a single job, and in some cases (mllm, nn_ensemble) using the new `--jobs 4` option further improves performance. Memory usage has decreased for MLLM and Omikuji.

</details>

## Reduced performance

<details>
<summary>annif suggest (mllm) with a corpus of documents - slightly slower</summary>

| mllm suggest | before (main) | after (PR) |
| ------------ | ------------- | ---------- |
| user time    | 124.31        | 136.56     |
| wall time    | 2:04.31       | 2:16.56    |
| max rss      | 312952        | 321740     |

This is a little bit slower than before, probably because results have to be converted from NumPy vectors to sparse arrays which in this case just slows things down.

</details>

<details>
<summary>annif train (pav) - slightly slower</summary>

| pav train | before (main) | after (PR) |
| --------- | ------------- | ---------- |
| user time | 1306.44       | 1374.53    |
| wall time | 21:53.99      | 23:03.23   |
| max rss   | 13397520      | 13394764   |

I didn't investigate this in detail, but clearly there is a bit of a slowdown.
</details>

<details>
<summary>annif hyperopt (ensemble) - much longer wall time due to bad threading</summary>

| ensemble hyperopt | before (main) | after (PR) |
| ----------------- | ------------- | ---------- |
| user time         | 236.50        | 238.26     |
| wall time         | 1:35.12       | 2:06.23    |
| max rss           | 13558412      | 13205052   |

The user time is unchanged, but wall time has increased significantly. I did some profiling and it seems to me that the main reason for the slowdown is contention for the GIL; due to the way sparse arrays are implemented and used, eval calculations are now mostly done in Python code instead of NumPy operations, and NumPy is better at threading since it can release the GIL during some calculations. A silver lining here is that memory usage decreased by around 250MB. (See below for a suggestion on how to improve this)

</details>

## No significant difference

<details>
<summary>Basic CLI operations</summary>

| annif --help | before (main) | after (PR) |
| ------------ | ------------- | ---------- |
| user time    | 1.48          | 01.09      |
| wall time    | 0:00.67       | 0:00.72    |
| max rss      | 61068         | 61000      |

| annif list-projects | before (main) | after (PR) |
| ------------- | ------------- | ---------- |
| user time     | 4.96          | 4.99       |
| wall time     | 0:03.39       | 0:03.44    |
| max rss       | 405000        | 405632     |

| annif list-vocabs | before (main) | after (PR) |
| ----------- | ------------- | ---------- |
| user time   | 4.81          | 5.26       |
| wall time   | 0:03.24       | 0:03.18    |
| max rss     | 406336        | 405564     |

Lots of variation between runs, but there is no significant difference.
</details>

<details>
<summary>annif suggest (most backends) with a corpus of documents</summary>

| tfidf suggest | before (main) | after (PR) |
| ------------- | ------------- | ---------- |
| user time     | 139.18        | 137.01     |
| wall time     | 2:21.40       | 2:18.01    |
| max rss       | 540700        | 544692     |

| fasttext suggest | before (main) | after (PR) |
| ---------------- | ------------- | ---------- |
| user time        | 15.46         | 14.66      |
| wall time        | 0:17.32       | 0:17.18    |
| max rss          | 7464564       | 7466736    |

| omikuji suggest | before (main) | after (PR) |
| -------------- | ------------- | ---------- |
| user time      | 52.08         | 52.66      |
| wall time      | 0:55.29       | 0:55.55    |
| max rss        | 6266832       | 6268096    |

| svc suggest (ykl) | before (main) | after (PR) |
| ----------------- | ------------- | ---------- |
| user time         | 18.24         | 18.52      |
| wall time         | 0:17.87       | 0:17.68    |
| max rss           | 1985268       | 1985208    |

| ensemble suggest | before (main) | after (PR) |
| ---------------- | ------------- | ---------- |
| user time        | 183.46        | 180.69     |
| wall time        | 3:10.45       | 3:10.64    |
| max rss          | 13248652      | 13203956   |

| pav suggest | before (main) | after (PR) |
| ----------- | ------------- | ---------- |
| user time   | 191.90        | 192.24     |
| wall time   | 3:17.12       | 3:18.13    |
| max rss     | 13250576      | 13214236   |

| nn_ensemble suggest | before (main) | after (PR) |
| ------------------- | ------------- | ---------- |
| user time           | 192.41        | 187.32     |
| wall time           | 3:14.34       | 3:12.49    |
| max rss             | 13733072      | 13735572   |

</details>

<details>
<summary>annif eval (svc, pav)</summary>

| svc eval (ykl) | before (main) -j1 | after (PR) -j1 | before (main) -j4 | after (PR) -j4 |
| -------------- | ----------------- | -------------- | ----------------- | -------------- |
| user time      | 31.32             | 31.27          | 35.23             | 33.68          |
| wall time      | 0:30.85           | 0:29.71        | 0:20.64           | 0:19.18        |
| max rss        | 2088652           | 1949652        | 2006592           | 1881268        |

This was done using YKL as the vocabulary and kirjaesittelyt2021/ykl test set. Runtime is about the same, but memory usage decreased by 130MB!

| pav eval  | before (main) -j1 | after (PR) -j1 | before (main) -j4 | after (PR) -j4 |
| --------- | ----------------- | -------------- | ----------------- | -------------- |
| user time | 189.44            | 192.63         | 232.83            | 221.67         |
| wall time | 3:16.27           | 3:18.89        | 2:00.68           | 1:49.79        |
| max rss   | 13298404          | 13236048       | 13215296          | 13178672       |

A bit faster when using `-j4`, otherwise no big difference, though memory usage decreased by 60MB.

</details>

<details>
<summary>annif train (nn_ensemble)</summary>

| nn_ensemble train | before (main) -j4 | after (PR) -j4 |
| ----------------- | ----------------- | -------------- |
| user time         | 4243.75           | 4292.64        |
| wall time         | 8:41.98           | 8:43.56        |
| max rss           | 15620888          | 16439540       |

Overall train time remains about the same, but memory usage has increased. I think there is room for improvement here, as noted below.

</details>

# Code quality

On the whole, this PR _reduces_ the amount of code by more than 100 lines, mainly because having a single represenation for suggestion results simplifies the implementation. I've also both dropped some unit tests and added new ones; the total number of tests has grown by one.

I tried to make the new implementation as clean as possible, but there are a few places where Codebeat complains about too much complexity. In both `SuggestionBatch.from_sequence` and `filter_suggestions` the problem is that efficiently constructing a sparse array is a bit complicated and messy as it involves creating three parallel lists; I originally tried to use `dok_array` as an intermediate representation, but it turned out to be slow. Anyway, I'm running out of ideas on how to simplify the code further. Suggestions welcome!

# Potential future work

I'm not quite happy with how the NN ensemble handles suggestion results from other projects, both during training and suggest operations. For example, the training samples are stored in LMDB one document at a time, but now it would be easier to store them as whole batches instead, which could be more efficient. But I decided that this PR is already much too big and it would make sense to try to improve batching in the NN ensemble in a separate follow-up PR. There is already an attempt to do part of this in PR #676; that could be a possible starting point.

The threading performance of `annif hyperopt` was already bad, and now it got worse. The solution could be to switch to process-based multiprocessing. This has been difficult to do with Optuna (needs an external relational database), but the Optuna FAQ now [states](https://optuna.readthedocs.io/en/stable/faq.html#multi-processing-parallelization-with-single-node) that it could also be done with [JournalFileStorage](https://optuna.readthedocs.io/en/stable/reference/generated/optuna.storages.JournalFileStorage.html#optuna.storages.JournalFileStorage), which sounds more promising.