### PR TITLE
Avoid scikit-learn UserWarning for vectorizer parameter token_pattern

### DIFF
--- a/annif/backend/mixins.py
+++ b/annif/backend/mixins.py
@@ -75,6 +75,9 @@ class TfidfVectorizerMixin:
         self, input: Iterable[str], params: dict[str, Any] = {}
     ) -> csr_matrix:
         self.info("creating vectorizer")
+        # avoid UserWarning when overriding tokenizer
+        if "tokenizer" in params:
+            params["token_pattern"] = None
         self.vectorizer = TfidfVectorizer(**params)
         veccorpus = self.vectorizer.fit_transform(input)
         annif.util.atomic_save(

--- a/annif/backend/mixins.py
+++ b/annif/backend/mixins.py
@@ -72,9 +72,11 @@ class TfidfVectorizerMixin:
                 )
 
     def create_vectorizer(
-        self, input: Iterable[str], params: dict[str, Any] = {}
+        self, input: Iterable[str], params: dict[str, Any] = None
     ) -> csr_matrix:
         self.info("creating vectorizer")
+        if params is None:
+            params = {}
         # avoid UserWarning when overriding tokenizer
         if "tokenizer" in params:
             params["token_pattern"] = None

--- a/annif/lexical/mllm.py
+++ b/annif/lexical/mllm.py
@@ -223,7 +223,7 @@ class MLLMModel:
         self._prepare_relations(graph, vocab)
 
         self._vectorizer = CountVectorizer(
-            binary=True, tokenizer=analyzer.tokenize_words
+            binary=True, tokenizer=analyzer.tokenize_words, token_pattern=None
         )
         label_corpus = self._vectorizer.fit_transform((t.label for t in terms))
 


### PR DESCRIPTION
scikit-learn vectorizers used by Annif (CountVectorizer, TfidfVectorizer) trigger this warning:

    UserWarning: The parameter 'token_pattern' will not be used since 'tokenizer' is not None'

This is a bit surprising, since we are not setting `token_pattern` ourselves, but its default value is not None. This PR fixes the warning by explicitly setting `token_pattern=None` whenever the `tokenizer` parameter is set in Annif calling code.