### PR TITLE
Fix missing confirmation in apt-upgrade in Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ARG optional_dependencies="voikko fasttext nn omikuji yake spacy stwfsa"
 ARG POETRY_VIRTUALENVS_CREATE=false
 
 # Install system dependencies needed at runtime:
-RUN apt-get update && apt-get upgrade && \
+RUN apt-get update && apt-get upgrade -y && \
 	if [[ $optional_dependencies =~ "voikko" ]]; then \
 		apt-get install -y --no-install-recommends \
 			libvoikko1 \


### PR DESCRIPTION
`apt-get upgrade` was added in Docker build to ensure that system packages are up-to-date in the image in PR #707, but I did not add `-y` option to it, because it seemed unnecessary as the command worked while testing without it (and in this [SO post](https://askubuntu.com/questions/976080/is-y-redundant-in-apt-get-update) the `-y` was concluded to be unnecessary, but the post was about `apt-get update`!) 

However, it seems that when there is some packages to upgrade, then then the `-y` option is necessary. Without it the [build](https://github.com/NatLibFi/Annif/actions/runs/5175147366/jobs/9322461848) fails:
```#5 2.926 Reading state information...
#5 2.944 Calculating upgrade...
#5 3.091 The following packages will be upgraded:
#5 3.091   libssl1.1 openssl
#5 3.094 2 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
#5 3.094 Need to get 2413 kB of archives.
#5 3.094 After this operation, 4096 B disk space will be freed.
#5 3.094 Do you want to continue? [Y/n] Abort.
------
ERROR: failed to solve: executor failed running [/bin/bash -c apt-get update && apt-get upgrade && 	if [[ $optional_dependencies =~ "voikko" ]]; then 		apt-get install -y --no-install-recommends 			libvoikko1 			voikko-fi; 	fi && 	apt-get install -y --no-install-recommends rsync && 	rm -rf /var/lib/apt/lists/* /usr/include/*]: exit code: 1
Error: buildx failed with: ERROR: failed to solve: executor failed running [/bin/bash -c apt-get update && apt-get upgrade && 	if [[ $optional_dependencies =~ "voikko" ]]; then 		apt-get install -y --no-install-recommends 			libvoikko1 			voikko-fi; 	fi && 	apt-get install -y --no-install-recommends rsync && 	rm -rf /var/lib/apt/lists/* /usr/include/*]: exit code: 1