### PR TITLE
Upgrade to Connexion3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,4 +54,6 @@ RUN groupadd -g 998 annif_user && \
     chown -R annif_user:annif_user /annif-projects /Annif/tests/data
 USER annif_user
 
+ENV GUNICORN_CMD_ARGS="--worker-class uvicorn.workers.UvicornWorker"
+
 CMD annif

--- a/annif/__init__.py
+++ b/annif/__init__.py
@@ -7,6 +7,8 @@ import os
 import os.path
 from typing import TYPE_CHECKING
 
+from flask import Flask
+
 logging.basicConfig()
 logger = logging.getLogger("annif")
 logger.setLevel(level=logging.INFO)
@@ -14,12 +16,11 @@ logger.setLevel(level=logging.INFO)
 import annif.backend  # noqa
 
 if TYPE_CHECKING:
-    from flask.app import Flask
+    from connexion.apps.flask import FlaskApp
 
 
 def create_flask_app(config_name: str | None = None) -> Flask:
     """Create a Flask app to be used by the CLI."""
-    from flask import Flask
 
     _set_tensorflow_loglevel()
 
@@ -31,7 +32,7 @@ def create_flask_app(config_name: str | None = None) -> Flask:
     return app
 
 
-def create_app(config_name: str | None = None) -> Flask:
+def create_cx_app(config_name: str | None = None) -> FlaskApp:
     """Create a Connexion app to be used for the API."""
     import connexion
 
@@ -66,6 +67,9 @@ def create_app(config_name: str | None = None) -> Flask:
 
     # return the Connexion app
     return cxapp
+
+
+create_app = create_cx_app  # Alias to allow starting directly with uvicorn run
 
 
 def _get_config_name(config_name: str | None) -> str:

--- a/annif/__init__.py
+++ b/annif/__init__.py
@@ -30,19 +30,21 @@ def create_app(config_name=None):
     import connexion
     from flask_cors import CORS
 
-    from annif.openapi.validation import CustomRequestBodyValidator
+    import annif.registry
+
+    # from annif.openapi.validation import CustomRequestBodyValidator  # TODO Re-enable
 
     specdir = os.path.join(os.path.dirname(__file__), "openapi")
-    cxapp = connexion.App(__name__, specification_dir=specdir)
+    cxapp = connexion.FlaskApp(__name__, specification_dir=specdir)
     config_name = _get_config_name(config_name)
     logger.debug(f"creating connexion app with configuration {config_name}")
     cxapp.app.config.from_object(config_name)
     cxapp.app.config.from_envvar("ANNIF_SETTINGS", silent=True)
 
-    validator_map = {
-        "body": CustomRequestBodyValidator,
-    }
-    cxapp.add_api("annif.yaml", validator_map=validator_map)
+    # validator_map = {
+    #     "body": CustomRequestBodyValidator,
+    # }
+    cxapp.add_api("annif.yaml")  # validator_map=validator_map)
 
     # add CORS support
     CORS(cxapp.app)
@@ -56,8 +58,8 @@ def create_app(config_name=None):
 
     cxapp.app.register_blueprint(bp)
 
-    # return the Flask app
-    return cxapp.app
+    # return the Connexion app
+    return cxapp
 
 
 def _get_config_name(config_name):

--- a/annif/__init__.py
+++ b/annif/__init__.py
@@ -33,11 +33,9 @@ def create_flask_app(config_name: str | None = None) -> Flask:
 
 def create_app(config_name: str | None = None) -> Flask:
     """Create a Connexion app to be used for the API."""
-    # 'cxapp' here is the Connexion application that has a normal Flask app
-    # as a property (cxapp.app)
     import connexion
-    from flask_cors import CORS
 
+    # from flask_cors import CORS  # TODO Use CORSMiddleware
     import annif.registry
 
     # from annif.openapi.validation import CustomRequestBodyValidator  # TODO Re-enable
