### PR TITLE
Suppress TensorFlow info messages to debug level

### DIFF
--- a/annif/__init__.py
+++ b/annif/__init__.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING
 logging.basicConfig()
 logger = logging.getLogger("annif")
 logger.setLevel(level=logging.INFO)
+os.environ.setdefault("TF_CPP_MIN_LOG_LEVEL", "1")  # Hide TF info messages by default
 
 import annif.backend  # noqa
 

--- a/annif/__init__.py
+++ b/annif/__init__.py
@@ -85,8 +85,8 @@ def _set_tensorflow_loglevel():
         0: "0",  # NOTSET
         10: "0",  # DEBUG
         20: "1",  # INFO
-        30: "2",  # WARNING
-        40: "3",  # ERROR
+        30: "1",  # WARNING
+        40: "2",  # ERROR
         50: "3",  # CRITICAL
     }
     tf_loglevel = tf_loglevel_mapping[annif_loglevel]

--- a/annif/__init__.py
+++ b/annif/__init__.py
@@ -80,6 +80,9 @@ def _get_config_name(config_name: str | None) -> str:
 
 
 def _set_tensorflow_loglevel():
+    """Set TensorFlow log level based on Annif log level (--verbosity/-v
+    option) using an environment variable. INFO messages by TF are shown only on
+    DEBUG (or NOTSET) level of Annif."""
     annif_loglevel = logger.getEffectiveLevel()
     tf_loglevel_mapping = {
         0: "0",  # NOTSET

--- a/annif/__init__.py
+++ b/annif/__init__.py
@@ -10,7 +10,6 @@ from typing import TYPE_CHECKING
 logging.basicConfig()
 logger = logging.getLogger("annif")
 logger.setLevel(level=logging.INFO)
-os.environ.setdefault("TF_CPP_MIN_LOG_LEVEL", "1")  # Hide TF info messages by default
 
 import annif.backend  # noqa
 
@@ -21,6 +20,8 @@ if TYPE_CHECKING:
 def create_flask_app(config_name: str | None = None) -> Flask:
     """Create a Flask app to be used by the CLI."""
     from flask import Flask
+
+    _set_tensorflow_loglevel()
 
     app = Flask(__name__)
     config_name = _get_config_name(config_name)
@@ -76,3 +77,17 @@ def _get_config_name(config_name: str | None) -> str:
         else:
             config_name = "annif.default_config.ProductionConfig"  # pragma: no cover
     return config_name
+
+
+def _set_tensorflow_loglevel():
+    annif_loglevel = logger.getEffectiveLevel()
+    tf_loglevel_mapping = {
+        0: "0",  # NOTSET
+        10: "0",  # DEBUG
+        20: "1",  # INFO
+        30: "2",  # WARNING
+        40: "3",  # ERROR
+        50: "3",  # CRITICAL
+    }
+    tf_loglevel = tf_loglevel_mapping[annif_loglevel]
+    os.environ.setdefault("TF_CPP_MIN_LOG_LEVEL", tf_loglevel)

--- a/annif/backend/__init__.py
+++ b/annif/backend/__init__.py
@@ -44,11 +44,10 @@ def _mllm() -> Type[AnnifBackend]:
 
 def _nn_ensemble() -> Type[AnnifBackend]:
     try:
-        os.environ["TF_CPP_MIN_LOG_LEVEL"] = "1"
+        # Hide TF info messages by default
+        os.environ.setdefault("TF_CPP_MIN_LOG_LEVEL", "1")
 
         from . import nn_ensemble
-
-        os.environ["TF_CPP_MIN_LOG_LEVEL"] = "0"
 
         return nn_ensemble.NNEnsembleBackend
     except ImportError:

--- a/annif/backend/__init__.py
+++ b/annif/backend/__init__.py
@@ -1,6 +1,7 @@
 """Registry of backend types for Annif"""
 from __future__ import annotations
 
+import os
 from typing import TYPE_CHECKING, Type
 
 if TYPE_CHECKING:
@@ -43,7 +44,11 @@ def _mllm() -> Type[AnnifBackend]:
 
 def _nn_ensemble() -> Type[AnnifBackend]:
     try:
+        os.environ["TF_CPP_MIN_LOG_LEVEL"] = "1"
+
         from . import nn_ensemble
+
+        os.environ["TF_CPP_MIN_LOG_LEVEL"] = "0"
 
         return nn_ensemble.NNEnsembleBackend
     except ImportError:

--- a/annif/backend/__init__.py
+++ b/annif/backend/__init__.py
@@ -1,7 +1,6 @@
 """Registry of backend types for Annif"""
 from __future__ import annotations
 
-import os
 from typing import TYPE_CHECKING, Type
 
 if TYPE_CHECKING:
@@ -44,9 +43,6 @@ def _mllm() -> Type[AnnifBackend]:
 
 def _nn_ensemble() -> Type[AnnifBackend]:
     try:
-        # Hide TF info messages by default
-        os.environ.setdefault("TF_CPP_MIN_LOG_LEVEL", "1")
-
         from . import nn_ensemble
 
         return nn_ensemble.NNEnsembleBackend

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -37,7 +37,7 @@ def test_tensorflow_loglevel():
     assert os.environ[tf_env] == "1"  # Show WARNING and ERROR messages by TF
     os.environ.pop(tf_env)
     runner.invoke(annif.cli.cli, ["list-projects", "-v", "ERROR"])
-    assert os.environ[tf_env] == "2"  # Show no messages by TF
+    assert os.environ[tf_env] == "2"  # Show ERROR messages by TF
     os.environ.pop(tf_env)
     runner.invoke(annif.cli.cli, ["list-projects", "-v", "CRITICAL"])
     assert os.environ[tf_env] == "3"  # Show no messages by TF

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -23,6 +23,27 @@ TEMP_PROJECT = "".join(random.choice("abcdefghiklmnopqrstuvwxyz") for _ in range
 PROJECTS_CONFIG_PATH = "tests/projects_for_config_path_option.cfg"
 
 
+@mock.patch.dict(os.environ, clear=True)
+def test_tensorflow_loglevel():
+    tf_env = "TF_CPP_MIN_LOG_LEVEL"
+
+    runner.invoke(annif.cli.cli, ["list-projects", "-v", "DEBUG"])
+    assert os.environ[tf_env] == "0"
+    os.environ.pop(tf_env)
+    runner.invoke(annif.cli.cli, ["list-projects"])  # INFO level by default
+    assert os.environ[tf_env] == "1"
+    os.environ.pop(tf_env)
+    runner.invoke(annif.cli.cli, ["list-projects", "-v", "WARN"])
+    assert os.environ[tf_env] == "2"
+    os.environ.pop(tf_env)
+    runner.invoke(annif.cli.cli, ["list-projects", "-v", "ERROR"])
+    assert os.environ[tf_env] == "3"
+    os.environ.pop(tf_env)
+    runner.invoke(annif.cli.cli, ["list-projects", "-v", "CRITICAL"])
+    assert os.environ[tf_env] == "3"
+    os.environ.pop(tf_env)
+
+
 def test_list_projects():
     result = runner.invoke(annif.cli.cli, ["list-projects"])
     assert not result.exception
@@ -1122,24 +1143,3 @@ def test_completion_show_project_project_ids_dummy():
 def test_completion_load_vocab_vocab_ids_all():
     completions = get_completions(annif.cli.cli, ["load-vocab"], "")
     assert completions == ["dummy", "dummy-noname", "yso"]
-
-
-def test_tensorflow_loglevel():
-    tf_env = "TF_CPP_MIN_LOG_LEVEL"
-    assert tf_env not in os.environ.keys()
-
-    runner.invoke(annif.cli.cli, ["list-projects", "-v", "DEBUG"])
-    assert os.environ[tf_env] == "0"
-    os.environ.pop(tf_env)
-    runner.invoke(annif.cli.cli, ["list-projects"])  # INFO level by default
-    assert os.environ[tf_env] == "1"
-    os.environ.pop(tf_env)
-    runner.invoke(annif.cli.cli, ["list-projects", "-v", "WARN"])
-    assert os.environ[tf_env] == "2"
-    os.environ.pop(tf_env)
-    runner.invoke(annif.cli.cli, ["list-projects", "-v", "ERROR"])
-    assert os.environ[tf_env] == "3"
-    os.environ.pop(tf_env)
-    runner.invoke(annif.cli.cli, ["list-projects", "-v", "CRITICAL"])
-    assert os.environ[tf_env] == "3"
-    os.environ.pop(tf_env)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1122,3 +1122,24 @@ def test_completion_show_project_project_ids_dummy():
 def test_completion_load_vocab_vocab_ids_all():
     completions = get_completions(annif.cli.cli, ["load-vocab"], "")
     assert completions == ["dummy", "dummy-noname", "yso"]
+
+
+def test_tensorflow_loglevel():
+    tf_env = "TF_CPP_MIN_LOG_LEVEL"
+    assert tf_env not in os.environ.keys()
+
+    runner.invoke(annif.cli.cli, ["list-projects", "-v", "DEBUG"])
+    assert os.environ[tf_env] == "0"
+    os.environ.pop(tf_env)
+    runner.invoke(annif.cli.cli, ["list-projects"])  # INFO level by default
+    assert os.environ[tf_env] == "1"
+    os.environ.pop(tf_env)
+    runner.invoke(annif.cli.cli, ["list-projects", "-v", "WARN"])
+    assert os.environ[tf_env] == "2"
+    os.environ.pop(tf_env)
+    runner.invoke(annif.cli.cli, ["list-projects", "-v", "ERROR"])
+    assert os.environ[tf_env] == "3"
+    os.environ.pop(tf_env)
+    runner.invoke(annif.cli.cli, ["list-projects", "-v", "CRITICAL"])
+    assert os.environ[tf_env] == "3"
+    os.environ.pop(tf_env)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -28,19 +28,19 @@ def test_tensorflow_loglevel():
     tf_env = "TF_CPP_MIN_LOG_LEVEL"
 
     runner.invoke(annif.cli.cli, ["list-projects", "-v", "DEBUG"])
-    assert os.environ[tf_env] == "0"
+    assert os.environ[tf_env] == "0"  # Show INFO, WARNING and ERROR messages by TF
     os.environ.pop(tf_env)
     runner.invoke(annif.cli.cli, ["list-projects"])  # INFO level by default
-    assert os.environ[tf_env] == "1"
+    assert os.environ[tf_env] == "1"  # Show WARNING and ERROR messages by TF
     os.environ.pop(tf_env)
     runner.invoke(annif.cli.cli, ["list-projects", "-v", "WARN"])
-    assert os.environ[tf_env] == "2"
+    assert os.environ[tf_env] == "1"  # Show WARNING and ERROR messages by TF
     os.environ.pop(tf_env)
     runner.invoke(annif.cli.cli, ["list-projects", "-v", "ERROR"])
-    assert os.environ[tf_env] == "3"
+    assert os.environ[tf_env] == "2"  # Show no messages by TF
     os.environ.pop(tf_env)
     runner.invoke(annif.cli.cli, ["list-projects", "-v", "CRITICAL"])
-    assert os.environ[tf_env] == "3"
+    assert os.environ[tf_env] == "3"  # Show no messages by TF
     os.environ.pop(tf_env)
 
 


### PR DESCRIPTION
Makes TF log level to be set by Annif log level using `TF_CPP_MIN_LOG_LEVEL` env variable.

Mainly used for hiding distracting TF INFO messages. Closes #720. Based on [this SO answer](https://stackoverflow.com/a/42121886).

The env setting is in the `annif/__init__.py` to make the log level change work also when TF is used by spaCy analyzer (which was not  apparent at first), in addition to TF usage by NN ensemble backend.  

I am not seeing the second message mentioned in the issue: 

    2023-07-25 11:31:44.032688: I tensorflow/core/util/port.cc:104] oneDNN custom operations are on. You may see slightly different numerical results due to floating-point round-off errors from different computation orders. To turn them off, set the environment variable `TF_ENABLE_ONEDNN_OPTS=0`.

I hope also this message arises during TF import, so this PR should fix that part of the issue too (Edit: no, it did not, but the current approach should take care it). Could @osma verify this?
