### PR TITLE
Fix RTD builds by upgrading dependencies 

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
-sphinx==4.5.*
+sphinx==7.2.*
 sphinx-rtd-theme
-sphinxcontrib-apidoc==0.3.0
+sphinxcontrib-apidoc==0.5.*
 sphinx-click
-docutils==0.16
+docutils==0.20.*


### PR DESCRIPTION
The builds for readthedocs documentation (e.g. [this](https://readthedocs.org/projects/annif/builds/23322209/)) were failing due to an error:
```
...
Sphinx version error:
The sphinxcontrib.applehelp extension used by this project needs at least Sphinx v5.0; it therefore cannot be built with this version.
```

This is fixed by upgrading dependencies used in the build.