### PR TITLE
Show scores in outputs of `suggest`, `eval` and `index` with 4 decimals

### DIFF
--- a/annif/cli.py
+++ b/annif/cli.py
@@ -427,12 +427,16 @@ def run_eval(
         ):
             eval_batch.evaluate_many(hit_sets[project_id], subject_sets)
 
-    template = "{0:<30}\t{1}"
+    template = "{0:<30}\t{1:{fmt_spec}}"
     metrics = eval_batch.results(
         metrics=metric, results_file=results_file, language=project.vocab_lang
     )
     for metric, score in metrics.items():
-        click.echo(template.format(metric + ":", score))
+        if isinstance(score, int):
+            fmt_spec = "d"
+        elif isinstance(score, float):
+            fmt_spec = ".04f"
+        click.echo(template.format(metric + ":", score, fmt_spec=fmt_spec))
     if metrics_file:
         json.dump(
             {metric_code(mname): val for mname, val in metrics.items()},

--- a/annif/cli_util.py
+++ b/annif/cli_util.py
@@ -166,9 +166,10 @@ def show_hits(hits, project, lang, file=None):
     a table, with one row per hit. Each row contains the URI, label, possible notation,
     and score of the suggestion. The label is given in the specified language.
     """
+    template = "<{}>\t{}\t{:.04f}"
     for hit in hits:
         subj = project.subjects[hit.subject_id]
-        line = "<{}>\t{}\t{}".format(
+        line = template.format(
             subj.uri,
             "\t".join(filter(None, (subj.labels[lang], subj.notation))),
             hit.score,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -827,7 +827,7 @@ def test_eval_resultsfile(tmpdir):
             denominator += 1
     assert precision_numerator / denominator == precision
     assert recall_numerator / denominator == recall
-    assert f_measure_numerator / denominator == f_measure
+    assert round(f_measure_numerator / denominator, 4) == f_measure
 
 
 def test_eval_badresultsfile(tmpdir):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -398,7 +398,7 @@ def test_learn_nonexistent_path():
 def test_suggest():
     result = runner.invoke(annif.cli.cli, ["suggest", "dummy-fi"], input="kissa")
     assert not result.exception
-    assert result.output == "<http://example.org/dummy>\tdummy-fi\t1.0\n"
+    assert result.output == "<http://example.org/dummy>\tdummy-fi\t1.0000\n"
     assert result.exit_code == 0
 
 
@@ -407,7 +407,7 @@ def test_suggest_with_language_override():
         annif.cli.cli, ["suggest", "--language", "en", "dummy-fi"], input="kissa"
     )
     assert not result.exception
-    assert result.output == "<http://example.org/dummy>\tdummy\t1.0\n"
+    assert result.output == "<http://example.org/dummy>\tdummy\t1.0000\n"
     assert result.exit_code == 0
 
 
@@ -427,7 +427,7 @@ def test_suggest_with_different_vocab_language():
         annif.cli.cli, ["suggest", "dummy-vocablang"], input="the cat sat on the mat"
     )
     assert not result.exception
-    assert result.output == "<http://example.org/dummy>\tdummy-fi\t1.0\n"
+    assert result.output == "<http://example.org/dummy>\tdummy-fi\t1.0000\n"
     assert result.exit_code == 0
 
 
@@ -438,7 +438,7 @@ def test_suggest_with_notations():
         input="kissa",
     )
     assert not result.exception
-    assert result.output == "<http://example.org/none>\tnone-fi\t42.42\t1.0\n"
+    assert result.output == "<http://example.org/none>\tnone-fi\t42.42\t1.0000\n"
     assert result.exit_code == 0
 
 
@@ -481,7 +481,7 @@ def test_suggest_ensemble():
         annif.cli.cli, ["suggest", "ensemble"], input="the cat sat on the mat"
     )
     assert not result.exception
-    assert result.output == "<http://example.org/dummy>\tdummy\t1.0\n"
+    assert result.output == "<http://example.org/dummy>\tdummy\t1.0000\n"
     assert result.exit_code == 0
 
 
@@ -493,7 +493,7 @@ def test_suggest_file(tmpdir):
 
     assert not result.exception
     assert f"Suggestions for {docfile}" in result.output
-    assert "<http://example.org/dummy>\tdummy-fi\t1.0\n" in result.output
+    assert "<http://example.org/dummy>\tdummy-fi\t1.0000\n" in result.output
     assert result.exit_code == 0
 
 
@@ -510,7 +510,7 @@ def test_suggest_two_files(tmpdir):
     assert not result.exception
     assert f"Suggestions for {docfile1}" in result.output
     assert f"Suggestions for {docfile2}" in result.output
-    assert result.output.count("<http://example.org/dummy>\tdummy-fi\t1.0\n") == 2
+    assert result.output.count("<http://example.org/dummy>\tdummy-fi\t1.0000\n") == 2
     assert result.exit_code == 0
 
 
@@ -528,7 +528,7 @@ def test_suggest_two_files_docs_limit(tmpdir):
     assert not result.exception
     assert f"Suggestions for {docfile1}" in result.output
     assert f"Suggestions for {docfile2}" not in result.output
-    assert result.output.count("<http://example.org/dummy>\tdummy-fi\t1.0\n") == 1
+    assert result.output.count("<http://example.org/dummy>\tdummy-fi\t1.0000\n") == 1
     assert result.exit_code == 0
 
 
@@ -543,7 +543,7 @@ def test_suggest_file_and_stdin(tmpdir):
     assert not result.exception
     assert f"Suggestions for {docfile1}" in result.output
     assert "Suggestions for -" in result.output
-    assert result.output.count("<http://example.org/dummy>\tdummy-fi\t1.0\n") == 2
+    assert result.output.count("<http://example.org/dummy>\tdummy-fi\t1.0000\n") == 2
     assert result.exit_code == 0
 
 
@@ -564,7 +564,7 @@ def test_suggest_dash_path():
         annif.cli.cli, ["suggest", "dummy-fi", "-"], input="the cat sat on the mat"
     )
     assert not result.exception
-    assert result.output == "<http://example.org/dummy>\tdummy-fi\t1.0\n"
+    assert result.output == "<http://example.org/dummy>\tdummy-fi\t1.0000\n"
     assert result.exit_code == 0
 
 
@@ -578,7 +578,7 @@ def test_index(tmpdir):
     assert tmpdir.join("doc1.annif").exists()
     assert (
         tmpdir.join("doc1.annif").read_text("utf-8")
-        == "<http://example.org/dummy>\tdummy\t1.0\n"
+        == "<http://example.org/dummy>\tdummy\t1.0000\n"
     )
 
     # make sure that preexisting subject files are not overwritten
@@ -593,7 +593,7 @@ def test_index(tmpdir):
     assert "Not overwriting" not in result.output
     assert (
         tmpdir.join("doc1.annif").read_text("utf-8")
-        == "<http://example.org/dummy>\tdummy-fi\t1.0\n"
+        == "<http://example.org/dummy>\tdummy-fi\t1.0000\n"
     )
 
 
@@ -609,7 +609,7 @@ def test_index_with_language_override(tmpdir):
     assert tmpdir.join("doc1.annif").exists()
     assert (
         tmpdir.join("doc1.annif").read_text("utf-8")
-        == "<http://example.org/dummy>\tdummy-fi\t1.0\n"
+        == "<http://example.org/dummy>\tdummy-fi\t1.0000\n"
     )
 
 


### PR DESCRIPTION
Currently the output of `annif suggest` (to stdout) and `annif index` (to `document.annif` file) is e.g. as follows:
```
<http://www.yso.fi/onto/yso/p109998>	Röyttä (Ii)	0.4971785247325897
<http://www.yso.fi/onto/yso/p38304>	stabiilius (muuttumattomuus)	0.4472784399986267
<http://www.yso.fi/onto/yso/p10546>	hydrodynamiikka	0.4472784399986267
<http://www.yso.fi/onto/yso/p2048>	jääliikenne	0.44725048542022705
<http://www.yso.fi/onto/yso/p4911>	laivat	0.42701175808906555
<http://www.yso.fi/onto/yso/p12284>	hinaajat	0.40847617387771606
<http://www.yso.fi/onto/yso/p19211>	hydrostatiikka	0.3946342170238495
<http://www.yso.fi/onto/yso/p17953>	rahtilaivat	0.37881672382354736
<http://www.yso.fi/onto/yso/p16317>	höyrylaivat	0.36528536677360535
<http://www.yso.fi/onto/yso/p3976>	koneistot	0.3235071897506714
```
And the output of `annif eval`:
```
Precision (doc avg):          	0.12500000000000003
Recall (doc avg):             	0.2593537414965987
F1 score (doc avg):           	0.16722522342270243
Precision (subj avg):         	0.0006919161493665802
Recall (subj avg):            	0.0005637320849872252
F1 score (subj avg):          	0.00058845613207959
Precision (weighted subj avg):	0.42108585858585856
Recall (weighted subj avg):   	0.26515151515151514
F1 score (weighted subj avg): 	0.3055555555555555
Precision (microavg):         	0.125
Recall (microavg):            	0.26515151515151514
F1 score (microavg):          	0.16990291262135923
F1@5:                         	0.17080142080142083
NDCG:                         	0.23108215630054474
NDCG@5:                       	0.19264987111091614
NDCG@10:                      	0.23108215630054474
Precision@1:                  	0.21428571428571427
Precision@3:                  	0.21428571428571425
Precision@5:                  	0.17142857142857149
True positives:               	35
False positives:              	245
False negatives:              	97
Documents evaluated:          	28
```

The very many decimals make reading the outputs a bit hard, but they don't offer any significant value.

This PR makes the shown scores to be rounded to 4 decimal places.
