### PR TITLE
Fix GitHub Actions workflow: Do not require "publish Docker latest" before "publish release"

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -154,7 +154,7 @@ jobs:
 
   publish-release:
     name: publish release
-    needs: [publish-docker-latest]
+    needs: [lint, test, test-docker-image]
     runs-on: ubuntu-22.04
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
     steps:


### PR DESCRIPTION
I tried to streamline the CI/CD workflow by making "publish release" job to require "publish latest Docker image" job in #712. 

I did not consider that the ["publish latest Docker image" job is skipped for tag events](https://github.com/NatLibFi/Annif/actions/runs/4730405830), and so also the "publish release" job would be skipped and never run.

Better to revert back to the previous configuration, where both jobs in question require the same test/lint jobs.
