### PR TITLE
Upgrade Docker baseimage to Debian Bookworm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim-bullseye
+FROM python:3.10-slim-bookworm
 LABEL org.opencontainers.image.authors="grp-natlibfi-annif@helsinki.fi"
 SHELL ["/bin/bash", "-c"]
 


### PR DESCRIPTION
[Debian Bookworm (v12.0)](https://www.debian.org/releases/bookworm/) was released 10.6.2023. It seems like a good idea to upgrade Annif's Docker image to be based on that now, before Annif 1.0 release (although the base image should not affect Annif).