### PR TITLE
Ensure system packages are up-to-date in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ARG optional_dependencies="voikko fasttext nn omikuji yake spacy stwfsa"
 ARG POETRY_VIRTUALENVS_CREATE=false
 
 # Install system dependencies needed at runtime:
-RUN apt-get update && \
+RUN apt-get update && apt-get upgrade && \
 	if [[ $optional_dependencies =~ "voikko" ]]; then \
 		apt-get install -y --no-install-recommends \
 			libvoikko1 \


### PR DESCRIPTION
Run `apt-get upgrade` in Docker build to ensure that system packages are up-to-date in the image.