### PR TITLE
Fix: Add `--host` to `annif run`

### DIFF
--- a/annif/cli.py
+++ b/annif/cli.py
@@ -444,6 +444,7 @@ def run_eval(
 
 
 @cli.command("run")
+@click.option("--host", type=str, default="127.0.0.1")
 @click.option("--port", type=int, default=5000)
 @click.option("--log-level")
 @click_log.simple_verbosity_option(logger, default="ERROR")


### PR DESCRIPTION
So that tutorial for web ui (https://github.com/NatLibFi/Annif-tutorial/blob/master/transcripts/web-ui.md) can be followed for docker installations.