### PR TITLE
Automate NLTK datapackage `punkt_tab` download

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,6 @@ The recommended way is to install Annif from
     source annif-venv/bin/activate
     pip install annif
 
-You will also need NLTK data files:
-
-    python -m nltk.downloader punkt_tab
-
 Start up the application:
 
     annif
@@ -112,10 +108,6 @@ By default development dependencies are included. Use option `-E` to install dep
 Enter the virtual environment:
 
     poetry shell
-
-You will also need NLTK data files:
-
-    python -m nltk.downloader punkt_tab
 
 Start up the application:
 

--- a/annif/analyzer/analyzer.py
+++ b/annif/analyzer/analyzer.py
@@ -38,6 +38,8 @@ class Analyzer(metaclass=abc.ABCMeta):
                     "downloading it now."
                 )
                 nltk.download(_NLTK_TOKENIZER_DATA)
+            else:
+                raise
 
     def tokenize_sentences(self, text: str) -> list[str]:
         """Tokenize a piece of text (e.g. a document) into sentences."""

--- a/annif/analyzer/analyzer.py
+++ b/annif/analyzer/analyzer.py
@@ -11,6 +11,7 @@ import annif
 logger = annif.logger
 
 _KEY_TOKEN_MIN_LENGTH = "token_min_length"
+_NLTK_TOKENIZER_DATA = "punkt_tab"
 
 
 class Analyzer(metaclass=abc.ABCMeta):
@@ -28,14 +29,15 @@ class Analyzer(metaclass=abc.ABCMeta):
         import nltk.data
 
         try:
-            nltk.data.find("tokenizers/punkt_tab")
+            nltk.data.find("tokenizers/" + _NLTK_TOKENIZER_DATA)
         except LookupError as err:
             logger.debug(str(err))
-            if "punkt_tab" in str(err):  # "punkt_tab" is surrounded by color code tags
+            if _NLTK_TOKENIZER_DATA in str(err):
                 logger.warning(
-                    'NLTK datapackage "punkt_tab" not found, downloading it now.'
+                    f'NLTK datapackage "{_NLTK_TOKENIZER_DATA}" not found, '
+                    "downloading it now."
                 )
-                nltk.download("punkt_tab")
+                nltk.download(_NLTK_TOKENIZER_DATA)
 
     def tokenize_sentences(self, text: str) -> list[str]:
         """Tokenize a piece of text (e.g. a document) into sentences."""

--- a/annif/analyzer/analyzer.py
+++ b/annif/analyzer/analyzer.py
@@ -6,6 +6,10 @@ import abc
 import functools
 import unicodedata
 
+import annif
+
+logger = annif.logger
+
 _KEY_TOKEN_MIN_LENGTH = "token_min_length"
 
 
@@ -20,6 +24,18 @@ class Analyzer(metaclass=abc.ABCMeta):
     def __init__(self, **kwargs) -> None:
         if _KEY_TOKEN_MIN_LENGTH in kwargs:
             self.token_min_length = int(kwargs[_KEY_TOKEN_MIN_LENGTH])
+
+        import nltk.data
+
+        try:
+            nltk.data.find("tokenizers/punkt_tab")
+        except LookupError as err:
+            logger.debug(str(err))
+            if "punkt_tab" in str(err):  # "punkt_tab" is surrounded by color code tags
+                logger.warning(
+                    'NLTK datapackage "punkt_tab" not found, downloading it now.'
+                )
+                nltk.download("punkt_tab")
 
     def tokenize_sentences(self, text: str) -> list[str]:
         """Tokenize a piece of text (e.g. a document) into sentences."""

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -1,5 +1,7 @@
 """Unit tests for analyzers in Annif"""
 
+from unittest import mock
+
 import pytest
 
 import annif.analyzer
@@ -13,6 +15,15 @@ def test_get_analyzer_nonexistent():
 def test_get_analyzer_badspec():
     with pytest.raises(ValueError):
         annif.analyzer.get_analyzer("()")
+
+
+@mock.patch("nltk.data.find", side_effect=LookupError("Resource punkt_tab not found"))
+@mock.patch("nltk.download")
+def test_nltk_data_missing(download, find):
+    annif.analyzer.get_analyzer("snowball(english)")
+    assert find.called
+    assert download.called
+    assert download.call_args == mock.call("punkt_tab")
 
 
 def test_english_analyzer_normalize_word():


### PR DESCRIPTION
Based on the update-dependencies-v1.2 branch (PR #796) because it upgrades NLTK to a version that needs the `punkt_tab` package (not `punkt` anymore): https://github.com/nltk/nltk/pull/3283) 

The download is performed automatically when instantiating an Analyzer object, if the `punkt_tab` data is not found. The `README.md` has been adjusted for this (i.e. removed the instructions to run `python -m nltk.downloader punkt_tab`). NB: Adjust Wiki pages too on release.

In Dockerfile [this data download step](https://github.com/NatLibFi/Annif/blob/automate-nltkdata-download/Dockerfile#L31) is retained, so when using the Dockerimage everything is ready without download needs (otherwise the data would be re-downloaded every time Annif is used in a new container, because the NLTK data storage is not mounted to a volume).

Also in the CI/CD pipeline there is still [this explicit download step](https://github.com/NatLibFi/Annif/blob/45be777cfd12609150973b95d496cf232862526f/.github/workflows/cicd.yml#L104).

BTW, now when modifying this, it would be a good time to consider changing the location of the NLTK data storage, which is discussed [here](https://github.com/NatLibFi/Annif/pull/540#issuecomment-996714399). However, the current `~/nltk_data/` is not bad, I think.