### PR TITLE
Upgrade Simplemma & limit its memory usage

### DIFF
--- a/annif/analyzer/simplemma.py
+++ b/annif/analyzer/simplemma.py
@@ -2,9 +2,7 @@
 
 from __future__ import annotations
 
-import simplemma
-
-import annif.langsupport
+import annif.simplemma_util
 
 from . import analyzer
 
@@ -14,10 +12,7 @@ class SimplemmaAnalyzer(analyzer.Analyzer):
 
     def __init__(self, param: str, **kwargs) -> None:
         self.lang = param
-        self.lemmatizer = simplemma.Lemmatizer(
-            lemmatization_strategy=annif.langsupport.lemmatization_strategy
-        )
         super().__init__(**kwargs)
 
     def _normalize_word(self, word: str) -> str:
-        return self.lemmatizer.lemmatize(word, lang=self.lang)
+        return annif.simplemma_util.lemmatizer.lemmatize(word, lang=self.lang)

--- a/annif/analyzer/simplemma.py
+++ b/annif/analyzer/simplemma.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import simplemma
 
+import annif.langsupport
+
 from . import analyzer
 
 
@@ -12,7 +14,10 @@ class SimplemmaAnalyzer(analyzer.Analyzer):
 
     def __init__(self, param: str, **kwargs) -> None:
         self.lang = param
+        self.lemmatizer = simplemma.Lemmatizer(
+            lemmatization_strategy=annif.langsupport.lemmatization_strategy
+        )
         super().__init__(**kwargs)
 
     def _normalize_word(self, word: str) -> str:
-        return simplemma.lemmatize(word, lang=self.lang)
+        return self.lemmatizer.lemmatize(word, lang=self.lang)

--- a/annif/langsupport.py
+++ b/annif/langsupport.py
@@ -1,9 +1,0 @@
-"""Language support and language detection functionality for Annif"""
-
-from simplemma.strategies import DefaultStrategy
-from simplemma.strategies.dictionaries import DefaultDictionaryFactory
-
-LANG_CACHE_SIZE = 5  # How many language dictionaries to keep in memory at once (max)
-
-dictionary_factory = DefaultDictionaryFactory(cache_max_size=LANG_CACHE_SIZE)
-lemmatization_strategy = DefaultStrategy(dictionary_factory=dictionary_factory)

--- a/annif/langsupport.py
+++ b/annif/langsupport.py
@@ -1,0 +1,9 @@
+"""Language support and language detection functionality for Annif"""
+
+from simplemma.strategies import DefaultStrategy
+from simplemma.strategies.dictionaries import DefaultDictionaryFactory
+
+LANG_CACHE_SIZE = 5  # How many language dictionaries to keep in memory at once (max)
+
+dictionary_factory = DefaultDictionaryFactory(cache_max_size=LANG_CACHE_SIZE)
+lemmatization_strategy = DefaultStrategy(dictionary_factory=dictionary_factory)

--- a/annif/simplemma_util.py
+++ b/annif/simplemma_util.py
@@ -1,0 +1,15 @@
+"""Wrapper code for using Simplemma functionality in Annif"""
+
+from simplemma import LanguageDetector, Lemmatizer
+from simplemma.strategies import DefaultStrategy
+from simplemma.strategies.dictionaries import DefaultDictionaryFactory
+
+LANG_CACHE_SIZE = 5  # How many language dictionaries to keep in memory at once (max)
+
+_dictionary_factory = DefaultDictionaryFactory(cache_max_size=LANG_CACHE_SIZE)
+_lemmatization_strategy = DefaultStrategy(dictionary_factory=_dictionary_factory)
+lemmatizer = Lemmatizer(lemmatization_strategy=_lemmatization_strategy)
+
+
+def get_language_detector(lang: str) -> LanguageDetector:
+    return LanguageDetector(lang, lemmatization_strategy=_lemmatization_strategy)

--- a/annif/simplemma_util.py
+++ b/annif/simplemma_util.py
@@ -1,5 +1,7 @@
 """Wrapper code for using Simplemma functionality in Annif"""
 
+from typing import Tuple, Union
+
 from simplemma import LanguageDetector, Lemmatizer
 from simplemma.strategies import DefaultStrategy
 from simplemma.strategies.dictionaries import DefaultDictionaryFactory
