### PR TITLE
Increase maximum startup time threshold (0.3 -> 0.4 s)

### DIFF
--- a/tests/time-startup.sh
+++ b/tests/time-startup.sh
@@ -18,7 +18,7 @@ average_startup_time=$(echo "scale=3; ($startup_time1 + $startup_time2 + $startu
 echo "Average Startup time: $average_startup_time seconds"
 
 # Set the threshold for acceptable startup time in seconds
-threshold=0.300
+threshold=0.400
 
 # Compare the average startup time with the threshold
 if (( $(echo "$average_startup_time > $threshold" | bc -l) )); then


### PR DESCRIPTION
We have a CI test for startup time, implemented in PR #706, designed to prevent situations where basic Annif CLI commands suddenly take a long time due to e.g. slow imports.

The threshold value was set to 0.300 seconds. But nowadays this test quite often fails because the startup takes a bit longer, e.g. 0.35 seconds. I don't think anything has changed with the imports, it's just that the CI environment runs a bit slower than it used to.

This PR increases the threshold value to 0.400 seconds, which should prevent spurious test failures but still ensure that startup times have not increased dramatically.