### PR TITLE
Add GH Actions workflow for rebuilding the Docker image of the latest release

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -183,8 +183,8 @@ jobs:
       with:
         images: quay.io/natlibfi/annif
         tags: |
-          type=semver,pattern={{version}}
           type=semver,pattern={{version}},suffix=-{{date 'YYYYMMDD'}}
+          type=semver,pattern={{version}}
           type=semver,pattern={{major}}.{{minor}}
     - name: Build and push to Quay.io
       uses: docker/build-push-action@c56af957549030174b10d6867f20e78cfd7debc5  # v3.2.0

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -184,6 +184,7 @@ jobs:
         images: quay.io/natlibfi/annif
         tags: |
           type=semver,pattern={{version}}
+          type=semver,pattern={{version}},suffix=-{{date 'YYYYMMDD'}}
           type=semver,pattern={{major}}.{{minor}}
     - name: Build and push to Quay.io
       uses: docker/build-push-action@c56af957549030174b10d6867f20e78cfd7debc5  # v3.2.0

--- a/.github/workflows/docker-rebuild.yml
+++ b/.github/workflows/docker-rebuild.yml
@@ -41,6 +41,7 @@ jobs:
           latest=false
         tags: |
           type=semver,pattern={{version}}
+          type=semver,pattern={{version}},suffix=-{{date 'YYYYMMDD'}}
           type=semver,pattern={{major}}.{{minor}}
     - name: Build and push to Quay.io
       uses: docker/build-push-action@44ea916f6c540f9302d50c2b1e5a8dc071f15cdf  # v4.1.0

--- a/.github/workflows/docker-rebuild.yml
+++ b/.github/workflows/docker-rebuild.yml
@@ -1,6 +1,5 @@
 name: "Docker rebuild"
-on:
-  workflow_dispatch:
+on: workflow_dispatch
 jobs:
   rebuild-docker-images:
     name: "Docker rebuild"

--- a/.github/workflows/docker-rebuild.yml
+++ b/.github/workflows/docker-rebuild.yml
@@ -20,6 +20,7 @@ jobs:
     - name: "Build for testing"
       uses: docker/build-push-action@c56af957549030174b10d6867f20e78cfd7debc5  # v3.2.0
       with:
+        context: .
         push: false
         tags: test-image
     - name: "Test with pytest"
@@ -46,6 +47,7 @@ jobs:
     - name: Build and push to Quay.io
       uses: docker/build-push-action@44ea916f6c540f9302d50c2b1e5a8dc071f15cdf  # v4.1.0
       with:
+        context: .
         push: true
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-rebuild.yml
+++ b/.github/workflows/docker-rebuild.yml
@@ -9,14 +9,9 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    - name: "Checkout most recent tag"
-      run: |
-        git fetch --tags origin
-        git describe --abbrev=0 | xargs git checkout
     - name: "Build for testing"
       uses: docker/build-push-action@c56af957549030174b10d6867f20e78cfd7debc5  # v3.2.0
       with:
-        context: .
         push: false
         tags: test-image
     - name: "Test with pytest"
@@ -43,7 +38,6 @@ jobs:
     - name: Build and push to Quay.io
       uses: docker/build-push-action@44ea916f6c540f9302d50c2b1e5a8dc071f15cdf  # v4.1.0
       with:
-        context: .
         push: true
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-rebuild.yml
+++ b/.github/workflows/docker-rebuild.yml
@@ -6,9 +6,6 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 15
     steps:
-    - uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
     - name: "Build for testing"
       uses: docker/build-push-action@c56af957549030174b10d6867f20e78cfd7debc5  # v3.2.0
       with:
@@ -27,7 +24,6 @@ jobs:
       id: meta
       uses: docker/metadata-action@2c0bd771b40637d97bf205cbccdd294a32112176  # v4.5.0
       with:
-        context: git
         images: quay.io/natlibfi/annif
         flavor: |
           latest=false

