### PR TITLE
Fix displaying of modification time for null value in Web UI project information

### DIFF
--- a/annif/templates/home.html
+++ b/annif/templates/home.html
@@ -161,7 +161,10 @@ Vue.component('annif-project-info', {
       return this.projects.find(p => {return p.project_id===this.project})
     },
     getDateString: function(d) {
-      // Returns modification time in the format 'yyyy-mm-dd hh:mm:ss UTC'
+      // Returns modification time in the format 'yyyy-mm-dd hh:mm:ss UTC' or '-' in
+      // case of null modification time
+      if (d === null)
+        return '-';
       date = new Date(d);
       return (
         [ date.getUTCFullYear(), ('0' + (date.getUTCMonth() + 1)).slice(-2), ('0' + date.getUTCDate()).slice(-2) ].join('-') + ' ' +


### PR DESCRIPTION
When the modification time of a project was None/null, Web UI project information section showed 1970-01-01 00:00:00.

Now "-" is displayed instead in the case of null value.