### PR TITLE
Create `SECURITY.md`

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,14 +2,18 @@
 
 ## Supported Versions
 
-We aim to update all Annif dependencies to their latest versions
-on each Annif minor version release, but this can be restricted by the
-[backward compatibility policy](https://github.com/NatLibFi/Annif/wiki/Backward-compatibility-between-Annif-releases).
+The [most recent Annif (major/minor) release](https://github.com/NatLibFi/Annif/releases)
+is considered supported,
+in the sense that if a serious bug or vulnerability is encountered in it,
+a patch release is made to fix the issue.
 
-However, the [dependencies of a given Annif release](https://github.com/NatLibFi/Annif/blob/main/pyproject.toml)
+Generally, we aim to update all dependencies to their latest versions
+on each Annif major/minor release, but this can be restricted by the
+[backward compatibility policy](https://github.com/NatLibFi/Annif/wiki/Backward-compatibility-between-Annif-releases).
+However, note that the [dependencies of a given Annif release](https://github.com/NatLibFi/Annif/blob/main/pyproject.toml)
 are pinned only on minor version level, so all patch level fixes of dependencies
-can be applied to an Annif installation just by running
-`pip install annif --upgrade`.
+can be applied to an Annif installation
+(either manually updating the outdated packages or recreating the virtual environment and reinstalling Annif).
 
 ### Docker image
 The Docker image of the latest Annif release in the
@@ -38,11 +42,10 @@ Each security concern will be assigned to a handler from our team,
 who will contact you if there's a need for additional information.
 We confirm the problem and keep you informed of the fix.
 
-Please include the following information along with your report:
+Make sure to add the following details when submitting your report:
 
-- A descriptive title, clearly stating the nature and object software (Annif) of the report.
-- Your name and affiliation (if any).
-- A description of the technical details of the vulnerabilities.
-- A minimal example of the vulnerability.
-- An explanation of who can exploit this vulnerability, and what they gain when doing so.
-- Whether this vulnerability is public or known to third parties. If it is, please provide details.
+- A clear and descriptive title that outlines the report's subject and the software it pertains to (Annif).
+- Break down the technical aspects of the vulnerability in your description.
+- A minimal example showcasing the vulnerability.
+- An explanation who has the potential to exploit this vulnerability and the benefits they would derive from doing so.
+- Whether the vulnerability is public knowledge or known to third parties, and if so, share relevant details.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -34,6 +34,7 @@ do not apply to Annif use.
 
 We value your findings, and we would be grateful if you report
 any concerns or vulnerabilities by email to **`finto-posti@helsinki.fi`**.
+_Do not create a GitHub issue for security vulnerabilities_.
 Note that Annif team is a part of the larger Finto team,
 which has resources for the contact service throughout the year.
 
@@ -47,8 +48,9 @@ We confirm the problem and keep you informed of the fix.
 To facilitate a quick and accurate response make sure to include the following details when submitting your report:
 
 - A clear and descriptive title that outlines the report's subject and the software it pertains to (Annif).
-- The versions of Annif, its dependencies and the (possible) other related software that give rise to the vulnerability.
+- The version(s) of Annif, its dependencies and the (possible) other related software that contribute to the vulnerability.
 - Break down the technical aspects of the vulnerability in your description.
 - A minimal example showcasing the vulnerability.
 - An explanation who has the potential to exploit this vulnerability and the benefits they would derive from doing so.
 - Whether the vulnerability is public knowledge or known to third parties, and if so, share relevant details.
+- (A remediation suggestion if you have have one.)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,18 +2,15 @@
 
 ## Supported Versions
 
-The [most recent Annif (major/minor) release](https://github.com/NatLibFi/Annif/releases)
+The [most recent Annif major/minor release](https://github.com/NatLibFi/Annif/releases)
 is considered supported,
 in the sense that if a serious bug or vulnerability is encountered in it,
 a patch release is made to fix the issue.
 
-Generally, we aim to update all dependencies to their latest versions
-on each Annif major/minor release, but this can be restricted by the
-[backward compatibility policy](https://github.com/NatLibFi/Annif/wiki/Backward-compatibility-between-Annif-releases).
+Generally, we aim to update all dependencies to their latest versions on each Annif major/minor release.
 However, note that the [dependencies of a given Annif release](https://github.com/NatLibFi/Annif/blob/main/pyproject.toml)
-are pinned only on minor version level, so all patch level fixes of dependencies
-can be applied to an Annif installation
-(either manually updating the outdated packages or recreating the virtual environment and reinstalling Annif).
+are pinned only on minor version level, so all patch level fixes of dependencies can be applied to an Annif installation,
+by either manually updating the outdated packages or recreating the virtual environment from scratch and reinstalling Annif.
 
 ### Docker image
 The Docker image of the latest Annif release in the
@@ -39,7 +36,7 @@ If the security vulnerability is in a third-party software library,
 please report it also to the team maintaining it.
 
 Each security concern will be assigned to a handler from our team,
-who will contact you if there's a need for additional information.
+who will contact you if there is a need for additional information.
 We confirm the problem and keep you informed of the fix.
 
 Make sure to add the following details when submitting your report:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,30 +5,35 @@
 The [most recent Annif major/minor release](https://github.com/NatLibFi/Annif/releases)
 is considered supported,
 in the sense that if a serious bug or vulnerability is encountered in it,
-a patch release is made to fix the issue.
+we relase a patch to fix the issue.
 
 Generally, we aim to update all dependencies to their latest versions on each Annif major/minor release.
-However, note that the [dependencies of a given Annif release](https://github.com/NatLibFi/Annif/blob/main/pyproject.toml)
-are pinned only on minor version level, so all patch level fixes of dependencies can be applied to an Annif installation,
+However, note that most of the [dependencies of a given Annif release](https://github.com/NatLibFi/Annif/blob/main/pyproject.toml)
+are pinned only on minor version level, so patch level fixes of (most) dependencies can be applied to an Annif installation,
 by either manually updating the outdated packages or recreating the virtual environment from scratch and reinstalling Annif.
 
 ### Docker image
-The Docker image of the latest Annif release in the
-[quay.io repository](https://quay.io/repository/natlibfi/annif?tab=tags)
-is rebuilt from time to time in order to update both system packages and Annif dependencies in the image.
+We rebuild and publish a new Docker image of the latest Annif release in the
+[quay.io repository](https://quay.io/repository/natlibfi/annif?tab=info)
+when it is considered necessary in order to update both system packages and Annif dependencies of the image.
+A new image is published about once every month.
 
 The security scanner that is used on quay.io is
 [Clair](https://access.redhat.com/documentation/en-us/red_hat_quay/3/html/about_quay_io/clair-vulnerability-scanner).
-Typically the scanner detects many vulnerabilities at any moment in the Annif image, even several tens.
+You can see the vulnerabilities detected in an image by navigating via the link in the Security Scan column of the [tags view](https://quay.io/repository/natlibfi/annif?tab=tags),
+see the screenshot below.
+
+The scanner typically detects many vulnerabilities, that is several tens, in the packages of the images, even when they have been rebuild recently.
 However, there exist patches for only some of the vulnerabilities,
 and due to the way that Annif uses the dependencies, most of the detected vulnerabilities
 do not apply to Annif use.
 
+<img src="https://github.com/NatLibFi/Annif/assets/34240031/bab1316e-57fb-46a4-8ec0-94a414b26e2a" width="500">
+
 ## Reporting a Vulnerability
 
-Thank you for improving the security of Annif.
-We value your findings, and we'd be grateful if you report
-any concerns or vulnerabilities directly to `finto-posti@helsinki.fi`.
+We value your findings, and we would be grateful if you report
+any concerns or vulnerabilities by email to **`finto-posti@helsinki.fi`**.
 Note that Annif team is a part of the larger Finto team,
 which has resources for the contact service throughout the year.
 
@@ -39,9 +44,10 @@ Each security concern will be assigned to a handler from our team,
 who will contact you if there is a need for additional information.
 We confirm the problem and keep you informed of the fix.
 
-Make sure to add the following details when submitting your report:
+To facilitate a quick and accurate response make sure to include the following details when submitting your report:
 
 - A clear and descriptive title that outlines the report's subject and the software it pertains to (Annif).
+- The versions of Annif, its dependencies and the (possible) other related software that give rise to the vulnerability.
 - Break down the technical aspects of the vulnerability in your description.
 - A minimal example showcasing the vulnerability.
 - An explanation who has the potential to exploit this vulnerability and the benefits they would derive from doing so.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,48 @@
+# Security Policy
+
+## Supported Versions
+
+We aim to update all Annif dependencies to their latest versions
+on each Annif minor version release, but this can be restricted by the
+[backward compatibility policy](https://github.com/NatLibFi/Annif/wiki/Backward-compatibility-between-Annif-releases).
+
+However, the [dependencies of a given Annif release](https://github.com/NatLibFi/Annif/blob/main/pyproject.toml)
+are pinned only on minor version level, so all patch level fixes of dependencies
+can be applied to an Annif installation just by running
+`pip install annif --upgrade`.
+
+### Docker image
+The Docker image of the latest Annif release in the
+[quay.io repository](https://quay.io/repository/natlibfi/annif?tab=tags)
+is rebuilt from time to time in order to update both system packages and Annif dependencies in the image.
+
+The security scanner that is used on quay.io is
+[Clair](https://access.redhat.com/documentation/en-us/red_hat_quay/3/html/about_quay_io/clair-vulnerability-scanner).
+Typically the scanner detects many vulnerabilities at any moment in the Annif image, even several tens.
+However, there exist patches for only some of the vulnerabilities,
+and due to the way that Annif uses the dependencies, most of the detected vulnerabilities
+do not apply to Annif use.
+
+## Reporting a Vulnerability
+
+Thank you for improving the security of Annif.
+We value your findings, and we'd be grateful if you report
+any concerns or vulnerabilities directly to `finto-posti@helsinki.fi`.
+Note that Annif team is a part of the larger Finto team,
+which has resources for the contact service throughout the year.
+
+If the security vulnerability is in a third-party software library,
+please report it also to the team maintaining it.
+
+Each security concern will be assigned to a handler from our team,
+who will contact you if there's a need for additional information.
+We confirm the problem and keep you informed of the fix.
+
+Please include the following information along with your report:
+
+- A descriptive title, clearly stating the nature and object software (Annif) of the report.
+- Your name and affiliation (if any).
+- A description of the technical details of the vulnerabilities.
+- A minimal example of the vulnerability.
+- An explanation of who can exploit this vulnerability, and what they gain when doing so.
+- Whether this vulnerability is public or known to third parties. If it is, please provide details.


### PR DESCRIPTION
It is a good practice to inform how to report vulnerabilities, which is what `SECURITY.md` file is for.

~I have worded this in `SECURITY.md` file:~
~> However, the [dependencies of a given Annif release](https://github.com/NatLibFi/Annif/blob/main/pyproject.toml) are pinned only on minor version level~

~But this is actually not true;~ [Edited this part to include a true statement.]
There are the following patch level version pinnings:
- connexion `2.14.2`
- fasttext `0.9.2`
- lmdb `1.4.1`
- yake `0.4.5`

Right now I don't remember why they are pinned to patch level. Need to check that. It would be good that all (security) patches of dependencies could be applied without the need to update Annif version. Does some of these dependencies have such a backward compatibility policy that conflicts with Annif's policy?

~Also reword the bottom list.~ [Done.]

Also at the moment Annif repo has [Security advisories](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability) enabled (I enabled it when looking at this security reporting a while ago), which allows anyone to give a report via navigating to the Security tab in this repo. Having two reporting ways (finto-posti email and this reporting) can be confusing, so maybe the Security advisories functionality should be disabled.