### PR TITLE
Optimize CLI startup time

### DIFF
--- a/annif/__init__.py
+++ b/annif/__init__.py
@@ -4,11 +4,6 @@ import logging
 import os
 import os.path
 
-import connexion
-from flask_cors import CORS
-
-from annif.openapi.validation import CustomRequestBodyValidator
-
 logging.basicConfig()
 logger = logging.getLogger("annif")
 logger.setLevel(level=logging.INFO)
@@ -16,20 +11,31 @@ logger.setLevel(level=logging.INFO)
 import annif.backend  # noqa
 
 
+def create_flask_app(config_name=None):
+    """Create a Flask app to be used by the CLI."""
+    from flask import Flask
+
+    app = Flask(__name__)
+    config_name = _get_config_name(config_name)
+    logger.debug(f"creating flask app with configuration {config_name}")
+    app.config.from_object(config_name)
+    app.config.from_envvar("ANNIF_SETTINGS", silent=True)
+    return app
+
+
 def create_app(config_name=None):
+    """ "Create a Connexion app to be used for the API."""
     # 'cxapp' here is the Connexion application that has a normal Flask app
     # as a property (cxapp.app)
+    import connexion
+    from flask_cors import CORS
+
+    from annif.openapi.validation import CustomRequestBodyValidator
 
     specdir = os.path.join(os.path.dirname(__file__), "openapi")
     cxapp = connexion.App(__name__, specification_dir=specdir)
-    if config_name is None:
-        config_name = os.environ.get("ANNIF_CONFIG")
-    if config_name is None:
-        if os.environ.get("FLASK_RUN_FROM_CLI") == "true":
-            config_name = "annif.default_config.Config"
-        else:
-            config_name = "annif.default_config.ProductionConfig"
-    logger.debug("creating app with configuration %s", config_name)
+    config_name = _get_config_name(config_name)
+    logger.debug(f"creating connexion app with configuration {config_name}")
     cxapp.app.config.from_object(config_name)
     cxapp.app.config.from_envvar("ANNIF_SETTINGS", silent=True)
 
@@ -52,3 +58,14 @@ def create_app(config_name=None):
 
     # return the Flask app
     return cxapp.app
+
+
+def _get_config_name(config_name):
+    if config_name is None:
+        config_name = os.environ.get("ANNIF_CONFIG")
+    if config_name is None:
+        if os.environ.get("FLASK_RUN_FROM_CLI") == "true":
+            config_name = "annif.default_config.Config"
+        else:
+            config_name = "annif.default_config.ProductionConfig"
+    return config_name

--- a/annif/cli.py
+++ b/annif/cli.py
@@ -25,7 +25,14 @@ from annif.util import metric_code
 logger = annif.logger
 click_log.basic_config(logger)
 
-cli = FlaskGroup(create_app=annif.create_app, add_version_option=False)
+
+if len(sys.argv) > 1 and sys.argv[1] == "run":
+    create_app = annif.create_app  # Use Flask with Connexion
+else:
+    # Connexion is not needed for most CLI commands, use plain Flask
+    create_app = annif.create_flask_app
+
+cli = FlaskGroup(create_app=create_app, add_version_option=False)
 cli = click.version_option(message="%(version)s")(cli)
 
 

--- a/annif/corpus/skos.py
+++ b/annif/corpus/skos.py
@@ -4,7 +4,6 @@ import collections
 import os.path
 import shutil
 
-import joblib
 import rdflib
 import rdflib.util
 from rdflib.namespace import OWL, RDF, RDFS, SKOS
@@ -17,6 +16,7 @@ from .types import Subject, SubjectCorpus
 def serialize_subjects_to_skos(subjects, path):
     """Create a SKOS representation of the given subjects and serialize it
     into a SKOS/Turtle file with the given path name."""
+    import joblib
 
     graph = rdflib.Graph()
     graph.namespace_manager.bind("skos", SKOS)
@@ -54,6 +54,8 @@ class SubjectFileSKOS(SubjectCorpus):
     def __init__(self, path):
         self.path = path
         if path.endswith(".dump.gz"):
+            import joblib
+
             self.graph = joblib.load(path)
         else:
             self.graph = rdflib.Graph()
@@ -132,6 +134,8 @@ class SubjectFileSKOS(SubjectCorpus):
             # need to serialize into Turtle
             self.graph.serialize(destination=path, format="turtle")
         # also dump the graph in joblib format which is faster to load
+        import joblib
+
         annif.util.atomic_save(
             self.graph,
             *os.path.split(path.replace(".ttl", ".dump.gz")),

--- a/annif/corpus/subject.py
+++ b/annif/corpus/subject.py
@@ -3,8 +3,6 @@
 import csv
 import os.path
 
-import numpy as np
-
 import annif
 import annif.util
 
@@ -273,6 +271,8 @@ class SubjectSet:
         None), otherwise create and return a new one of the given size."""
 
         if destination is None:
+            import numpy as np
+
             assert size is not None and size > 0
             destination = np.zeros(size, dtype=bool)
 


### PR DESCRIPTION
Optimizes CLI startup time by avoiding unnecessary imports for basic commands, mainly to improve the CLI command completion response times in #693.

Changes: 

- Imports of joblib and numpy are simply moved inside the functions/methods where they are used.

- Import of connexion is avoided for CLI commands (all but `annif run`) by using separate creation scripts for plain-Flask and Connexion-Flask applications. When started via `gunicorn "annif:create_app()` the Connexion-Flask app is created as previously.

This is a continuation of optimizations in #544.

I checked the import time of the [pre-release of  connexion 3](https://github.com/spec-first/connexion/releases/tag/3.0.0a5), and it was even slower (~0.35 s) than of the current v2.14.* (0.12 s), so avoiding connexion import is even more valuable in the future.

**Improvement compared to current main**
The improvement seems to be some 0.3 seconds (coming quite evenly from joblib, numpy, and connexion). 

Before (main):
```
$ time annif --version
1.0.0.dev0

real	0m0.610s
user	0m0.948s
sys	0m0.666s
```
```
$ time annif --help
Usage: annif [OPTIONS] COMMAND [ARGS]...
...
real	0m0.689s
user	0m1.079s
sys	0m0.626s
```
```
$ time annif list-vocabs 
Vocabulary ID       Languages                 Size  Loaded
----------------------------------------------------------
yso                 en,fi,se,sv              38179  True  
ykl                 -                            -  False 
thema-fi            -                            -  False 

real	0m1.214s
user	0m1.500s
sys	0m0.665s
```
After (PR):
```
$ time annif --version
1.0.0.dev0

real	0m0.293s
user	0m0.265s
sys	0m0.029s
```
```
$ time annif --help
Usage: annif [OPTIONS] COMMAND [ARGS]...
...
real	0m0.305s
user	0m0.266s
sys	0m0.038s
```
```
$ time annif list-vocabs 
Vocabulary ID       Languages                 Size  Loaded
----------------------------------------------------------
yso                 en,fi,se,sv              38179  True  
ykl                 -                            -  False 
thema-fi            -                            -  False 

real	0m0.945s
user	0m0.880s
sys	0m0.065s
```

The CLI command completion response times seemed to follow times of `annif --help`, so they are improved similarly.


Timing imports for completion responses does not show any easy targets for further optimization. The rdflib is used via multiple modules and in nearly all methods of `corpus.subject.SubjectFileSKOS`, and I don't know how rdflib import could be done only when needed in there in a nice way. 

Tuna output for the timing of `list-*` completion response time:

![image](https://user-images.githubusercontent.com/34240031/234003623-49dd9fe5-51c3-41e1-ba75-18f684872c9b.png)
