### PR TITLE
Show Annif version in WebUI

### DIFF
--- a/annif/static/css/style.css
+++ b/annif/static/css/style.css
@@ -31,6 +31,11 @@ h1 { font-size: 2rem; }
   border-radius: 0px;
   padding: 2px 7px;
 }
+#annif-version {
+  float: right;
+  margin-top: 0.5rem;
+  font-size: 1rem;
+}
 label, #suggestions {
   border-top: 1px solid #343260;
   margin-bottom: 0.5rem;

--- a/annif/templates/home.html
+++ b/annif/templates/home.html
@@ -51,7 +51,7 @@
       <div class="row mb-5">
         <div class="col-md-8">
           <annif-textarea @text-changed="onTextChanged" @text-cleared="onTextCleared"></annif-textarea>
-          <span id="annif-version">v<% annif_version %></span>
+          <span id="annif-version">Annif v<% annif_version %></span>
         </div>
         <div class="col-md-4">
           <div id="project-selection-wrapper">

--- a/annif/templates/home.html
+++ b/annif/templates/home.html
@@ -51,6 +51,7 @@
       <div class="row mb-5">
         <div class="col-md-8">
           <annif-textarea @text-changed="onTextChanged" @text-cleared="onTextCleared"></annif-textarea>
+          <span id="annif-version">v<% annif_version %></span>
         </div>
         <div class="col-md-4">
           <div id="project-selection-wrapper">
@@ -233,6 +234,7 @@ new Vue({
   el: '#app',
   data: {
     text: '',
+    annif_version: '',
     project: '',
     limit: 10,
     projects: [],
@@ -243,6 +245,7 @@ new Vue({
   mounted: function() {
     // TBD: we can add a button to reload the list of projects later
     this.loadProjects();
+    this.loadVersion();
   },
   methods: {
     clearResults: function() {
@@ -281,6 +284,13 @@ new Vue({
             this_.problems.push(new Problem(title, detail, true));
           }
         });
+    },
+    loadVersion: function() {
+      var this_ = this;
+      axios.get('/v1')
+        .then(res => {
+          this_.annif_version = res.data.version;
+        })
     },
     suggest: function(event) {
       this.problems = [];


### PR DESCRIPTION
It would be nice to know which version of Annif is running for the Web UI.

This PR adds a version number string, e.g. `Annif v1.1.0` (or `Annif v1.1.0.dev0` for the development version) outside the text box in the lower right corner, see screenshot below.

An alternative position for the version number could be just below "Web UI" title in the header, but the position of this PR is the same as will be in Finto AI.

![image](https://github.com/NatLibFi/Annif/assets/34240031/7a35c3b9-5609-47f5-999d-568561cfd308)
