### PR TITLE
Drop Python 3.8 support

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -23,7 +23,7 @@ jobs:
     - name: "Prepare: restore caches, install Poetry, set up Python"
       uses: ./.github/actions/prepare
       with:
-        python-version: "3.10"
+        python-version: "3.11"
         poetry-version: ${{ env.POETRY_VERSION }}
     - name: Install Python dev dependencies
       run: |
@@ -47,7 +47,7 @@ jobs:
       id: prepare
       uses: ./.github/actions/prepare
       with:
-        python-version: "3.9"
+        python-version: "3.10"
         poetry-version: ${{ env.POETRY_VERSION }}
     - name: Install Python dependencies
       run: |
@@ -61,7 +61,7 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11"]
     name: test on Python ${{ matrix.python-version }}
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -79,19 +79,15 @@ jobs:
     - name: Install Python dependencies
       run: |
         # Selectively install the optional dependencies for some Python versions
-        # For Python 3.8:
-        if [[ ${{ matrix.python-version }} == '3.8' ]]; then
-          poetry install -E "nn omikuji yake voikko stwfsa";
-        fi
         # For Python 3.9:
         if [[ ${{ matrix.python-version }} == '3.9' ]]; then
-          poetry install -E "fasttext spacy";
-          # download the small English pretrained spaCy model needed by spacy analyzer
-          poetry run python -m spacy download en_core_web_sm --upgrade-strategy only-if-needed
+          poetry install -E "nn omikuji yake voikko stwfsa";
         fi
         # For Python 3.10:
         if [[ ${{ matrix.python-version }} == '3.10' ]]; then
-          poetry install -E "nn omikuji yake stwfsa";
+          poetry install -E "fasttext spacy";
+          # download the small English pretrained spaCy model needed by spacy analyzer
+          poetry run python -m spacy download en_core_web_sm --upgrade-strategy only-if-needed
         fi
         # For Python 3.11:
         if [[ ${{ matrix.python-version }} == '3.11' ]]; then
@@ -103,7 +99,7 @@ jobs:
     - name: Test with pytest
       run: |
         poetry run pytest --cov=./ --cov-report xml
-        if [[ ${{ matrix.python-version }} == '3.9' ]]; then
+        if [[ ${{ matrix.python-version }} == '3.10' ]]; then
           poetry run pytest --cov=./ --cov-report xml --cov-append -m slow
         fi
     - name: Upload coverage to Codecov

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -4,7 +4,7 @@ checks:
     duplicate_code: true
 build:
   environment:
-    python: 3.8.12
+    python: 3.9.17
   dependencies:
     override:
      - pip install .[dev]

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ already functional for many common tasks.
 
 Annif is developed and tested on Linux. If you want to run Annif on Windows or Mac OS, the recommended way is to use Docker (see below) or a Linux virtual machine.
 
-You will need Python 3.8+ to install Annif.
+You will need Python 3.9+ to install Annif.
 
 The recommended way is to install Annif from
 [PyPI](https://pypi.org/project/annif/) into a virtual environment.

--- a/annif/backend/yake.py
+++ b/annif/backend/yake.py
@@ -51,7 +51,7 @@ class YakeBackend(backend.AnnifBackend):
 
     @property
     def label_types(self) -> list[URIRef]:
-        if type(self.params["label_types"]) == str:  # Label types set by user
+        if isinstance(self.params["label_types"], str):  # Label types set by user
             label_types = [lt.strip() for lt in self.params["label_types"].split(",")]
             self._validate_label_types(label_types)
         else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ schemathesis = "3.*.*"
 [tool.poetry.extras]
 fasttext = ["fasttext-wheel"]
 voikko = ["voikko"]
-nn = ["tensorflow-cpu", "tensorflow-io-gcs-filesystem", "lmdb"]
+nn = ["tensorflow-cpu", "lmdb"]
 omikuji = ["omikuji"]
 yake = ["yake"]
 spacy = ["spacy"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers=[
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.8,<3.12"
+python = ">=3.9,<3.12"
 
 connexion = {version = "2.14.2", extras = ["swagger-ui"]}
 flask = "2.2.*"
@@ -52,7 +52,6 @@ jsonschema = "4.17.*"
 fasttext-wheel = {version = "0.9.2", optional = true}
 voikko = {version = "0.5.*", optional = true}
 tensorflow-cpu = {version = "2.13.*", optional = true}
-tensorflow-io-gcs-filesystem = {version = "<=0.34.*", optional = true, python = "3.8"}
 lmdb = {version = "1.4.1", optional = true}
 omikuji = {version = "0.5.*", optional = true}
 yake = {version = "0.4.5", optional = true}


### PR DESCRIPTION
I started to update dependencies for the next release, but noted that many dependencies cannot be upgraded for Python 3.8, so it seems to best to drop it out the Python versions that Annif supports (after this 3.8-3.11). This is in line with the [Backward compatibility policy](https://github.com/NatLibFi/Annif/wiki/Backward-compatibility-between-Annif-releases#python-environment).

In the CI/CD pipeline the Python versions used in different actions are rotated forward.

Also removes the tensorflow-io-gcs-filesystem dependency, which was recently added in #759 to fix installing Annif on Python 3.8.