### PR TITLE
Python 3.12 support

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -61,7 +61,7 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
     name: test on Python ${{ matrix.python-version }}
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -92,6 +92,12 @@ jobs:
         # For Python 3.11:
         if [[ ${{ matrix.python-version }} == '3.11' ]]; then
           poetry install -E "nn fasttext yake stwfsa voikko spacy";
+          # download the small English pretrained spaCy model needed by spacy analyzer
+          poetry run python -m spacy download en_core_web_sm --upgrade-strategy only-if-needed
+        fi
+        # For Python 3.12:
+        if [[ ${{ matrix.python-version }} == '3.12' ]]; then
+          poetry install -E "fasttext yake voikko spacy";
           # download the small English pretrained spaCy model needed by spacy analyzer
           poetry run python -m spacy download en_core_web_sm --upgrade-strategy only-if-needed
         fi

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ already functional for many common tasks.
 
 Annif is developed and tested on Linux. If you want to run Annif on Windows or Mac OS, the recommended way is to use Docker (see below) or a Linux virtual machine.
 
-You will need Python 3.9+ to install Annif.
+You will need Python 3.9-3.12 to install Annif.
 
 The recommended way is to install Annif from
 [PyPI](https://pypi.org/project/annif/) into a virtual environment.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,12 +51,12 @@ jsonschema = "4.21.*"
 
 fasttext-wheel = { version = "0.9.2", optional = true }
 voikko = { version = "0.5.*", optional = true }
-tensorflow-cpu = { version = "2.15.*", optional = true }
+tensorflow-cpu = { version = "2.15.*", optional = true, python = "<3.12" }
 lmdb = { version = "1.4.1", optional = true }
 omikuji = { version = "0.5.*", optional = true }
 yake = { version = "0.4.8", optional = true }
 spacy = { version = "3.7.*", optional = true }
-stwfsapy = { version = "0.4.*", optional = true }
+stwfsapy = { version = "0.4.*", optional = true, python = "<3.12" }
 
 [tool.poetry.dev-dependencies]
 py = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.9,<3.12"
+python = ">=3.9,<3.13"
 
 connexion = { version = "2.14.2", extras = ["swagger-ui"] }
 flask = "2.2.*"


### PR DESCRIPTION
Annif on Python 3.12 already works when the optional dependencies stwfsapy and tensorflow-cpu are not installed or even declared as dependecies.

~Closes #779.~ 
At the moment does not fully close #779 because stwfsapy and NN ensemble will not work on Python 3.12.