### PR TITLE
Add reconciliation API endpoint to REST API

### DIFF
--- a/annif/openapi/annif.yaml
+++ b/annif/openapi/annif.yaml
@@ -184,26 +184,38 @@ paths:
     get:
       tags:
       - Reconciliation
-      summary: reconcile against a project
+      summary: get reconciliation service manifest or reconcile against a project
       operationId: annif.rest.reconcile_metadata
       parameters:
       - $ref: '#/components/parameters/project_id'
-      # queries parameter doesn't work for some reason
       - in: query
+        description: A call to the reconciliation service API
         name: queries
+        required: false
         schema:
-          type: object
+          type: string
           additionalProperties:
             type: object
             required:
-            - query
+              - query
             properties:
               query:
                 type: string
-                description: query string
-          example: 
-            {"q0": {"query": "query"}}
-        required: false
+                description: Query string to search for
+              limit:
+                type: integer
+                description: Maximum number of results to return
+        example:
+          '{
+            "q0": {
+              "query": "example query",
+              "limit": 10
+            },
+            "q1": {
+              "query": "another example",
+              "limit": 15
+            }
+          }'
       responses:
         "200":
           description: successful operation
@@ -212,7 +224,53 @@ paths:
               schema:
                 oneOf:
                   - $ref: '#/components/schemas/ReconcileMetadata'
-                  - $ref: '#/components/schemas/Reconcile'
+                  - $ref: '#/components/schemas/ReconciliationResult'
+              examples:
+                ReconcileMetadata:
+                  summary: Reconciliation service manifest
+                  value:
+                    {
+                      "defaultTypes": [
+                        {
+                          "id": "default-type",
+                          "name": "Default type"
+                        }
+                      ],
+                      "identifierSpace": "",
+                      "name": "Annif Reconciliation Service for Dummy Finnish",
+                      "schemaSpace": "http://www.w3.org/2004/02/skos/core#Concept",
+                      "versions": [
+                        "0.2"
+                      ],
+                      "view": {
+                        "url": "{{id}}"
+                      }
+                    }
+                ReconciliationResult:
+                  summary: Reconciliation result
+                  value:
+                    {
+                      "q0": {
+                        "result": [
+                          {
+                            "id": "example-id",
+                            "name": "example name",
+                            "score": 0.5,
+                            "match": true
+                          }
+                        ]
+                      },
+                      "q1": {
+                        "result": [
+                          {
+                            "id": "another-id",
+                            "name": "another name",
+                            "score": 0.5,
+                            "match": false
+                          }
+                        ]
+                      }
+                    }
         "404":
           $ref: '#/components/responses/NotFound'
     post:
@@ -235,6 +293,7 @@ paths:
               properties:
                 queries:
                   type: object
+                  description: A call to the reconciliation service API
                   additionalProperties:
                     type: object
                     required:
@@ -242,19 +301,19 @@ paths:
                     properties:
                       query:
                         type: string
-                        description: query string
+                        description: Query string to search for
                       limit:
                         type: integer
-                        description: maximum number of results to return
+                        description: Maximum number of results to return
                   example:
                     {
                       "q0": {
-                        "query": "cat",
+                        "query": "example query",
                         "limit": 10
                       },
                       "q1": {
-                        "query": "dog",
-                        "limit": 10
+                        "query": "another example",
+                        "limit": 15
                       }
                     }
         required: true
@@ -264,7 +323,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Reconcile'
+                $ref: '#/components/schemas/ReconciliationResult'
         "404":
           $ref: '#/components/responses/NotFound'
 components:
@@ -401,6 +460,105 @@ components:
                 type: string
                 example: Vulpes vulpes
       description: A document with attached, known good subjects
