### PR TITLE
Fix tests error due to pinned schemathesis version 3.19.* / Docker rebuild

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ flake8 = "*"
 bumpversion = "*"
 black = "23.*"
 isort = "*"
-schemathesis = "3.19.*"
+schemathesis = "3.*.*"
 
 [tool.poetry.extras]
 fasttext = ["fasttext-wheel"]


### PR DESCRIPTION
Fix the unit tests by switching to pin Schemathesis version only on major level. Closes #747.