### PR TITLE
Upgrade Docker baseimage to Python 3.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim-bookworm
+FROM python:3.12-slim-bookworm
 LABEL org.opencontainers.image.authors="grp-natlibfi-annif@helsinki.fi"
 SHELL ["/bin/bash", "-c"]
 


### PR DESCRIPTION
Now when Python 3.12 will be fully supported (after https://github.com/NatLibFi/Annif/pull/796), lets upgrade to it in Docker image.

The upgrade should bring some performance improvements. 