+    ReconcileMetadata:
+      required:
+      - name
+      - defaultTypes
+      - view
+      - identifierSpace
+      - schemaSpace
+      - versions
+      type: object
+      properties:
+        name:
+          type: string
+          example: Annif Reconciliation Service
+        identifierSpace:
+          type: string
+          example: ""
+        schemaSpace:
+          type: string
+          example: "http://www.w3.org/2004/02/skos/core#Concept"
+        defaultTypes:
+          type: array
+          items:
+            type: object
+            required:
+            - id
+            - name
+            properties:
+              id:
+                type: string
+                example: type-id
+              name:
+                type: string
+                example: type name
+        view:
+          type: object
+          required:
+          - url
+          properties:
+            url:
+              type: string
+              example: "{{id}}"
+        versions:
+          type: array
+          items:
+            type: string
+            example: 0.2
+      description: Reconciliation service information
+    ReconciliationResult:
+      type: object
+      additionalProperties:
+        type: object
+        required:
+        - result
+        properties:
+          result:
+            type: array
+            items:
+              type: object
+              required:
+              - id
+              - name
+              - score
+              - match
+              properties:
+                id:
+                  type: string
+                  example: example-id
+                name:
+                  type: string
+                  example: example name
+                score:
+                  type: number
+                  example: 0.5
+                match:
+                  type: boolean
+                  example: true
+      example:
+        {
+          "q0": {
+            "result": [
+              {
+                "id": "example-id",
+                "name": "example name",
+                "score": 0.5,
+                "match": true
+              }
+            ]
+          },
+          "q1": {
+            "result": [
+              {
+                "id": "another-id",
+                "name": "another name",
+                "score": 0.5,
+                "match": false
+              }
+            ]
+          }
+        }
     Problem:
       type: object
       properties:
@@ -441,101 +599,6 @@ components:
             An absolute URI that identifies the specific occurrence of the problem.
             It may or may not yield further information if dereferenced.
           format: uri
-    ReconcileMetadata:
-      required:
-      - name
-      - defaultTypes
-      - view
-      - identifierSpace
-      - schemaSpace
-      - versions
-      type: object
-      properties:
-        name:
-          type: string
-          example: Annif Reconciliation Service
-        identifierSpace:
-          type: string
-          example: ""
-        schemaSpace:
-          type: string
-          example: ""
-        defaultTypes:
-          type: array
-          items:
-            type: object
-            required:
-            - id
-            - name
-            properties:
-              id:
-                type: string
-                example: type_id
-              name:
-                type: string
-                example: type_name
-        view:
-          type: object
-          required:
-          - url
-          properties:
-            url:
-              type: string
-              example: '{{id}}'
-        versions:
-          type: array
-          items:
-            type: string
-            example: 0.2
-      description: Reconciliation service information
-    Reconcile:
-      type: object
-      additionalProperties:
-        type: object
-        required:
-        - result
-        properties:
-          result:
-            type: array
-            items:
-              type: object
-              required:
-              - id
-              - name
-              - score
-              - match
-              properties:
-                id:
-                  type: string
-                name:
-                  type: string
-                score:
-                  type: number
-                match:
-                  type: boolean
-      example:
-        {
-          "q0": {
-            "result": [
-              {
-                "id": "id0",
-                "name": "name0",
-                "score": 0.5,
-                "match": true
-              }
-            ]
-          },
-          "q1": {
-            "result": [
-              {
-                "id": "id1",
-                "name": "name1",
-                "score": 0.5,
-                "match": false
-              }
-            ]
-          }
-        }
   parameters:
     project_id:
       name: project_id

--- a/annif/openapi/annif.yaml
+++ b/annif/openapi/annif.yaml
@@ -180,6 +180,93 @@ paths:
         "503":
           $ref: '#/components/responses/ServiceUnavailable'
       x-codegen-request-body-name: documents
