### PR TITLE
Allow loading selected projects using environment variable

### DIFF
--- a/annif/registry.py
+++ b/annif/registry.py
@@ -1,6 +1,7 @@
 """Registry that keeps track of Annif projects"""
 from __future__ import annotations
 
+import os
 import re
 
 from flask import Flask, current_app
@@ -35,9 +36,11 @@ class AnnifRegistry:
         self._projects_config_path = projects_config_path
         self._datadir = datadir
         self._init_vars()
+        projects_pattern = os.getenv("ANNIF_PROJECTS_INIT", ".*")
         if init_projects:
             for project in self._projects[self._rid].values():
-                project.initialize()
+                if re.search(projects_pattern, project.project_id) is not None:
+                    project.initialize()
 
     def _init_vars(self) -> None:
         # initialize the static variables, if necessary

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
 """common fixtures for use by all test classes"""
 
-import os.path
+import os
 import shutil
 import unittest.mock
 
@@ -29,6 +29,13 @@ def app():
 
 @pytest.fixture(scope="module")
 def app_with_initialize():
+    app = annif.create_app(config_name="annif.default_config.TestingInitializeConfig")
+    return app
+
+
+@pytest.fixture(scope="module")
+@unittest.mock.patch.dict(os.environ, {"ANNIF_PROJECTS_INIT": ".*-fi"})
+def app_with_initialize_fi_projects():
     app = annif.create_app(config_name="annif.default_config.TestingInitializeConfig")
     return app
 

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -300,6 +300,20 @@ def test_project_initialized(app_with_initialize):
     assert project.backend.initialized
 
 
+def test_project_not_initialized_with_selection(app_with_initialize_fi_projects):
+    with app_with_initialize_fi_projects.app_context():
+        project = annif.registry.get_project("dummy-en")
+    assert not project.initialized
+    assert not project.backend.initialized
+
+
+def test_project_initialized_with_selection(app_with_initialize_fi_projects):
+    with app_with_initialize_fi_projects.app_context():
+        project = annif.registry.get_project("dummy-fi")
+    assert project.initialized
+    assert project.backend.initialized
+
+
 def test_project_file_not_found():
     app = annif.create_app(config_name="annif.default_config.TestingNoProjectsConfig")
     with app.app_context():


### PR DESCRIPTION
This PR makes it possible to select the projects that Annif loads on startup via a regexp pattern given in the environment variable `ANNIF_PROJECTS_INIT`.  The same env can be used in NGINX in its [location directive](https://nginx.org/en/docs/http/ngx_http_core_module.html#location) configuration to make NGINX pass a request to the Annif instance that has loaded the requested project.

An image with these changes has been running at ai.dev.finto.fi. The used helm-chart includes grouping projects with these environment variables:

    yso-.*fi
    yso-.*sv
    yso-.*en
    kauno-.*
    thema-.*
    ykl-.*


Closes #733.