### PR TITLE
Fix project data files detection

### DIFF
--- a/annif/backend/backend.py
+++ b/annif/backend/backend.py
@@ -53,14 +53,15 @@ class AnnifBackend(metaclass=abc.ABCMeta):
 
     @property
     def _model_file_paths(self) -> list:
-        all_paths = glob(os.path.join(self.datadir, "*"))
+        all_paths = glob(os.path.join(self.datadir, "**"), recursive=True)
+        file_paths = [p for p in all_paths if os.path.isfile(p)]
         ignore_patterns = ("*-train*", "tmp-*", "vectorizer")
         ignore_paths = [
             path
             for igp in ignore_patterns
             for path in glob(os.path.join(self.datadir, igp))
         ]
-        return list(set(all_paths) - set(ignore_paths))
+        return list(set(file_paths) - set(ignore_paths))
 
     @property
     def is_trained(self) -> bool:


### PR DESCRIPTION
 I noticed that after 

    annif download yso-bonsai-en juhoinkinen/Annif-models-upload-testing

the modification time of omikuji projects as detected by Annif is wrong; it is shown to be the extraction time:
```
annif show-project yso-bonsai-en 
...
Modification time: 2024-03-13 11:36:22
```
This is because of the timestamp of the `data/projects/yso-bonsai-en/omikuji-model/` _directory_, which is set to the time when the files it contains get extracted.

_Originally posted by @juhoinkinen in https://github.com/NatLibFi/Annif/issues/762#issuecomment-1994122090_

---

This PR fixes the above problem by making all subdirectories in project data directory to be disregarded as model data files (the directories themselves do not affect the model results).

Also make the files in the subdirectories be regarded as they should be.