### PR TITLE
Group Dependabot GitHub Actions updates into one PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Dependabot is good for keeping GH Actions up-to-date, but it has been opening one PR per Action to update (once a month), which has meant several open Dependabot PRs (currently 3). But I noticed that it is possible to make Dependabot to put all its updates to one PR, like in https://github.com/tensorflow/io/pull/1964.

See the [documentation](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups) of the feature. 