### PR TITLE
Fix installation on Python 3.8 due to missing Tensorflow-io wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ jsonschema = "4.17.*"
 fasttext-wheel = {version = "0.9.2", optional = true}
 voikko = {version = "0.5.*", optional = true}
 tensorflow-cpu = {version = "2.13.*", optional = true}
+tensorflow-io-gcs-filesystem = {version = "<=0.34.*", optional = true, python = "3.8"}
 lmdb = {version = "1.4.1", optional = true}
 omikuji = {version = "0.5.*", optional = true}
 yake = {version = "0.4.5", optional = true}
@@ -74,7 +75,7 @@ schemathesis = "3.*.*"
 [tool.poetry.extras]
 fasttext = ["fasttext-wheel"]
 voikko = ["voikko"]
-nn = ["tensorflow-cpu", "lmdb"]
+nn = ["tensorflow-cpu", "tensorflow-io-gcs-filesystem", "lmdb"]
 omikuji = ["omikuji"]
 yake = ["yake"]
 spacy = ["spacy"]


### PR DESCRIPTION
[TensorFlow IO v0.35.0](https://github.com/tensorflow/io/releases/tag/v0.35.0) was released in December 19th. That release in PyPI does not provide many [platform wheels](https://pypi.org/project/tensorflow-io-gcs-filesystem/0.35.0/#files) that were provided by [v0.34.0](https://pypi.org/project/tensorflow-io-gcs-filesystem/0.34.0/#files). See the tracking issue https://github.com/tensorflow/io/issues/1906.

Now Annif installation with NN ensemble backend fails on Python 3.8 (there were some failed [CI runs](https://github.com/NatLibFi/Annif/actions/runs/7380737366)). 

We may want to drop support for Python 3.8 for Annif v1.1, but for the meantime, this fixes the installation by making TensorFlow IO a direct dependency for Python 3.8 and pins its version to 0.34.*.