### PR TITLE
Project-targeted Schemathesis test and OpenAPI schema fix

### DIFF
--- a/annif/openapi/annif.yaml
+++ b/annif/openapi/annif.yaml
@@ -224,6 +224,7 @@ components:
         notation:
           type: string
           example: "42.42"
+          nullable: true
         score:
           type: number
           example: 0.85
@@ -246,6 +247,8 @@ components:
           type: array
           items:
             type: object
+            required:
+              - uri
             properties:
               uri:
                 type: string

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,3 +91,6 @@ build-backend = "poetry.core.masonry.api"
 profile = "black"
 line_length = "88"
 skip_gitignore = true
+
+[tool.pytest.ini_options]
+addopts = "-m 'not slow'"

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -15,3 +15,11 @@ def check_cors(response, case):
 def test_api(case, app):
     response = case.call_wsgi(app)
     case.validate_response(response, additional_checks=(check_cors,))
+
+
+@schema.parametrize(endpoint="/v1/projects/{project_id}")
+@settings(max_examples=100)
+def test_api_target_dummy_fi(case, app):
+    case.path_parameters = {"project_id": "dummy-fi"}
+    response = case.call_wsgi(app)
+    case.validate_response(response)

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -1,4 +1,5 @@
 """Unit tests for Annif REST API / Swagger spec"""
+import pytest
 import schemathesis
 from hypothesis import settings
 
@@ -17,6 +18,7 @@ def test_api(case, app):
     case.validate_response(response, additional_checks=(check_cors,))
 
 
+@pytest.mark.slow
 @schema.parametrize(endpoint="/v1/projects/{project_id}")
 @settings(max_examples=100)
 def test_api_target_dummy_fi(case, app):


### PR DESCRIPTION
PR #682 introduced Schemathesis for testing REST API. However, as noted in https://github.com/NatLibFi/Annif/pull/664#issuecomment-1476336156, Schemathesis creates random path (and query) parameters, which means most of the test requests target non-existent projects giving just 404 error.

This PR adds a test that targets the methods in the endpoint `/v1/projects/{project_id}*` and uses a fixed project-id `dummy-fi`. A project with this id exists, so the test requests probe the actions that are (mostly) missed otherwise. 

This test noted two attributes in the OpenAPI specification that should be required or nullable, which are fixed. [openapi-diff tool](https://hub.docker.com/r/openapitools/openapi-diff/) tool complains that the fixes break backward compatibility:
```
==========================================================================
==                            API CHANGE LOG                            ==
==========================================================================
                              Annif REST API                              
--------------------------------------------------------------------------
--                            What's Changed                            --
--------------------------------------------------------------------------
- POST   /projects/{project_id}/learn
  Request:
        - Changed application/json
          Schema: Broken compatibility
--------------------------------------------------------------------------
--                                Result                                --
--------------------------------------------------------------------------
                 API changes broke backward compatibility                 
--------------------------------------------------------------------------
```
However I think the fixes should be harmless for backward compatibility and should be done:
- `notation` in SuggestionResult should be `nullable` because it is `None` if the vocabulary does not contain notations, which usually is the case
- `uri` in subjects of IndexedDocument should be required because otherwise Internal error due to `KeyError: 'uri'` occurs

At first I thought that also `text` and `subjects` in IndexedDocument should be required, but maybe not, at least that case is covered with an [if condition:](https://github.com/NatLibFi/Annif/blob/4bf5610219e3e2dd23a0e0464b834338f0465009/annif/rest.py#L116)https://github.com/NatLibFi/Annif/blob/4bf5610219e3e2dd23a0e0464b834338f0465009/annif/rest.py#L116

Also, this test is quite slow (10-15 s) and when the `suggest-batch` endpoint will be added it becomes even slower (20-25 s), so I marked it "slow" with a pytest decorator and configured pytest to skip it by default. It can be run using `-m slow` option:

     pytest -m slow