### PR TITLE
Fix missing limit parameter in STWFSA backend

### DIFF
--- a/annif/backend/backend.py
+++ b/annif/backend/backend.py
@@ -40,7 +40,9 @@ class AnnifBackend(metaclass=abc.ABCMeta):
         self.datadir = project.datadir
 
     def default_params(self) -> dict[str, Any]:
-        return self.DEFAULT_PARAMETERS
+        params = AnnifBackend.DEFAULT_PARAMETERS.copy()
+        params.update(self.DEFAULT_PARAMETERS)  # Optional backend specific parameters
+        return params
 
     @property
     def params(self) -> dict[str, Any]:

--- a/annif/backend/dummy.py
+++ b/annif/backend/dummy.py
@@ -18,9 +18,6 @@ class DummyBackend(backend.AnnifLearningBackend):
     is_trained = True
     modification_time = None
 
-    def default_params(self) -> dict[str, int]:
-        return backend.AnnifBackend.DEFAULT_PARAMETERS
-
     def initialize(self, parallel: bool = False) -> None:
         self.initialized = True
 

--- a/annif/backend/mllm.py
+++ b/annif/backend/mllm.py
@@ -13,7 +13,7 @@ from annif.exception import NotInitializedException, NotSupportedException
 from annif.lexical.mllm import MLLMModel
 from annif.suggestion import vector_to_suggestions
 
-from . import backend, hyperopt
+from . import hyperopt
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -94,11 +94,6 @@ class MLLMBackend(hyperopt.AnnifHyperoptBackend):
 
     def get_hp_optimizer(self, corpus: DocumentCorpus, metric: str) -> MLLMOptimizer:
         return MLLMOptimizer(self, corpus, metric)
-
-    def default_params(self) -> dict[str, Any]:
-        params = backend.AnnifBackend.DEFAULT_PARAMETERS.copy()
-        params.update(self.DEFAULT_PARAMETERS)
-        return params
 
     def _load_model(self) -> MLLMModel:
         path = os.path.join(self.datadir, self.MODEL_FILE)

--- a/annif/backend/nn_ensemble.py
+++ b/annif/backend/nn_ensemble.py
@@ -112,11 +112,6 @@ class NNEnsembleBackend(backend.AnnifLearningBackend, ensemble.BaseEnsembleBacke
     # defaults for uninitialized instances
     _model = None
 
-    def default_params(self) -> dict[str, Any]:
-        params = backend.AnnifBackend.DEFAULT_PARAMETERS.copy()
-        params.update(self.DEFAULT_PARAMETERS)
-        return params
-
     def initialize(self, parallel: bool = False) -> None:
         super().initialize(parallel)
         if self._model is not None:

--- a/annif/backend/omikuji.py
+++ b/annif/backend/omikuji.py
@@ -43,11 +43,6 @@ class OmikujiBackend(mixins.TfidfVectorizerMixin, backend.AnnifBackend):
         "collapse_every_n_layers": 0,
     }
 
-    def default_params(self) -> dict[str, Any]:
-        params = backend.AnnifBackend.DEFAULT_PARAMETERS.copy()
-        params.update(self.DEFAULT_PARAMETERS)
-        return params
-
     def _initialize_model(self) -> None:
         if self._model is None:
             path = os.path.join(self.datadir, self.MODEL_FILE)

--- a/annif/backend/pav.py
+++ b/annif/backend/pav.py
@@ -17,7 +17,7 @@ import annif.util
 from annif.exception import NotInitializedException, NotSupportedException
 from annif.suggestion import SubjectSuggestion, SuggestionBatch
 
-from . import backend, ensemble
+from . import ensemble
 
 if TYPE_CHECKING:
     from annif.corpus.document import DocumentCorpus
@@ -35,11 +35,6 @@ class PAVBackend(ensemble.BaseEnsembleBackend):
     _models = None
 
     DEFAULT_PARAMETERS = {"min-docs": 10}
-
-    def default_params(self) -> dict[str, Any]:
-        params = backend.AnnifBackend.DEFAULT_PARAMETERS.copy()
-        params.update(self.DEFAULT_PARAMETERS)
-        return params
 
     def initialize(self, parallel: bool = False) -> None:
         super().initialize(parallel)

--- a/annif/backend/svc.py
+++ b/annif/backend/svc.py
@@ -33,11 +33,6 @@ class SVCBackend(mixins.TfidfVectorizerMixin, backend.AnnifBackend):
 
     DEFAULT_PARAMETERS = {"min_df": 1, "ngram": 1}
 
-    def default_params(self) -> dict[str, Any]:
-        params = backend.AnnifBackend.DEFAULT_PARAMETERS.copy()
-        params.update(self.DEFAULT_PARAMETERS)
-        return params
-
     def _initialize_model(self) -> None:
         if self._model is None:
             path = os.path.join(self.datadir, self.MODEL_FILE)