@@ -55,7 +53,7 @@ def create_app(config_name: str | None = None) -> Flask:
     cxapp.add_api("annif.yaml")  # validator_map=validator_map)
 
     # add CORS support
-    CORS(cxapp.app)
+    # CORS(cxapp.app)
 
     if cxapp.app.config["INITIALIZE_PROJECTS"]:
         annif.registry.initialize_projects(cxapp.app)

--- a/annif/__init__.py
+++ b/annif/__init__.py
@@ -35,6 +35,8 @@ def create_flask_app(config_name: str | None = None) -> Flask:
 def create_cx_app(config_name: str | None = None) -> FlaskApp:
     """Create a Connexion app to be used for the API."""
     import connexion
+    from connexion.middleware import MiddlewarePosition
+    from starlette.middleware.cors import CORSMiddleware
 
     # from flask_cors import CORS  # TODO Use CORSMiddleware
     import annif.registry
@@ -54,7 +56,11 @@ def create_cx_app(config_name: str | None = None) -> FlaskApp:
     cxapp.add_api("annif.yaml")  # validator_map=validator_map)
 
     # add CORS support
-    # CORS(cxapp.app)
+    cxapp.add_middleware(
+        CORSMiddleware,
+        position=MiddlewarePosition.BEFORE_EXCEPTION,
+        allow_origins=["*"],
+    )
 
     if cxapp.app.config["INITIALIZE_PROJECTS"]:
         annif.registry.initialize_projects(cxapp.app)

--- a/annif/cli.py
+++ b/annif/cli.py
@@ -27,7 +27,7 @@ logger = annif.logger
 click_log.basic_config(logger)
 
 
-if len(sys.argv) > 1 and sys.argv[1] == "run":
+if len(sys.argv) > 1 and sys.argv[1] in ("run", "routes"):
     create_app = annif.create_app  # Use Flask with Connexion
 else:
     # Connexion is not needed for most CLI commands, use plain Flask

