### PR TITLE
Test CLI startup time with CI/CD job

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -36,6 +36,24 @@ jobs:
       run: |
         poetry run flake8
 
+  time-startup:
+    runs-on: ubuntu-22.04
+    name: check CLI startup time
+    steps:
+    - uses: actions/checkout@v3
+    - name: "Prepare: restore caches, install Poetry, set up Python"
+      id: prepare
+      uses: ./.github/actions/prepare
+      with:
+        python-version: "3.9"
+        poetry-version: ${{ env.POETRY_VERSION }}
+    - name: Install Python dependencies
+      run: |
+        poetry install
+    - name: Check startup time
+      run: |
+        poetry run tests/time-startup.sh
+
   test:
     runs-on: ubuntu-22.04
     timeout-minutes: 15

--- a/tests/time-startup.sh
+++ b/tests/time-startup.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Function to measure startup time
+measure_startup_time() {
+    startup_time=$( { time -p annif --help >/dev/null; } 2>&1 | awk '/^user/{u=$2}/^sys/{s=$2} END{print u+s}' )
+    echo "$startup_time"
+}
+
+startup_time1=$(measure_startup_time)
+startup_time2=$(measure_startup_time)
+startup_time3=$(measure_startup_time)
+startup_time4=$(measure_startup_time)
+
+# Calculate the average startup time
+average_startup_time=$(echo "scale=3; ($startup_time1 + $startup_time2 + $startup_time3 + $startup_time4) / 4" | bc)
+
+# Print the average startup time
+echo "Average Startup time: $average_startup_time seconds"
+
+# Set the threshold for acceptable startup time in seconds
+threshold=0.300
+
+# Compare the average startup time with the threshold
+if (( $(echo "$average_startup_time > $threshold" | bc -l) )); then
+    echo "Startup time (user + sys time) exceeds the threshold of $threshold s. Test failed."
+    exit 1
+fi


### PR DESCRIPTION
Adds a GitHub Actions job with a shell script for measuring the CLI startup time to prevent its unnoticed deterioration.

The startup time was optimized in #696, and now it is good make sure the startup remains fast. For example, I noticed that adding type hints (planned in #690) [can slow the startup, but this can be avoided by postponing the evaluation of annotations](https://docs.python.org/3/whatsnew/3.7.html#pep-563-postponed-evaluation-of-annotations).

The timing script executes `annif --help` four times and measures user + sys time. If the average of the user + sys time is over a threshold, the job fails. The threshold is set to 0.300 s.

In the [five previous runs](https://github.com/NatLibFi/Annif/actions/runs/5022302154) the measured time was 0.245 s, 0.240 s, 0.252 s, 0.242 s and 0.245 s, but in some earlier runs the measured time was over 0.300 s. So failures can be expected, however I think it does not matter if they are reasonably rare (say ~10% of runs).

Failure of this job does not make the other jobs fail, so unit testing, linting and publishing are run in any case.
