### PR TITLE
Upgrade to Python 3.10 in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-slim-bullseye
+FROM python:3.10-slim-bullseye
 LABEL org.opencontainers.image.authors="grp-natlibfi-annif@helsinki.fi"
 SHELL ["/bin/bash", "-c"]
 


### PR DESCRIPTION
Updates the baseimage of Annif's Docker image to Python 3.10.

Python 3.10 might improve performance somewhat.