### PR TITLE
Add `--trust-repo` option to `download` CLI command

### DIFF
--- a/annif/cli.py
+++ b/annif/cli.py
@@ -633,7 +633,9 @@ def run_upload(
     that match the given `project_ids_pattern` to archive files, and uploads the
     archives along with the project configurations to the specified Hugging Face
     Hub repository. An authentication token and commit message can be given with
-    options.
+    options. If the README.md does not exist in the repository it is
+    created with default contents and metadata of the uploaded projects, if it exists,
+    its metadata are updated as necessary.
     """
     from huggingface_hub import HfApi
     from huggingface_hub.utils import HfHubHTTPError, HFValidationError
@@ -690,8 +692,14 @@ def run_upload(
     is_flag=True,
     help="Replace an existing project/vocabulary/config with the downloaded one",
 )
+@click.option(
+    "--trust-repo",
+    default=False,
+    is_flag=True,
+    help="Allow download from the repository even when it has no entries in the cache",
+)
 @cli_util.common_options
-def run_download(project_ids_pattern, repo_id, token, revision, force):
+def run_download(project_ids_pattern, repo_id, token, revision, force, trust_repo):
     """
     Download selected projects and their vocabularies from a Hugging Face Hub
     repository.
@@ -700,11 +708,13 @@ def run_download(project_ids_pattern, repo_id, token, revision, force):
     configuration files of the projects that match the given
     `project_ids_pattern` from the specified Hugging Face Hub repository and
     unzips the archives to `data/` directory and places the configuration files
-    to `projects.d/` directory. An authentication token and revision can
-    be given with options. If the README.md does not exist in the repository it is
-    created with default contents and metadata of the uploaded projects, if it exists,
-    its metadata are updated as necessary.
+    to `projects.d/` directory. An authentication token and revision can be given with
+    options. If the repository hasn’t been used for downloads previously
+    (i.e., it doesn’t appear in the Hugging Face Hub cache on local system), the
+    `--trust-repo` option needs to be used.
     """
+
+    hfh_util.check_is_download_allowed(trust_repo, repo_id, token)
 
     project_ids = hfh_util.get_matching_project_ids_from_hf_hub(
         project_ids_pattern, repo_id, token, revision

--- a/annif/cli.py
+++ b/annif/cli.py
@@ -714,7 +714,7 @@ def run_download(project_ids_pattern, repo_id, token, revision, force, trust_rep
     `--trust-repo` option needs to be used.
     """
 
-    hfh_util.check_is_download_allowed(trust_repo, repo_id, token)
+    hfh_util.check_is_download_allowed(trust_repo, repo_id)
 
     project_ids = hfh_util.get_matching_project_ids_from_hf_hub(
         project_ids_pattern, repo_id, token, revision

--- a/annif/hfh_util.py
+++ b/annif/hfh_util.py
@@ -32,7 +32,7 @@ def check_is_download_allowed(trust_repo, repo_id, token):
             f'Download allowed from "{repo_id}" because "--trust-repo" flag is used.'
         )
         return
-    if _is_repo_in_cache(repo_id, token):
+    if _is_repo_in_cache(repo_id):
         logger.debug(
             f'Download allowed from "{repo_id}" because repo is already in cache.'
         )
@@ -42,7 +42,7 @@ def check_is_download_allowed(trust_repo, repo_id, token):
     )
 
 
-def _is_repo_in_cache(repo_id, token):
+def _is_repo_in_cache(repo_id):
     from huggingface_hub import CacheNotFound, scan_cache_dir
 
     try:

--- a/annif/hfh_util.py
+++ b/annif/hfh_util.py
@@ -24,7 +24,7 @@ from annif.project import Access, AnnifProject
 logger = annif.logger
 
 
-def check_is_download_allowed(trust_repo, repo_id, token):
+def check_is_download_allowed(trust_repo, repo_id):
     """Check if downloading from the specified repository is allowed based on the trust
     option and cache status."""
     if trust_repo:

--- a/annif/hfh_util.py
+++ b/annif/hfh_util.py
@@ -24,6 +24,35 @@ from annif.project import Access, AnnifProject
 logger = annif.logger
 
 
