### PR TITLE
Fix Python version in GH Actions CI/CD pipeline

### DIFF
--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -25,7 +25,7 @@ runs:
     - name: Install Poetry
       shell: bash
       run: |
-        pipx install poetry==${{ inputs.poetry-version }}
+        pipx install poetry==${{ inputs.poetry-version }} --python $(which python${{ inputs.python-version }})
     - name: Set up Python ${{ inputs.python-version }}
       uses: actions/setup-python@5ccb29d8773c3f3f653e1705f474dfaa8a06a912  # v4.4.0
       with:

--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -22,11 +22,11 @@ runs:
         key: ignore-me
         restore-keys: |
           poetry-installation-and-cache-${{ inputs.python-version }}-${{ inputs.poetry-version }}-
-    - name: Install Poetry
-      shell: bash
-      run: |
-        pipx install poetry==${{ inputs.poetry-version }} --python $(which python${{ inputs.python-version }})
     - name: Set up Python ${{ inputs.python-version }}
       uses: actions/setup-python@5ccb29d8773c3f3f653e1705f474dfaa8a06a912  # v4.4.0
       with:
         python-version: ${{ inputs.python-version }}
+    - name: Install Poetry
+      shell: bash
+      run: |
+        pipx install poetry==${{ inputs.poetry-version }} --python $(which python${{ inputs.python-version }})

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -10,7 +10,7 @@ on:
 env:
   PIPX_HOME: "/home/runner/.cache/pipx"
   PIPX_BIN_DIR: "/home/runner/.local/bin"
-  POETRY_VERSION: "1.4.1"
+  POETRY_VERSION: "1.5.1"
 jobs:
 
   lint:


### PR DESCRIPTION
All test jobs were using Python 3.10 although the intent was to use the ones defined in the matrix, i.e. 3.0, 3.9 and 3.10. This was visible only(?) in the output of the pytest step, which for all jobs was:

    platform linux -- Python 3.10.6, pytest-7.4.0, pluggy-1.2.0

The wrong version of Python was in use because Poetry was installed with pipx, which seemed to use Python 3.10 by default.

The intended Python version is now given to pipx when installing poetry, and this need to be done only after the Python set-up step.

Also upgrades Poetry to v1.5.1