### PR TITLE
Updates for ReadTheDocs documentation

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,7 +8,7 @@ version: 2
 build:
   os: "ubuntu-22.04"
   tools:
-    python: "3.9"
+    python: "3.10"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,7 +6,7 @@
 version: 2
 
 build:
-  os: "ubuntu-20.04"
+  os: "ubuntu-22.04"
   tools:
     python: "3.9"
 

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -33,4 +33,3 @@ python:
     - requirements: docs/requirements.txt
     - method: pip
       path: .
-  system_packages: true

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -29,7 +29,6 @@ python:
         - fasttext
         - stwfsa
         - yake
-        - pycld3
         - spacy
     - requirements: docs/requirements.txt
     - method: pip

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -27,6 +27,7 @@ python:
         - nn
         - omikuji
         - fasttext
+        - stwfsa
         - yake
         - pycld3
         - spacy

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,6 +13,7 @@
 import os
 import re
 import sys
+from datetime import date
 
 sys.path.insert(0, os.path.abspath(".."))
 
@@ -20,7 +21,11 @@ sys.path.insert(0, os.path.abspath(".."))
 # -- Project information -----------------------------------------------------
 
 project = "annif"
-copyright = "2017, University Of Helsinki (The National Library Of Finland)"
+copyright = (
+    f"2017-{date.today().year}, University Of Helsinki "
+    + "(The National Library Of Finland)"
+)
+
 author = "Osma Suominen"
 
 # Get version number from GitHub tag

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,7 +26,7 @@ copyright = (
     + "(The National Library Of Finland)"
 )
 
-author = "Osma Suominen"
+author = "National Library Of Finland"
 
 # Get version number from GitHub tag
 release = re.sub("^v", "", os.popen("git describe --tags").read().strip())

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -32,7 +32,7 @@ author = "Osma Suominen"
 release = re.sub("^v", "", os.popen("git describe --tags").read().strip())
 # The short X.Y version.
 version = release
-
+html_title = project + " " + release
 
 # -- General configuration ---------------------------------------------------
 


### PR DESCRIPTION
Miscellaneous updates and tweaks for the documentation, prompted by the email from RTD:

> We are removing the "use system packages" feature on August 29th. Make sure you are installing all the required dependecies to build your project's documentation using a requirements.txt file and specifying it in your .readthedocs.yaml.

It seemed were having the setting `system_packages: true` for no reason in the configuration, so it is removed.

Also
- updates the RTD build environment to Ubuntu 22.04 and Python 3.10
- adds SWTFSA dependency to be installed to have its docstrings in the docs (forgotten from #700)
- removes pycld3 dependency (forgotten from #626)
- refines and updates the documentation page (using tips from a [blog post](https://documatt.com/blog/2021/sphinx-conf-py-tips.html))