### PR TITLE
Debug ValueError by Voikko analyzer 

### DIFF
--- a/annif/analyzer/analyzer.py
+++ b/annif/analyzer/analyzer.py
@@ -5,6 +5,8 @@ import abc
 import functools
 import unicodedata
 
+from annif.exception import OperationFailedException
+
 _KEY_TOKEN_MIN_LENGTH = "token_min_length"
 
 
@@ -44,11 +46,16 @@ class Analyzer(metaclass=abc.ABCMeta):
 
         import nltk.tokenize
 
-        return [
-            self._normalize_word(word)
-            for word in nltk.tokenize.word_tokenize(text)
-            if (not filter or self.is_valid_token(word))
-        ]
+        try:
+            return [
+                self._normalize_word(word)
+                for word in nltk.tokenize.word_tokenize(text)
+                if (not filter or self.is_valid_token(word))
+            ]
+        except OperationFailedException as err:
+            raise OperationFailedException(
+                f"Error in tokenization of text '{text}'"
+            ) from err
 
     def _normalize_word(self, word):
         """Normalize (stem or lemmatize) a word form into a normal form."""

--- a/annif/analyzer/voikko.py
+++ b/annif/analyzer/voikko.py
@@ -5,6 +5,8 @@ import functools
 
 import voikko.libvoikko
 
+from annif.exception import OperationFailedException
+
 from . import analyzer
 
 
@@ -27,7 +29,13 @@ class VoikkoAnalyzer(analyzer.Analyzer):
     def _normalize_word(self, word: str) -> str:
         if self.voikko is None:
             self.voikko = voikko.libvoikko.Voikko(self.param)
-        result = self.voikko.analyze(word)
+        try:
+            result = self.voikko.analyze(word)
+        except ValueError as err:
+            raise OperationFailedException(
+                f"Voikko error in analysis of word '{word}'"
+            ) from err
+
         if len(result) > 0 and "BASEFORM" in result[0]:
             return result[0]["BASEFORM"]
         return word

--- a/tests/test_analyzer_voikko.py
+++ b/tests/test_analyzer_voikko.py
@@ -1,8 +1,11 @@
 """Unit tests for voikko analyzer in Annif"""
 
+from unittest import mock
+
 import pytest
 
 import annif.analyzer
+from annif.exception import OperationFailedException
 
 voikko = pytest.importorskip("annif.analyzer.voikko")
 
@@ -18,3 +21,15 @@ def test_voikko_finnish_analyzer_normalize_word():
     assert analyzer._normalize_word("xyzzy") == "xyzzy"
     assert analyzer._normalize_word("vanhat") == "vanha"
     assert analyzer._normalize_word("koirien") == "koira"
+
+
+def test_voikko_analyze_valueerror():
+    analyzer = annif.analyzer.get_analyzer("voikko(fi)")
+    with mock.patch(
+        "voikko.libvoikko.Voikko.analyze",
+        side_effect=ValueError,
+    ):
+        with pytest.raises(
+            OperationFailedException, match="Voikko error in analysis of word 'kissa'"
+        ):
+            assert analyzer._normalize_word("kissa")


### PR DESCRIPTION
This aims to help to debug why the ValueError by Voikko analyzer arises (#737).

When this is merged, the latest Docker image could be deployed to ai.dev.finto.fi, which could then be used to investigate the situation.

Is there anything else that could be logged, in addition to the triggering word, @osma?