### PR TITLE
Fix limit parameter not passed to requests by HTTP backend

### DIFF
--- a/annif/backend/http.py
+++ b/annif/backend/http.py
@@ -68,6 +68,8 @@ class HTTPBackend(backend.AnnifBackend):
         data = {"text": text}
         if "project" in params:
             data["project"] = params["project"]
+        if "limit" in params:
+            data["limit"] = params["limit"]
 
         try:
             req = requests.post(params["endpoint"], data=data, headers=self.headers)


### PR DESCRIPTION
I noticed that the limit parameter in the project configuration had no effect to the number of the suggestions in the case of the HTTP backend. This is fixed by adding that parameter to the POST request, if it is used.

Also adds a test to verify that the the POST request by the HTTP backend actually contains the intended arguments.