### PR TITLE
Fix tests and Docker rebuild due to defunct Schemathesis and pytest dependencies resolution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ stwfsapy = {version="0.3.*", optional = true}
 
 [tool.poetry.dev-dependencies]
 py = "*"
-pytest = "*"
+pytest = "7.*"
 requests = "*"
 pytest-cov = "*"
 pytest-watch = "*"


### PR DESCRIPTION
[Pytest 8.0.0 was released](https://pythontest.com/pytest/pytest-8-is-here/) on 2014-01-17. Lately Schemathesis releases have been [pinning pytest to <=8](https://github.com/schemathesis/schemathesis/blob/e088280b17b38245a00d66782f22f175a520d510/pyproject.toml#L46), and as Poetry favored pytest over Schemathesis in version resolution, pytest 8 and Schemathesis 3.14.2 (version just before pytest <=8 pinning) are now being installed. 

The problem is that tests (and thus Docker rebuild) do not work with this ancient Schemathesis version:
```
...
RuntimeError: The starlette.testclient module requires the httpx package to be installed.
You can install this with:
    $ pip install httpx 
```

This is fixed by pinning to pytest 7.\*.* in Annif.