### PR TITLE
Add `detect-language` CLI command to commands list in RTD documentation

### DIFF
--- a/docs/source/commands.rst
+++ b/docs/source/commands.rst
@@ -97,7 +97,7 @@ Subject index administration
 **REST equivalent**
 ::
 
-   /projects/<PROJECT_ID>/learn
+   POST /projects/<PROJECT_ID>/learn
 
 .. click:: annif.cli:run_suggest
    :prog: annif suggest
@@ -152,7 +152,7 @@ Other
 **REST equivalent**
 ::
 
-   /detect-language
+   POST /detect-language
 
 .. click:: annif.cli:run_completion
    :prog: annif completion

--- a/docs/source/commands.rst
+++ b/docs/source/commands.rst
@@ -146,6 +146,14 @@ Subject index administration
 Other
 *****
 
+.. click:: annif.cli:run_detect_language
+   :prog: annif detect-language
+
+**REST equivalent**
+::
+
+   /detect-language
+
 .. click:: annif.cli:run_completion
    :prog: annif completion
 


### PR DESCRIPTION
Adds the necessary entry for the readthedocs documetation to include the new `detect-language` CLI command, added in #801.

Also marks REST /learn and /detect-language methods as POST like /suggest was marked.

The docs from this branch are visible [here](https://annif.readthedocs.io/en/docs-for-detect-language-cli-command/source/commands.html#other) at the moment. 