### PR TITLE
Add completion command to commands list in RTD

### DIFF
--- a/annif/cli.py
+++ b/annif/cli.py
@@ -587,7 +587,7 @@ def run_hyperopt(project_id, paths, docs_limit, trials, jobs, metric, results_fi
 @click.option("--bash", "shell", flag_value="bash")
 @click.option("--zsh", "shell", flag_value="zsh")
 @click.option("--fish", "shell", flag_value="fish")
-def completion(shell):
+def run_completion(shell):
     """Generate the script for tab-key autocompletion for the given shell. To enable the
     completion support in your current bash terminal session run\n
         source <(annif completion --bash)

--- a/docs/source/commands.rst
+++ b/docs/source/commands.rst
@@ -127,3 +127,14 @@ Subject index administration
 **REST equivalent**
 
    N/A
+
+*****
+Other
+*****
+
+.. click:: annif.cli:run_completion
+   :prog: annif completion
+
+**REST equivalent**
+
+   N/A


### PR DESCRIPTION
When the `annif completion` command was added in #693, it was forgotten to add the command in the [CLI commands page that is shown in ReadTheDocs](https://annif.readthedocs.io/en/stable/source/commands.html) (updating that page is [only semi-automatic](https://github.com/NatLibFi/Annif/pull/611#issuecomment-1228184329)).