--- a/annif/cli.py
+++ b/annif/cli.py
@@ -439,7 +439,7 @@ def run_eval(
 
 
 @cli.command("run")
-@click.option("--port", type=int)
+@click.option("--port", type=int, default=5000)
 @click.option("--log-level")
 @click_log.simple_verbosity_option(logger, default="ERROR")
 def run_app(**kwargs):

--- a/annif/cli.py
+++ b/annif/cli.py
@@ -30,6 +30,7 @@ cli = FlaskGroup(
     create_app=create_app, add_default_commands=False, add_version_option=False
 )
 cli = click.version_option(message="%(version)s")(cli)
+cli.params = [opt for opt in cli.params if opt.name not in ("env_file", "app")]
 
 
 @cli.command("list-projects")

--- a/annif/cli.py
+++ b/annif/cli.py
@@ -26,14 +26,10 @@ from annif.util import metric_code
 logger = annif.logger
 click_log.basic_config(logger)
 
-
-if len(sys.argv) > 1 and sys.argv[1] in ("run", "routes"):
-    create_app = annif.create_app  # Use Flask with Connexion
-else:
-    # Connexion is not needed for most CLI commands, use plain Flask
-    create_app = annif.create_flask_app
-
-cli = FlaskGroup(create_app=create_app, add_version_option=False)
+create_app = annif.create_flask_app
+cli = FlaskGroup(
+    create_app=create_app, add_default_commands=False, add_version_option=False
+)
 cli = click.version_option(message="%(version)s")(cli)
 
 
@@ -441,6 +437,21 @@ def run_eval(
             metrics_file,
             indent=2,
         )
+
+
+@cli.command("run")
+@click.option("--port", type=int)
+@click.option("--log-level")
+@click_log.simple_verbosity_option(logger, default="ERROR")
+def run_app(**kwargs):
+    """
+    Run Annif in server mode for development.
+    \f
+    The server is for development purposes only.
+    """
+    kwargs = {k: v for k, v in kwargs.items() if v is not None}
+    cxapp = annif.create_cx_app()
+    cxapp.run(**kwargs)
 
 
 FILTER_BATCH_MAX_LIMIT = 15

--- a/annif/openapi/annif.yaml
+++ b/annif/openapi/annif.yaml
@@ -174,7 +174,9 @@ paths:
       responses:
         "204":
           description: successful operation
-          content: {}
+          content:
+            application/json:
+              {}
         "404":
           $ref: '#/components/responses/NotFound'
         "503":

--- a/annif/openapi/validation.py
+++ b/annif/openapi/validation.py
@@ -22,7 +22,7 @@ class CustomRequestBodyValidator(JSONRequestBodyValidator):
 
     def _validate(self, body: Any) -> dict | None:
         if not self._nullable and body is None:
-            raise BadRequestProblem("Request body must not be empty")
+            raise BadRequestProblem("Request body must not be empty")  # noqa
         try:
             return self._validator.validate(body)
         except ValidationError as exception:

--- a/annif/openapi/validation.py
+++ b/annif/openapi/validation.py
@@ -15,20 +15,16 @@ logger = logging.getLogger("openapi.validation")
 
 class CustomRequestBodyValidator(JSONRequestBodyValidator):
     """Custom request body validator that overrides the default error message for the
-    'maxItems' validator for the 'documents' property."""
+    'maxItems' validator for the 'documents' property to prevent logging request body
+    with the contents of all documents."""
 
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
     def _validate(self, body: Any) -> dict | None:
-        if not self._nullable and body is None:
-            raise BadRequestProblem(
-                "Request body must not be empty"
-            )  # pragma: no cover
         try:
             return self._validator.validate(body)
         except ValidationError as exception:
-            # Prevent logging request body with contents of all documents
             if exception.validator == "maxItems" and list(exception.schema_path) == [
                 "properties",
                 "documents",

--- a/annif/openapi/validation.py
+++ b/annif/openapi/validation.py
@@ -22,7 +22,9 @@ class CustomRequestBodyValidator(JSONRequestBodyValidator):
 
     def _validate(self, body: Any) -> dict | None:
         if not self._nullable and body is None:
-            raise BadRequestProblem("Request body must not be empty")  # noqa
+            raise BadRequestProblem(
+                "Request body must not be empty"
+            )  # pragma: no cover
         try:
             return self._validator.validate(body)
         except ValidationError as exception:

--- a/annif/rest.py
+++ b/annif/rest.py
@@ -33,7 +33,8 @@ def server_error(err):
 def show_info():
     """return version of annif and a title for the api according to OpenAPI spec"""
 
-    return {"title": "Annif REST API", "version": importlib.metadata.version("annif")}
+    result = {"title": "Annif REST API", "version": importlib.metadata.version("annif")}
+    return result, 200, {"Content-Type": "application/json"}
 
 
 def language_not_supported_error(lang):
@@ -49,12 +50,13 @@ def language_not_supported_error(lang):
 def list_projects():
     """return a dict with projects formatted according to OpenAPI spec"""
 
-    return {
+    result = {
         "projects": [
             proj.dump()
             for proj in annif.registry.get_projects(min_access=Access.public).values()
         ]
     }
+    return result, 200, {"Content-Type": "application/json"}
 
 
 def show_project(project_id):
@@ -64,7 +66,7 @@ def show_project(project_id):
         project = annif.registry.get_project(project_id, min_access=Access.hidden)
     except ValueError:
         return project_not_found_error(project_id)
-    return project.dump()
+    return project.dump(), 200, {"Content-Type": "application/json"}
 
 
 def _suggestion_to_dict(suggestion, subject_index, language):
@@ -103,7 +105,7 @@ def suggest(project_id, body):
 
     if _is_error(result):
         return result
-    return result[0]
+    return result[0], 200, {"Content-Type": "application/json"}
 
 
 def suggest_batch(project_id, body, **query_parameters):
@@ -117,7 +119,7 @@ def suggest_batch(project_id, body, **query_parameters):
         return result
     for document_results, document in zip(result, documents):
         document_results["document_id"] = document.get("document_id")
-    return result
+    return result, 200, {"Content-Type": "application/json"}
 
 
 def _suggest(project_id, documents, parameters):
@@ -179,4 +181,4 @@ def learn(project_id, body):
     except AnnifException as err:
         return server_error(err)
 
-    return None, 204
+    return None, 204, {"Content-Type": "application/json"}

--- a/annif/rest.py
+++ b/annif/rest.py
@@ -14,8 +14,6 @@ from annif.exception import AnnifException
 from annif.project import Access
 
 if TYPE_CHECKING:
-    from datetime import datetime
-
     from connexion.lifecycle import ConnexionResponse
 
     from annif.corpus.subject import SubjectIndex
@@ -43,7 +41,7 @@ def server_error(
     )
 
 
-def show_info() -> dict[str, str]:
+def show_info() -> tuple:
     """return version of annif and a title for the api according to OpenAPI spec"""
 
     result = {"title": "Annif REST API", "version": importlib.metadata.version("annif")}
@@ -60,7 +58,7 @@ def language_not_supported_error(lang: str) -> ConnexionResponse:
     )
 
 
-def list_projects() -> dict[str, list[dict[str, str | dict | bool | datetime | None]]]:
+def list_projects() -> tuple:
     """return a dict with projects formatted according to OpenAPI spec"""
 
     result = {

--- a/annif/templates/home.html
+++ b/annif/templates/home.html
@@ -296,7 +296,7 @@ new Vue({
         return;
       }
       var this_ = this;
-      var formData = new FormData();
+      var formData = new URLSearchParams();
       formData.append('text', this_.text);
       formData.append('limit', this_.limit);
       this_.loading = true;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,17 +7,7 @@ services:
     volumes:
       - ${ANNIF_PROJECTS}:/annif-projects
     user: ${MY_UID}:${MY_GID}
-    command:
-      [
-        "gunicorn",
-        "-k",
-        "uvicorn.workers.UvicornWorker",
-        "annif:create_app()",
-        "--bind",
-        "0.0.0.0:8000",
-        "--timeout",
-        "600"
-      ]
+    command: ["gunicorn", "annif:create_app()", "--bind", "0.0.0.0:8000", "--timeout", "600"]
 
   nginx:
     image: nginx

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,17 @@ services:
     volumes:
       - ${ANNIF_PROJECTS}:/annif-projects
     user: ${MY_UID}:${MY_GID}
-    command: ["gunicorn", "annif:create_app()", "--bind", "0.0.0.0:8000", "--timeout", "600"]
+    command:
+      [
+        "gunicorn",
+        "-k",
+        "uvicorn.workers.UvicornWorker",
+        "annif:create_app()",
+        "--bind",
+        "0.0.0.0:8000",
+        "--timeout",
+        "600"
+      ]
 
   nginx:
     image: nginx

--- a/docs/source/commands.rst
+++ b/docs/source/commands.rst
@@ -121,7 +121,7 @@ Subject index administration
 
    N/A
 
-.. click:: flask.cli:run_command
+.. click:: annif.cli:run_app
    :prog: annif run
 
 **REST equivalent**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers=[
 [tool.poetry.dependencies]
 python = ">=3.8,<3.12"
 
-connexion = {version = "3.0.*", extras = ["flask","uvicorn", "swagger-ui"]}
+connexion = {version = ">=3.0.5", extras = ["flask","uvicorn", "swagger-ui"]}
 click = "8.1.*"
 click-log = "0.4.*"
 joblib = "1.3.*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,8 +30,7 @@ classifiers=[
 [tool.poetry.dependencies]
 python = ">=3.8,<3.11"
 
-connexion = {version = "3.0.0a6", allow-prereleases = true, extras = ["flask","uvicorn", "swagger-ui"]}
-flask = ">=1.0.4,<3"
+connexion = {version = "3.0.*", extras = ["flask","uvicorn", "swagger-ui"]}
 flask-cors = "3.0.*"
 click = "8.1.*"
 click-log = "0.4.*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,6 @@ classifiers=[
 python = ">=3.8,<3.12"
 
 connexion = {version = "3.0.*", extras = ["flask","uvicorn", "swagger-ui"]}
-flask-cors = "4.0.*"
 click = "8.1.*"
 click-log = "0.4.*"
 joblib = "1.3.*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 [tool.poetry.dependencies]
 python = ">=3.9,<3.12"
 
-connexion = {version = ">=3.0.5", extras = ["flask", "uvicorn", "swagger-ui"]}
+connexion = { version = "~3.0.5", extras = ["flask", "uvicorn", "swagger-ui"] }
 click = "8.1.*"
 click-log = "0.4.*"
 joblib = "1.3.*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 [tool.poetry.dependencies]
 python = ">=3.9,<3.12"
 
-connexion = {version = ">=3.0.5", extras = ["flask","uvicorn", "swagger-ui"]}
+connexion = {version = ">=3.0.5", extras = ["flask", "uvicorn", "swagger-ui"]}
 click = "8.1.*"
 click-log = "0.4.*"
 joblib = "1.3.*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers=[
 [tool.poetry.dependencies]
 python = ">=3.8,<3.11"
 
-connexion = {version = "2.14.*", extras = ["swagger-ui"]}
+connexion = {version = "3.0.0a6", allow-prereleases = true, extras = ["flask","uvicorn", "swagger-ui"]}
 flask = ">=1.0.4,<3"
 flask-cors = "3.0.*"
 click = "8.1.*"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,27 +15,32 @@ import annif.registry
 
 
 @pytest.fixture(scope="module")
-def app():
+def cxapp():
     # make sure the dummy vocab is in place because many tests depend on it
     subjfile = os.path.join(os.path.dirname(__file__), "corpora", "dummy-subjects.csv")
-    app = annif.create_app(config_name="annif.default_config.TestingConfig")
-    with app.app_context():
+    cxapp = annif.create_app(config_name="annif.default_config.TestingConfig")
+    with cxapp.app.app_context():
         project = annif.registry.get_project("dummy-en")
         # the vocab is needed for both English and Finnish language projects
         vocab = annif.corpus.SubjectFileCSV(subjfile)
         project.vocab.load_vocabulary(vocab)
-    return app
+    return cxapp
+
+
+@pytest.fixture(scope="module")
+def app(cxapp):
+    return cxapp.app
 
 
 @pytest.fixture(scope="module")
 def app_with_initialize():
-    app = annif.create_app(config_name="annif.default_config.TestingInitializeConfig")
-    return app
+    cxapp = annif.create_app(config_name="annif.default_config.TestingInitializeConfig")
+    return cxapp.app
 
 
 @pytest.fixture
-def app_client(app):
-    with app.test_client() as app_client:
+def app_client(cxapp):
+    with cxapp.test_client() as app_client:
         yield app_client
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,8 +41,8 @@ def app_with_initialize():
 @pytest.fixture(scope="module")
 @unittest.mock.patch.dict(os.environ, {"ANNIF_PROJECTS_INIT": ".*-fi"})
 def app_with_initialize_fi_projects():
-    app = annif.create_app(config_name="annif.default_config.TestingInitializeConfig")
-    return app
+    cxapp = annif.create_app(config_name="annif.default_config.TestingInitializeConfig")
+    return cxapp.app
 
 
 @pytest.fixture

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1051,7 +1051,15 @@ def test_version_option():
     assert result.output.strip() == version.strip()
 
 
-def test_run():
+@mock.patch("connexion.FlaskApp.run")
+def test_run(run):
+    result = runner.invoke(annif.cli.cli, ["run"])
+    assert not result.exception
+    assert result.exit_code == 0
+    assert run.called
+
+
+def test_run_help():
     result = runner.invoke(annif.cli.cli, ["run", "--help"])
     assert not result.exception
     assert result.exit_code == 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1055,21 +1055,7 @@ def test_run():
     result = runner.invoke(annif.cli.cli, ["run", "--help"])
     assert not result.exception
     assert result.exit_code == 0
-    assert "Run a local development server." in result.output
-
-
-def test_routes_with_flask_app():
-    # When using plain Flask only the static endpoint exists
-    result = runner.invoke(annif.cli.cli, ["routes"])
-    assert re.search(r"static\s+GET\s+\/static\/\<path:filename\>", result.output)
-    assert not re.search(r"app.home\s+GET\s+\/", result.output)
-
-
-def test_routes_with_connexion_app():
-    # When using Connexion all endpoints exist
-    result = os.popen("python annif/cli.py routes").read()
-    assert re.search(r"static\s+GET\s+\/static\/<path:filename>", result)
-    assert re.search(r"app.home\s+GET\s+\/", result)
+    assert "Run Annif in server mode for development." in result.output
 
 
 def test_completion_script_generation():

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -26,9 +26,9 @@ def test_openapi_fuzzy(case, cxapp):
 @pytest.mark.slow
 @schema.parametrize(endpoint="/v1/projects/{project_id}")
 @settings(max_examples=50)
-def test_openapi_fuzzy_target_dummy_fi(case, app):
+def test_openapi_fuzzy_target_dummy_fi(case, cxapp):
     case.path_parameters = {"project_id": "dummy-fi"}
-    response = case.call_wsgi(app)
+    response = case.call_asgi(cxapp)
     case.validate_response(response)
 
 

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -14,8 +14,8 @@ def check_cors(response, case):
 
 @schema.parametrize()
 @settings(max_examples=10)
-def test_openapi_fuzzy(case, app):
-    response = case.call_wsgi(app)
+def test_openapi_fuzzy(case, cxapp):
+    response = case.call_asgi(cxapp)
     case.validate_response(response, additional_checks=(check_cors,))
 
 
@@ -31,13 +31,13 @@ def test_openapi_fuzzy_target_dummy_fi(case, app):
 def test_openapi_list_projects(app_client):
     req = app_client.get("http://localhost:8000/v1/projects")
     assert req.status_code == 200
-    assert "projects" in req.get_json()
+    assert "projects" in req.json()
 
 
 def test_openapi_show_project(app_client):
     req = app_client.get("http://localhost:8000/v1/projects/dummy-fi")
     assert req.status_code == 200
-    assert req.get_json()["project_id"] == "dummy-fi"
+    assert req.json()["project_id"] == "dummy-fi"
 
 
 def test_openapi_show_project_nonexistent(app_client):
@@ -51,7 +51,7 @@ def test_openapi_suggest(app_client):
         "http://localhost:8000/v1/projects/dummy-fi/suggest", data=data
     )
     assert req.status_code == 200
-    assert "results" in req.get_json()
+    assert "results" in req.json()
 
 
 def test_openapi_suggest_nonexistent(app_client):
@@ -76,18 +76,18 @@ def test_openapi_suggest_batch(app_client):
         "http://localhost:8000/v1/projects/dummy-fi/suggest-batch", json=data
     )
     assert req.status_code == 200
-    body = req.get_json()
+    body = req.json()
     assert len(body) == 32
     assert body[0]["results"][0]["label"] == "dummy-fi"
 
 
-def test_openapi_suggest_batch_too_many_documents(app_client):
-    data = {"documents": [{"text": "A quick brown fox jumped over the lazy dog."}] * 33}
-    req = app_client.post(
-        "http://localhost:8000/v1/projects/dummy-fi/suggest-batch", json=data
-    )
-    assert req.status_code == 400
-    assert req.get_json()["detail"] == "too many items - 'documents'"
+# def test_openapi_suggest_batch_too_many_documents(app_client):
+#     data = {"documents": [{"text": "A quick brown fox jumped over the lazy dog."}]*33}
+#     req = app_client.post(
+#         "http://localhost:8000/v1/projects/dummy-fi/suggest-batch", json=data
+#     )
+#     assert req.status_code == 400
+#     assert req.json()["detail"] == "too many items - 'documents'"
 
 
 def test_openapi_learn(app_client):

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -83,15 +83,6 @@ def test_openapi_suggest_novocab(app_client):
     assert req.status_code == 503
 
 
-def test_openapi_suggest_emptybody(app_client):
-    data = {}
-    req = app_client.post(
-        "http://localhost:8000/v1/projects/dummy-fi/suggest", data=data
-    )
-    assert req.status_code == 400
-    assert req.json()["detail"] == "RequestBody is required"
-
-
 def test_openapi_suggest_batch(app_client):
     data = {"documents": [{"text": "A quick brown fox jumped over the lazy dog."}] * 32}
     req = app_client.post(

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -94,13 +94,13 @@ def test_openapi_suggest_batch(app_client):
     assert body[0]["results"][0]["label"] == "dummy-fi"
 
 
-# def test_openapi_suggest_batch_too_many_documents(app_client):
-#     data = {"documents": [{"text": "A quick brown fox jumped over the lazy dog."}]*33}
-#     req = app_client.post(
-#         "http://localhost:8000/v1/projects/dummy-fi/suggest-batch", json=data
-#     )
-#     assert req.status_code == 400
-#     assert req.json()["detail"] == "too many items - 'documents'"
+def test_openapi_suggest_batch_too_many_documents(app_client):
+    data = {"documents": [{"text": "A quick brown fox jumped over the lazy dog."}] * 33}
+    req = app_client.post(
+        "http://localhost:8000/v1/projects/dummy-fi/suggest-batch", json=data
+    )
+    assert req.status_code == 400
+    assert req.json()["detail"] == "too many items - 'documents'"
 
 
 def test_openapi_learn(app_client):

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -7,6 +7,15 @@ from hypothesis import settings
 schema = schemathesis.from_path("annif/openapi/annif.yaml")
 
 
+@schemathesis.hook("filter_path_parameters")
+def filter_path_parameters(context, path_parameters):
+    # Exclude path parameters containing newline which crashes application
+    # https://github.com/spec-first/connexion/issues/1908
+    if path_parameters is not None and "project_id" in path_parameters:
+        return "%0A" not in path_parameters["project_id"]
+    return True
+
+
 @schema.parametrize()
 @settings(max_examples=10)
 def test_openapi_fuzzy(case, cxapp):

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -83,6 +83,15 @@ def test_openapi_suggest_novocab(app_client):
     assert req.status_code == 503
 
 
+def test_openapi_suggest_emptybody(app_client):
+    data = {}
+    req = app_client.post(
+        "http://localhost:8000/v1/projects/dummy-fi/suggest", data=data
+    )
+    assert req.status_code == 400
+    assert req.json()["detail"] == "RequestBody is required"
+
+
 def test_openapi_suggest_batch(app_client):
     data = {"documents": [{"text": "A quick brown fox jumped over the lazy dog."}] * 32}
     req = app_client.post(

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -132,10 +132,10 @@ def test_get_project_default_params_fasttext(registry):
 
 
 def test_get_project_invalid_config_file():
-    app = annif.create_app(
+    cxapp = annif.create_app(
         config_name="annif.default_config.TestingInvalidProjectsConfig"
     )
-    with app.app_context():
+    with cxapp.app.app_context():
         with pytest.raises(ConfigurationException):
             annif.registry.get_project("duplicatedvocab")
 
@@ -285,23 +285,23 @@ def test_project_initialized(app_with_initialize):
 
 
 def test_project_file_not_found():
-    app = annif.create_app(config_name="annif.default_config.TestingNoProjectsConfig")
-    with app.app_context():
+    cxapp = annif.create_app(config_name="annif.default_config.TestingNoProjectsConfig")
+    with cxapp.app.app_context():
         with pytest.raises(ValueError):
             annif.registry.get_project("dummy-en")
 
 
 def test_project_file_toml():
-    app = annif.create_app(config_name="annif.default_config.TestingTOMLConfig")
-    with app.app_context():
+    cxapp = annif.create_app(config_name="annif.default_config.TestingTOMLConfig")
+    with cxapp.app.app_context():
         assert len(annif.registry.get_projects()) == 2
         assert annif.registry.get_project("dummy-fi-toml").project_id == "dummy-fi-toml"
         assert annif.registry.get_project("dummy-en-toml").project_id == "dummy-en-toml"
 
 
 def test_project_directory():
-    app = annif.create_app(config_name="annif.default_config.TestingDirectoryConfig")
-    with app.app_context():
+    cxapp = annif.create_app(config_name="annif.default_config.TestingDirectoryConfig")
+    with cxapp.app.app_context():
         assert len(annif.registry.get_projects()) == 18 + 2
         assert annif.registry.get_project("dummy-fi").project_id == "dummy-fi"
         assert annif.registry.get_project("dummy-fi-toml").project_id == "dummy-fi-toml"


### PR DESCRIPTION
Upgrades to Connexion 3, closes #689 and #698.

Connexion 3 introduces many changes compared to Connexion 2, see the documentation [here](https://connexion.readthedocs.io/en/stable/v3.html).

Most importantly, after the upgrade to Connexion 3, running Annif with Gunicorn requires the use Uvicorn workers; the workers can be set using the `--worker-class/-k` option of Gunicorn:

    gunicorn --worker-class uvicorn.workers.UvicornWorker "annif:create_app()"

In Dockerfile there is the [enviroment variable](https://docs.gunicorn.org/en/stable/settings.html) `GUNICORN_CMD_ARGS="--worker-class uvicorn.workers.UvicornWorker"`, which gives Gunicorn the option by default, so Docker image users do not have to worry about this change.

---
The original PR discussion below beginning from first draft.

This seems to be surprisingly difficult. Connexion 3 documentation states that there are two modes of running/usage of Connexion: 
  1.  [Using stand-alone Connexion](https://connexion.readthedocs.io/en/latest/v3.html#using-stand-alone-connexion) - use the provided Flask app via `connexion.FlaskApp`
  2. [Using Connexion with existing ASGI or WSGI frameworks](https://connexion.readthedocs.io/en/latest/v3.html#using-connexion-with-asgi-or-wsgi-frameworks) - use the "middleware" `connexion.ConnexionMiddleware` to wrap an existing Flask app 

Previously Annif has been using the mode 1, and tried to continue with that. But now
> [Connexion 3.0 needs to be run using an ASGI server instead of a WSGI server. While any ASGI server should work, connexion comes with uvicorn as an extra](https://connexion.readthedocs.io/en/latest/v3.html#asgi-server)

And the app needs to be started with

     uvicorn --factory annif:create_app

The command

     annif run

does not know about uvicorn but apparently tries to use plain Flask, and the app won't start.

There are also [smaller breaking changes](https://connexion.readthedocs.io/en/latest/v3.html#smaller-breaking-changes), that needed to be addressed:
 - [Set content-types in response headers in rest methods](https://github.com/NatLibFi/Annif/commit/6d0a68fc4582d14393fa7abb97361befe5e8f53c), because

   - "We no longer guess a content type for response serialization if multiple are defined in the spec. We do take into account returned headers." (The Annif OpenAPI spec included both `application/json` and `application/problem+json`, which seemed to be the cause.)
    - "Content type is now validated for requests and responses if defined in the spec"

-  Changing `req.get_json()` -> `req.json()` in tests, apparently because of "connexion.request is now a Starlette Request instead of a Flask Request".