### PR TITLE
Sort language detection results by descending score

### DIFF
--- a/annif/rest.py
+++ b/annif/rest.py
@@ -100,10 +100,14 @@ def detect_language(body: dict[str, Any]):
         )
 
     result = {
-        "results": [
-            {"language": lang if lang != "unk" else None, "score": score}
-            for lang, score in proportions.items()
-        ]
+        "results": sorted(
+            [
+                {"language": lang if lang != "unk" else None, "score": score}
+                for lang, score in proportions.items()
+            ],
+            key=lambda x: x["score"],
+            reverse=True,
+        )
     }
     return result, 200, {"Content-Type": "application/json"}
 

--- a/tests/test_rest.py
+++ b/tests/test_rest.py
@@ -59,7 +59,7 @@ def test_rest_detect_language_english(app):
         result = annif.rest.detect_language(
             {"text": "example text", "languages": ["en", "fi", "sv"]}
         )[0]
-        assert {"language": "en", "score": 1} in result["results"]
+        assert result["results"][0] == {"language": "en", "score": 1}
 
 
 def test_rest_detect_language_unknown(app):
@@ -68,13 +68,13 @@ def test_rest_detect_language_unknown(app):
         result = annif.rest.detect_language(
             {"text": "exampley texty", "languages": ["fi", "sv"]}
         )[0]
-        assert {"language": None, "score": 1} in result["results"]
+        assert result["results"][0] == {"language": None, "score": 1}
 
 
 def test_rest_detect_language_no_text(app):
     with app.app_context():
         result = annif.rest.detect_language({"text": "", "languages": ["en"]})[0]
-        assert {"language": None, "score": 1} in result["results"]
+        assert result["results"][0] == {"language": None, "score": 1}
 
 
 def test_rest_detect_language_unsupported_candidates(app):


### PR DESCRIPTION
This is an improvement to the language detection REST API method (#631) which improves the implementation that was made in #659.

Results are now sorted by descending score, so the most likely language is returned first.