+  /projects/{project_id}/reconcile:
+    get:
+      tags:
+      - Reconciliation
+      summary: reconcile against a project
+      operationId: annif.rest.reconcile_metadata
+      parameters:
+      - $ref: '#/components/parameters/project_id'
+      # queries parameter doesn't work for some reason
+      - in: query
+        name: queries
+        schema:
+          type: object
+          additionalProperties:
+            type: object
+            required:
+            - query
+            properties:
+              query:
+                type: string
+                description: query string
+          example: 
+            {"q0": {"query": "query"}}
+        required: false
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/ReconcileMetadata'
+                  - $ref: '#/components/schemas/Reconcile'
+        "404":
+          $ref: '#/components/responses/NotFound'
+    post:
+      tags:
+      - Reconciliation
+      summary: reconcole against a project
+      operationId: annif.rest.reconcile
+      parameters:
+      - $ref: '#components/parameters/project_id'
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            encoding:
+              queries:
+                contentType: application/json
+            schema:
+              type: object
+              required:
+              - queries
+              properties:
+                queries:
+                  type: object
+                  additionalProperties:
+                    type: object
+                    required:
+                    - query
+                    properties:
+                      query:
+                        type: string
+                        description: query string
+                      limit:
+                        type: integer
+                        description: maximum number of results to return
+                  example:
+                    {
+                      "q0": {
+                        "query": "cat",
+                        "limit": 10
+                      },
+                      "q1": {
+                        "query": "dog",
+                        "limit": 10
+                      }
+                    }
+        required: true
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Reconcile'
+        "404":
+          $ref: '#/components/responses/NotFound'
 components:
   schemas:
     ApiInfo:
@@ -354,6 +441,101 @@ components:
             An absolute URI that identifies the specific occurrence of the problem.
             It may or may not yield further information if dereferenced.
           format: uri
+    ReconcileMetadata:
+      required:
+      - name
+      - defaultTypes
+      - view
+      - identifierSpace
+      - schemaSpace
+      - versions
+      type: object
+      properties:
+        name:
+          type: string
+          example: Annif Reconciliation Service
+        identifierSpace:
+          type: string
+          example: ""
+        schemaSpace:
+          type: string
+          example: ""
+        defaultTypes:
+          type: array
+          items:
+            type: object
+            required:
+            - id
+            - name
+            properties:
+              id:
+                type: string
+                example: type_id
+              name:
+                type: string
+                example: type_name
+        view:
+          type: object
+          required:
+          - url
+          properties:
+            url:
+              type: string
+              example: '{{id}}'
+        versions:
+          type: array
+          items:
+            type: string
+            example: 0.2
+      description: Reconciliation service information
+    Reconcile:
+      type: object
+      additionalProperties:
+        type: object
+        required:
+        - result
+        properties:
+          result:
+            type: array
+            items:
+              type: object
+              required:
+              - id
+              - name
+              - score
+              - match
+              properties:
+                id:
+                  type: string
+                name:
+                  type: string
+                score:
+                  type: number
+                match:
+                  type: boolean
+      example:
+        {
+          "q0": {
+            "result": [
+              {
+                "id": "id0",
+                "name": "name0",
+                "score": 0.5,
+                "match": true
+              }
+            ]
+          },
+          "q1": {
+            "result": [
+              {
+                "id": "id1",
+                "name": "name1",
+                "score": 0.5,
+                "match": false
+              }
+            ]
+          }
+        }
   parameters:
     project_id:
       name: project_id