--- a/annif/backend/yake.py
+++ b/annif/backend/yake.py
@@ -45,11 +45,6 @@ class YakeBackend(backend.AnnifBackend):
         "remove_parentheses": False,
     }
 
-    def default_params(self) -> dict[str, Any]:
-        params = backend.AnnifBackend.DEFAULT_PARAMETERS.copy()
-        params.update(self.DEFAULT_PARAMETERS)
-        return params
-
     @property
     def is_trained(self):
         return True

--- a/tests/test_backend_stwfsa.py
+++ b/tests/test_backend_stwfsa.py
@@ -24,6 +24,7 @@ def test_stwfsa_default_params(project):
         backend_id=stwfsa_backend_name, config_params={}, project=project
     )
     expected_default_params = {
+        "limit": 100,
         "concept_type_uri": "http://www.w3.org/2004/02/skos/core#Concept",
         "sub_thesaurus_type_uri": "http://www.w3.org/2004/02/skos/core#Collection",
         "thesaurus_relation_type_uri": "http://www.w3.org/2004/02/skos/core#member",


### PR DESCRIPTION
I noticed that if a STWFSA project configuration did not set the `limit` paramter, the operations based on suggest functionality (CLI commands suggest, eval, index...) were crashing:
```
echo kissa | annif suggest stwfsa-fi  
Traceback (most recent call last):
  File "/home/local/jmminkin/.cache/pypoetry/virtualenvs/annif-ul-EXdhi-py3.10/bin/annif", line 6, in <module>
    sys.exit(cli())
  File "/home/jmminkin/.cache/pypoetry/virtualenvs/annif-ul-EXdhi-py3.10/lib/python3.10/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/home/jmminkin/.cache/pypoetry/virtualenvs/annif-ul-EXdhi-py3.10/lib/python3.10/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/home/jmminkin/.cache/pypoetry/virtualenvs/annif-ul-EXdhi-py3.10/lib/python3.10/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/jmminkin/.cache/pypoetry/virtualenvs/annif-ul-EXdhi-py3.10/lib/python3.10/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/jmminkin/.cache/pypoetry/virtualenvs/annif-ul-EXdhi-py3.10/lib/python3.10/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/home/jmminkin/.cache/pypoetry/virtualenvs/annif-ul-EXdhi-py3.10/lib/python3.10/site-packages/click/decorators.py", line 26, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/home/jmminkin/.cache/pypoetry/virtualenvs/annif-ul-EXdhi-py3.10/lib/python3.10/site-packages/flask/cli.py", line 357, in decorator
    return __ctx.invoke(f, *args, **kwargs)
  File "/home/jmminkin/.cache/pypoetry/virtualenvs/annif-ul-EXdhi-py3.10/lib/python3.10/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/home/local/jmminkin/git/Annif/annif/cli.py", line 284, in run_suggest
    suggestions = project.suggest([text], backend_params).filter(limit, threshold)[
  File "/home/local/jmminkin/git/Annif/annif/project.py", line 253, in suggest
    return self._suggest_with_backend(texts, backend_params)
  File "/home/local/jmminkin/git/Annif/annif/project.py", line 143, in _suggest_with_backend
    return self.backend.suggest(texts, beparams)
  File "/home/local/jmminkin/git/Annif/annif/backend/backend.py", line 130, in suggest
    return self._suggest_batch(texts, params=beparams)
  File "/home/local/jmminkin/git/Annif/annif/backend/backend.py", line 118, in _suggest_batch
    limit=int(params.get("limit")),
TypeError: int() argument must be a string, a bytes-like object or a real number, not 'NoneType'
```

The default `limit` parameter was not obtainable from [`AnnifBackend.DEFAULT_PARAMETERS`](https://github.com/NatLibFi/Annif/blob/320af2b5d06addee0d13c429078e9b2a895b5d46/annif/backend/backend.py#L26), because `StwfsaBackend` class defined its own[ `DEFAULT_PARAMETERS` field](https://github.com/NatLibFi/Annif/blob/320af2b5d06addee0d13c429078e9b2a895b5d46/annif/backend/stwfsa.py#L49-L62) (without the limit parameter), but not a `default_params()` method. Other backends having their own `DEFAULT_PARAMETERS` field had that method to include the `AnnifBackend.DEFAULT_PARAMETERS` in the parameters.

I changed the `AnnifBackend.default_params()` method to include both `DEFAULT_PARAMETERS` from `AnnifBackend` (base) class and from the instances of the concrete backend (derived) classes, like most backends were already doing. This way there is no need to duplicate the method in so many backend classes. 

In the fasttext backend the [`default_params()` method](https://github.com/NatLibFi/Annif/blob/320af2b5d06addee0d13c429078e9b2a895b5d46/annif/backend/fasttext.py#L59-L63) includes also `DEFAULT_PARAMETERS` from `mixins.ChunkingBackend`, so it is needed to be retained to override the new `AnnifBackend.default_params()` method.