--- a/.github/workflows/docker-rebuild.yml
+++ b/.github/workflows/docker-rebuild.yml
@@ -1,0 +1,50 @@
+name: "Docker rebuild"
+on:
+  push:  # TODO Remove
+    branches:
+    - rebuild-docker-image
+  workflow_dispatch:
+jobs:
+  rebuild-docker-images:
+    name: "Docker rebuild"
+    runs-on: ubuntu-22.04
+    timeout-minutes: 15
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: "Checkout most recent tag"
+      run: |
+        git fetch --tags origin
+        git describe --abbrev=0 | xargs git checkout
+    - name: "Build for testing"
+      uses: docker/build-push-action@c56af957549030174b10d6867f20e78cfd7debc5  # v3.2.0
+      with:
+        push: false
+        tags: test-image
+    - name: "Test with pytest"
+      run: |
+        docker run --rm --workdir /Annif test-image pytest -p no:cacheprovider
+    - name: Login to Quay.io
+      uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc  # v2.2.0
+      with:
+        registry: quay.io
+        username: ${{ secrets.YHTEENTOIMIVUUSPALVELUT_QUAY_IO_USERNAME }}
+        password: ${{ secrets.YHTEENTOIMIVUUSPALVELUT_QUAY_IO_PASSWORD }}
+    - name: Docker meta
+      id: meta
+      uses: docker/metadata-action@2c0bd771b40637d97bf205cbccdd294a32112176  # v4.5.0
+      with:
+        context: git
+        images: quay.io/natlibfi/annif
+        flavor: |
+          latest=false
+        tags: |
+          type=semver,pattern={{version}}
+          type=semver,pattern={{major}}.{{minor}}
+    - name: Build and push to Quay.io
+      uses: docker/build-push-action@44ea916f6c540f9302d50c2b1e5a8dc071f15cdf  # v4.1.0
+      with:
+        push: true
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-rebuild.yml
+++ b/.github/workflows/docker-rebuild.yml
@@ -1,8 +1,5 @@
 name: "Docker rebuild"
 on:
-  push:  # TODO Remove
-    branches:
-    - rebuild-docker-image
   workflow_dispatch:
 jobs:
   rebuild-docker-images:

--- a/.github/workflows/docker-rebuild.yml
+++ b/.github/workflows/docker-rebuild.yml
@@ -41,8 +41,8 @@ jobs:
         flavor: |
           latest=false
         tags: |
-          type=semver,pattern={{version}}
           type=semver,pattern={{version}},suffix=-{{date 'YYYYMMDD'}}
+          type=semver,pattern={{version}}
           type=semver,pattern={{major}}.{{minor}}
     - name: Build and push to Quay.io
       uses: docker/build-push-action@44ea916f6c540f9302d50c2b1e5a8dc071f15cdf  # v4.1.0


### PR DESCRIPTION
This is a simplified version of PR #713: instead of doing rebuilds automatically with a schedule, this just intends to use the "workflow dispatch" trigger to manually start the build.

The Docker images of "maintained" releases should be rebuild regularly for system package updates, but this can be done manually (and for Annif deployments it is probably a good idea to have manual control on when updates happen).

For now is probably enough to consider only the most recent release to be "maintained" in this sense, but [any tag (since merging this PR) can selected for rebuild](https://docs.github.com/en/actions/using-workflows/manually-running-a-workflow#running-a-workflow).

This PR adds a GH Actions workflow, which

1. checkouts the git tag of the selected release
2. builds the image and tests it with pytest
3. pushes the image to quay.io with these tags of the release:
    -  `<major>.<minor>`
    -  `<major>.<minor>.<patch>`
    -  `<major>.<minor>.<patch>-<YYYYMMDD>` (date of build)

The date suffix allows pinning to a particular build of Annif's Docker image (assuming only one build per day), which is necessary also to retain a tag on an image, which would otherwise be purged from the quay.io repository, making pinning with manifest digests impossible.

The date suffix is also added to the image tags when doing the (initial) image builds for Annif releases.