### PR TITLE
Fix blocked http-request for version number on https site

### DIFF
--- a/annif/templates/home.html
+++ b/annif/templates/home.html
@@ -287,7 +287,7 @@ new Vue({
     },
     loadVersion: function() {
       var this_ = this;
-      axios.get('/v1')
+      axios.get('/v1/')
         .then(res => {
           this_.annif_version = res.data.version;
         })


### PR DESCRIPTION
Displaying the version of Annif on Web UI was added in PR #745, but it was not working when Annif was deployed on a site using https, e.g. https://dev.annif.org: Firefox console showed error

    Blocked loading mixed active content “http://dev.annif.org/v1/”

and the displayed version string was empty.

~This [SO answer](https://stackoverflow.com/a/57646910) advises to add a metatag for "[Content-Security-Policy: upgrade-insecure-requests](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy)". This "is intended for websites with large numbers of insecure legacy URLs that need to be rewritten", but I did not find another way to fix this, because the version number is queried from `/v1` path, whatever the site domain is.~

But now I started to wonder why the same error does not arise when querying projects from `/v1/projects` path, which is also a GET request...

Edit: Force pushed with a more proper way to fix this by fetching the version information from url `/v1/` (with trailing slash), which was hinted in some SO answers. It seemed that directly accessing https://dev.annif.org/v1 with a browser was returned with a 308 Permanent Redirect to https://dev.annif.org/v1/, so it seems the trailing slash "just makes this work", and this is related to the [(root) path defined in the OpenAPI spec used for the version](https://github.com/NatLibFi/Annif/blob/1e182b29fe2bd7e010e0d25b2b7623c0827509db/annif/openapi/annif.yaml#L8), which appends a slash to `/v1`. 