### PR TITLE
Avoid PytestUnknownMarkWarning due to "slow" marker 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,4 +93,7 @@ line_length = "88"
 skip_gitignore = true
 
 [tool.pytest.ini_options]
+markers = [
+    "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+]
 addopts = "-m 'not slow'"


### PR DESCRIPTION
Register "slow" test marker as described in [pytest documentation](https://docs.pytest.org/en/stable/how-to/mark.html#registering-marks) to avoid the warning:
```
tests/test_openapi.py:22
  /home/local/jmminkin/git/Annif/tests/test_openapi.py:22: PytestUnknownMarkWarning: Unknown pytest.mark.slow - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.slow
```

The "slow" marker was added in #685.