+def check_is_download_allowed(trust_repo, repo_id, token):
+    """Check if downloading from the specified repository is allowed based on the trust
+    option and cache status."""
+    if trust_repo:
+        logger.warning(
+            f'Download allowed from "{repo_id}" because "--trust-repo" flag is used.'
+        )
+        return
+    if _is_repo_in_cache(repo_id, token):
+        logger.debug(
+            f'Download allowed from "{repo_id}" because repo is already in cache.'
+        )
+        return
+    raise OperationFailedException(
+        f'Cannot download projects from untrusted repo "{repo_id}"'
+    )
+
+
+def _is_repo_in_cache(repo_id, token):
+    from huggingface_hub import CacheNotFound, scan_cache_dir
+
+    try:
+        cache = scan_cache_dir()
+    except CacheNotFound as err:
+        logger.debug(str(err) + "\nNo HFH cache found.")
+        return False
+    return repo_id in [info.repo_id for info in cache.repos]
+
+
 def get_matching_projects(pattern: str) -> list[AnnifProject]:
     """
     Get projects that match the given pattern.

--- a/tests/test_hfh_util.py
+++ b/tests/test_hfh_util.py
@@ -20,10 +20,9 @@ from annif.exception import OperationFailedException
 def test_download_allowed_trust_repo(mock_is_repo_in_cache, caplog):
     trust_repo = True
     repo_id = "dummy-repo"
-    token = "dummy-token"
 
     with caplog.at_level(logging.WARNING, logger="annif"):
-        annif.hfh_util.check_is_download_allowed(trust_repo, repo_id, token)
+        annif.hfh_util.check_is_download_allowed(trust_repo, repo_id)
     assert (
         'Download allowed from "dummy-repo" because "--trust-repo" flag is used.'
         in caplog.text
@@ -34,10 +33,9 @@ def test_download_allowed_trust_repo(mock_is_repo_in_cache, caplog):
 def test_download_allowed_repo_in_cache(mock_is_repo_in_cache, caplog):
     trust_repo = False
     repo_id = "dummy-repo"
-    token = "dummy-token"
 
     with caplog.at_level(logging.DEBUG, logger="annif"):
-        annif.hfh_util.check_is_download_allowed(trust_repo, repo_id, token)
+        annif.hfh_util.check_is_download_allowed(trust_repo, repo_id)
     assert (
         'Download allowed from "dummy-repo" because repo is already in cache.'
         in caplog.text
@@ -48,10 +46,9 @@ def test_download_allowed_repo_in_cache(mock_is_repo_in_cache, caplog):
 def test_download_not_allowed(mock_is_repo_in_cache):
     trust_repo = False
     repo_id = "dummy-repo"
-    token = "dummy-token"
 
     with pytest.raises(OperationFailedException) as excinfo:
-        annif.hfh_util.check_is_download_allowed(trust_repo, repo_id, token)
+        annif.hfh_util.check_is_download_allowed(trust_repo, repo_id)
     assert (
         str(excinfo.value)
         == 'Cannot download projects from untrusted repo "dummy-repo"'

--- a/tests/test_hfh_util.py
+++ b/tests/test_hfh_util.py
@@ -1,16 +1,61 @@
 """Unit test module for Hugging Face Hub utilities."""
 
 import io
+import logging
 import os.path
 import zipfile
 from datetime import datetime, timezone
 from unittest import mock
 
 import huggingface_hub
+import pytest
 from huggingface_hub.utils import EntryNotFoundError
 
 import annif.hfh_util
 from annif.config import AnnifConfigCFG
+from annif.exception import OperationFailedException
+
+
+@mock.patch("annif.hfh_util._is_repo_in_cache", return_value=False)
+def test_download_allowed_trust_repo(mock_is_repo_in_cache, caplog):
+    trust_repo = True
+    repo_id = "dummy-repo"
+    token = "dummy-token"
+
+    with caplog.at_level(logging.WARNING, logger="annif"):
+        annif.hfh_util.check_is_download_allowed(trust_repo, repo_id, token)
+    assert (
+        'Download allowed from "dummy-repo" because "--trust-repo" flag is used.'
+        in caplog.text
+    )
+
+
+@mock.patch("annif.hfh_util._is_repo_in_cache", return_value=True)
+def test_download_allowed_repo_in_cache(mock_is_repo_in_cache, caplog):
+    trust_repo = False
+    repo_id = "dummy-repo"
+    token = "dummy-token"
+
+    with caplog.at_level(logging.DEBUG, logger="annif"):
+        annif.hfh_util.check_is_download_allowed(trust_repo, repo_id, token)
+    assert (
+        'Download allowed from "dummy-repo" because repo is already in cache.'
+        in caplog.text
+    )
+
+
+@mock.patch("annif.hfh_util._is_repo_in_cache", return_value=False)
+def test_download_not_allowed(mock_is_repo_in_cache):
+    trust_repo = False
+    repo_id = "dummy-repo"
+    token = "dummy-token"
+
+    with pytest.raises(OperationFailedException) as excinfo:
+        annif.hfh_util.check_is_download_allowed(trust_repo, repo_id, token)
+    assert (
+        str(excinfo.value)
+        == 'Cannot download projects from untrusted repo "dummy-repo"'
+    )
 
 
 def test_archive_dir(testdatadir):

--- a/tests/test_hfh_util.py
+++ b/tests/test_hfh_util.py
@@ -43,7 +43,8 @@ def test_download_allowed_repo_in_cache(mock_is_repo_in_cache, caplog):
 
 
 @mock.patch("huggingface_hub.utils._cache_manager.HFCacheInfo")
-def test_download_not_allowed(mock_HFCacheInfo):
+@mock.patch("huggingface_hub.scan_cache_dir")  # Bypass CacheNotFound on CI/CD
+def test_download_not_allowed(mock_scan_cache_dir, mock_HFCacheInfo):
     trust_repo = False
     repo_id = "dummy-repo"
     mock_HFCacheInfo.return_value.repos = frozenset()

--- a/tests/test_hfh_util.py
+++ b/tests/test_hfh_util.py
@@ -42,10 +42,11 @@ def test_download_allowed_repo_in_cache(mock_is_repo_in_cache, caplog):
     )
 
 
-@mock.patch("annif.hfh_util._is_repo_in_cache", return_value=False)
-def test_download_not_allowed(mock_is_repo_in_cache):
+@mock.patch("huggingface_hub.utils._cache_manager.HFCacheInfo")
+def test_download_not_allowed(mock_HFCacheInfo):
     trust_repo = False
     repo_id = "dummy-repo"
+    mock_HFCacheInfo.return_value.repos = frozenset()
 
     with pytest.raises(OperationFailedException) as excinfo:
         annif.hfh_util.check_is_download_allowed(trust_repo, repo_id)


### PR DESCRIPTION
Downloading projects from Hugging Face Hub should be done from trusted sources only. 

After this PR, if the repository hasn’t been used for downloads previously (i.e., it doesn’t appear in the Hugging Face Hub cache on local system), the `--trust-repo` option needs to be used.