### PR TITLE
adding stable gensim for supporting py3.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ click = "8.1.*"
 click-log = "0.4.*"
 joblib = "1.4.*"
 nltk = "3.8.*"
-gensim = "4.3.*"
+gensim={git = "https://github.com/piskvorky/gensim.git", rev ="da2f388"}
 scikit-learn = "1.4.*"
 scipy = "1.12.*"
 rdflib = "7.0.*"


### PR DESCRIPTION
adding last stable commit of gensim for support python 3.12 solving: #779
I wrote similar problem here.
https://blog.techbend.io/overcoming-the-hazm-compatibility-challenge-with-python-312