--- a/annif/rest.py
+++ b/annif/rest.py
@@ -3,6 +3,7 @@ methods defined in the OpenAPI specification."""
 from __future__ import annotations
 
 import importlib
+import json
 from typing import TYPE_CHECKING, Any
 
 import connexion
@@ -252,11 +253,20 @@ def reconcile_metadata(
             "versions": ["0.2"],
             "name": "Annif Reconciliation Service for " + project.name,
             "identifierSpace": "",
-            "schemaSpace": "",
+            "schemaSpace": "http://www.w3.org/2004/02/skos/core#Concept",
             "view": {"url": "{{id}}"},
+            "defaultTypes": [{"id": "default-type", "name": "Default type"}],
         }
     else:
-        return {}
+        queries = json.loads(query_parameters["queries"])
+        results = {}
+        for key, query in queries.items():
+            data = _reconcile(project_id, query)
+            if _is_error(data):
+                return data
+            results[key] = {"result": data}
+
+        return results
 
 
 def reconcile(

--- a/tests/test_rest.py
+++ b/tests/test_rest.py
@@ -233,3 +233,31 @@ def test_rest_learn_not_supported(app):
     with app.app_context():
         result = annif.rest.learn("tfidf-fi", [])
         assert result.status_code == 503
+
+
+def test_rest_reconcile_metadata(app):
+    with app.app_context():
+        results = annif.rest.reconcile_metadata("dummy-fi")
+        assert results["name"] == "Annif Reconciliation Service for Dummy Finnish"
+
+
+def test_rest_reocncile_metadata_nonexistent(app):
+    with app.app_context():
+        result = annif.rest.reconcile_metadata("nonexistent")
+        assert result.status_code == 404
+
+
+def test_rest_reconcile(app):
+    with app.app_context():
+        results = annif.rest.reconcile(
+            "dummy-fi", {"queries": {"q0": {"query": "example text"}}}
+        )
+        assert "result" in results["q0"]
+
+
+def test_test_reconcile_nonexistent(app):
+    with app.app_context():
+        result = annif.rest.reconcile(
+            "nonexistent", {"queries": {"q0": {"query": "example text"}}}
+        )
+        assert result.status_code == 404

--- a/tests/test_rest.py
+++ b/tests/test_rest.py
@@ -247,6 +247,22 @@ def test_rest_reocncile_metadata_nonexistent(app):
         assert result.status_code == 404
 
 
+def test_rest_reconcile_metadata_queries(app):
+    with app.app_context():
+        results = annif.rest.reconcile_metadata(
+            "dummy-fi", queries='{"q0": {"query": "example text"}}'
+        )
+        assert "result" in results["q0"]
+
+
+def test_rest_reconcile_metadata_queries_nonexistent(app):
+    with app.app_context():
+        result = annif.rest.reconcile_metadata(
+            "nonexistent", queries='{"q0": {"query": "example text"}}'
+        )
+        assert result.status_code == 404
+
+
 def test_rest_reconcile(app):
     with app.app_context():
         results = annif.rest.reconcile(
@@ -255,7 +271,7 @@ def test_rest_reconcile(app):
         assert "result" in results["q0"]
 
 
-def test_test_reconcile_nonexistent(app):
+def test_rest_reconcile_nonexistent(app):
     with app.app_context():
         result = annif.rest.reconcile(
             "nonexistent", {"queries": {"q0": {"query": "example text"}}}


### PR DESCRIPTION
This PR adds a [Reconciliation API](https://www.w3.org/community/reports/reconciliation/CG-FINAL-specs-0.2-20230410/#service-manifest) endpoint to REST API as mentioned in #338. It allows reconciling against a project using the `/v1/projects/{project_id}/reconcile` API method.

The endpoint accepts `GET` and `POST` requests:
- A `GET` request with no parameters returns a [service manifest](https://www.w3.org/community/reports/reconciliation/CG-FINAL-specs-0.2-20230410/#service-manifest).
- A`GET` request with a URL query parameter [`queries`](https://www.w3.org/community/reports/reconciliation/CG-FINAL-specs-0.2-20230410/#structure-of-a-reconciliation-query) serialized as JSON returns a [reconciliation result batch](https://www.w3.org/community/reports/reconciliation/CG-FINAL-specs-0.2-20230410/#reconciliation-query-responses).
- A `POST` request with an `application/x-www-form-urlencoded` parameter [`queries`](https://www.w3.org/community/reports/reconciliation/CG-FINAL-specs-0.2-20230410/#structure-of-a-reconciliation-query) serialized as JSON returns a [reconciliation result batch](https://www.w3.org/community/reports/reconciliation/CG-FINAL-specs-0.2-20230410/#reconciliation-query-responses).

Only the fields `query` and `limit` are supported in the `queries` objects. Reconciliation result objects contain the fields `id`, `name`, `score` and `match`. Reconciliation doesn't support types or properties for now.

The reconciliation API specification requires the usage of the [`identifierSpace`](https://www.w3.org/community/reports/reconciliation/CG-FINAL-specs-0.2-20230410/#dfn-identifier-space) field in the service manifest. Since Annif doesn't require entities to be in a specific URI space and doesn't have a way to extract this infomation from a project, the field is left empty for now.