### PR TITLE
Fix train state and modification time for unfinished project training

### DIFF
--- a/annif/backend/backend.py
+++ b/annif/backend/backend.py
@@ -52,14 +52,25 @@ class AnnifBackend(metaclass=abc.ABCMeta):
         return params
 
     @property
+    def _model_file_paths(self) -> list:
+        all_paths = glob(os.path.join(self.datadir, "*"))
+        ignore_patterns = ("*-train*", "vectorizer")
+        ignore_paths = [
+            path
+            for igp in ignore_patterns
+            for path in glob(os.path.join(self.datadir, igp))
+        ]
+        return list(set(all_paths) - set(ignore_paths))
+
+    @property
     def is_trained(self) -> bool:
-        return bool(glob(os.path.join(self.datadir, "*")))
+        return bool(self._model_file_paths)
 
     @property
     def modification_time(self) -> datetime | None:
         mtimes = [
             datetime.utcfromtimestamp(os.path.getmtime(p))
-            for p in glob(os.path.join(self.datadir, "*"))
+            for p in self._model_file_paths
         ]
         most_recent = max(mtimes, default=None)
         if most_recent is None:

--- a/annif/backend/backend.py
+++ b/annif/backend/backend.py
@@ -54,7 +54,7 @@ class AnnifBackend(metaclass=abc.ABCMeta):
     @property
     def _model_file_paths(self) -> list:
         all_paths = glob(os.path.join(self.datadir, "*"))
-        ignore_patterns = ("*-train*", "vectorizer")
+        ignore_patterns = ("*-train*", "tmp-*", "vectorizer")
         ignore_paths = [
             path
             for igp in ignore_patterns

--- a/annif/util.py
+++ b/annif/util.py
@@ -35,6 +35,7 @@ def atomic_save(
     final name."""
 
     prefix, suffix = os.path.splitext(filename)
+    prefix = "tmp-" + prefix
     tempfd, tempfilename = tempfile.mkstemp(prefix=prefix, suffix=suffix, dir=dirname)
     os.close(tempfd)
     logger.debug("saving %s to temporary file %s", str(obj)[:90], tempfilename)

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -152,6 +152,20 @@ def test_project_tfidf_is_not_trained(registry):
     assert not project.is_trained
 
 
+def test_project_tfidf_is_not_trained_prepared_only(registry, testdatadir):
+    testdatadir.join("projects/tfidf-fi").ensure("vectorizer")
+    testdatadir.join("projects/tfidf-fi").ensure("dummy-tfidf-train.txt")
+    project = registry.get_project("tfidf-fi")
+    assert not project.is_trained
+
+
+def test_project_tfidf_modification_time_prepared_only(registry, testdatadir):
+    testdatadir.join("projects/tfidf-fi").ensure("vectorizer")
+    testdatadir.join("projects/tfidf-fi").ensure("dummy-tfidf-train.txt")
+    project = registry.get_project("tfidf-fi")
+    assert project.modification_time is None
+
+
 def test_project_train_tfidf(registry, document_corpus, testdatadir):
     project = registry.get_project("tfidf-fi")
     project.train(document_corpus)


### PR DESCRIPTION
If initial training of a project is not finished after any files have been created in the project's data directory, the train state and modification time information turn out incorrect (the project shows to be (fully) trained when it is not, and with a modification time). And when retraining a project is interrupted, the modification time is falsely updated.

This problem can realize more commonly when/if implementing [the `--prepare-only` option to the train command](https://github.com/NatLibFi/Annif/issues/583).

This PR makes the methods inquiring the train state and modification time to ignore files in the project's datadir with pattern `*-train*`, `tmp-*` and  `vectorizer`. The `tmp-` prefix is added to all temporary files, because some backends are using a tempfile for the model file during training, which can remain after unfinished training, e.g.  `stwfsa_predictor1mz8z4im.zip`.

The train and temp files should definitely be ignored, but the vectorizer file case is not so clear:
- a project is not trained when only the vectorizer file exists (PR implements this)
- when the vectorizer file (of a fully trained project) changes, the results of the model change, so modification time should be based also on vectorizer file mtime (PR **does not** implements this)

Instead of using global ignore patterns, this functionality could use the actual model file names/patterns per backend, but the field storing them varies a bit (`MODEL_FILE`, `INDEX_FILE`, `MODEL_FILE_PREFIX`). 