@@ -11,5 +13,5 @@ _lemmatization_strategy = DefaultStrategy(dictionary_factory=_dictionary_factory
 lemmatizer = Lemmatizer(lemmatization_strategy=_lemmatization_strategy)
 
 
-def get_language_detector(lang: str) -> LanguageDetector:
+def get_language_detector(lang: Union[str, Tuple[str, ...]]) -> LanguageDetector:
     return LanguageDetector(lang, lemmatization_strategy=_lemmatization_strategy)

--- a/annif/transform/langfilter.py
+++ b/annif/transform/langfilter.py
@@ -5,10 +5,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from simplemma import LanguageDetector
-
 import annif
-import annif.langsupport
+import annif.simplemma_util
 
 from . import transform
 
@@ -32,9 +30,8 @@ class LangFilter(transform.BaseTransform):
         self.text_min_length = int(text_min_length)
         self.sentence_min_length = int(sentence_min_length)
         self.min_ratio = float(min_ratio)
-        self.language_detector = LanguageDetector(
-            self.project.language,
-            lemmatization_strategy=annif.langsupport.lemmatization_strategy,
+        self.language_detector = annif.simplemma_util.get_language_detector(
+            self.project.language
         )
 
     def transform_fn(self, text: str) -> str:

--- a/annif/transform/langfilter.py
+++ b/annif/transform/langfilter.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from simplemma.langdetect import in_target_language
+from simplemma import LanguageDetector
 
 import annif
+import annif.langsupport
 
 from . import transform
 
@@ -31,6 +32,10 @@ class LangFilter(transform.BaseTransform):
         self.text_min_length = int(text_min_length)
         self.sentence_min_length = int(sentence_min_length)
         self.min_ratio = float(min_ratio)
+        self.language_detector = LanguageDetector(
+            self.project.language,
+            lemmatization_strategy=annif.langsupport.lemmatization_strategy,
+        )
 
     def transform_fn(self, text: str) -> str:
         if len(text) < self.text_min_length:
@@ -41,7 +46,7 @@ class LangFilter(transform.BaseTransform):
             if len(sent) < self.sentence_min_length:
                 retained_sentences.append(sent)
                 continue
-            proportion = in_target_language(sent, lang=(self.project.language,))
+            proportion = self.language_detector.proportion_in_target_languages(sent)
             if proportion >= self.min_ratio:
                 retained_sentences.append(sent)
         return " ".join(retained_sentences)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ numpy = "1.26.*"
 optuna = "3.6.*"
 python-dateutil = "2.9.*"
 tomli = { version = "2.0.*", python = "<3.11" }
-simplemma = { git = "https://github.com/adbar/simplemma", branch = "main" }
+simplemma = "1.0.*"
 jsonschema = "4.21.*"
 huggingface-hub = "0.22.*"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ numpy = "1.26.*"
 optuna = "3.6.*"
 python-dateutil = "2.9.*"
 tomli = { version = "2.0.*", python = "<3.11" }
-simplemma = "1.0.*"
+simplemma = "~1.1.1"
 jsonschema = "4.21.*"
 huggingface-hub = "0.22.*"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ numpy = "1.26.*"
 optuna = "3.6.*"
 python-dateutil = "2.9.*"
 tomli = { version = "2.0.*", python = "<3.11" }
-simplemma = "0.9.*"
+simplemma = { git = "https://github.com/adbar/simplemma", branch = "main" }
 jsonschema = "4.21.*"
 huggingface-hub = "0.22.*"
 

--- a/tests/test_simplemma_util.py
+++ b/tests/test_simplemma_util.py
@@ -1,0 +1,17 @@
+"""Unit tests for Simplemma utility functions"""
+
+from annif.simplemma_util import get_language_detector
+
+
+def test_get_language_detector():
+    detector = get_language_detector("en")
+    text = "She said 'au revoir' and left"
+    proportion = detector.proportion_in_target_languages(text)
+    assert proportion == 0.75
+
+
+def test_get_language_detector_many():
+    detector = get_language_detector(("en", "fr"))
+    text = "She said 'au revoir' and left"
+    proportion = detector.proportion_in_target_languages(text)
+    assert proportion == 1.0

--- a/tests/test_simplemma_util.py
+++ b/tests/test_simplemma_util.py
@@ -1,5 +1,7 @@
 """Unit tests for Simplemma utility functions"""
 
+import pytest
+
 from annif.simplemma_util import get_language_detector
 
 
@@ -7,11 +9,11 @@ def test_get_language_detector():
     detector = get_language_detector("en")
     text = "She said 'au revoir' and left"
     proportion = detector.proportion_in_target_languages(text)
-    assert proportion == 0.75
+    assert proportion == pytest.approx(0.75)
 
 
 def test_get_language_detector_many():
     detector = get_language_detector(("en", "fr"))
     text = "She said 'au revoir' and left"
     proportion = detector.proportion_in_target_languages(text)
-    assert proportion == 1.0
+    assert proportion == pytest.approx(1.0)


### PR DESCRIPTION
This PR upgrades Simplemma to the latest version 1.1.1 and adds some wrapper code to make it possible to use Simplemma language detection with a limit on the number of languages simultaneously loaded into memory. The number of languages is currently hardcoded at 5.

This will enable adding language detection functionality to the REST API in PR #659 , which has not been merged yet due to concerns about memory usage.