### PR TITLE
Scheduled weekly rebuild of Docker image of latest release

### DIFF
--- a/.github/workflows/cron-rebuild.yml
+++ b/.github/workflows/cron-rebuild.yml
@@ -1,0 +1,53 @@
+name: "Docker rebuild"
+on:
+  push:  # TODO Remove
+    branches:
+    - rebuild-docker-image-cron
+  workflow_dispatch:
+  schedule:
+  - cron: "22 8 * * 1"  # At 08:22 on Mondays UTC
+jobs:
+  rebuild-docker-images:
+    name: "Docker rebuild"
+    runs-on: ubuntu-22.04
+    timeout-minutes: 15
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: "Checkout most recent tag"
+      run: |
+        git fetch --tags origin
+        git describe --abbrev=0 | xargs git checkout
+    - name: "Build for testing"
+      uses: docker/build-push-action@c56af957549030174b10d6867f20e78cfd7debc5  # v3.2.0
+      with:
+        push: false
+        tags: test-image
+    - name: "Test with pytest"
+      run: |
+        docker run --rm --workdir /Annif test-image pytest -p no:cacheprovider
+    - name: Login to Quay.io
+      uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc  # v2.2.0
+      with:
+        # registry: quay.io  # TODO Switch back to quay.io
+        username: ${{ secrets.JUHON_DOCKERHUB_USERNAME }}
+        password: ${{ secrets.JUHON_DOCKERHUB_TOKEN }}
+    - name: Docker meta
+      id: meta
+      uses: docker/metadata-action@2c0bd771b40637d97bf205cbccdd294a32112176  # v4.5.0
+      with:
+        context: git
+        images: jinkinen/annif
+        # images: quay.io/natlibfi/annif # TODO Switch back
+        flavor: |
+          latest=false
+        tags: |
+          type=semver,pattern={{version}}
+          type=semver,pattern={{major}}.{{minor}}
+    - name: Build and push to Quay.io
+      uses: docker/build-push-action@44ea916f6c540f9302d50c2b1e5a8dc071f15cdf  # v4.1.0
+      with:
+        push: true
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
It might be a good idea to rebuild Docker images of "maintained" releases regularly for package updates. We could consider only the most recent release to be "maintained" in this sense (for now at least).

This PR adds a weekly run GH Actions workflow, which

1. checkouts the git tag of the latest release
2. builds image and tests it with pytest
3. pushes the image

Currently the image is pushed to my [DockerHub account](https://hub.docker.com/repository/docker/jinkinen/annif/tags?page=1&ordering=last_updated), and the schedule does not work because the (cron) workflow is not in the main branch.