### PR TITLE
Make fields variable width in the projects list of Hugging Face Hub Model Card

### DIFF
--- a/annif/hfh_util.py
+++ b/annif/hfh_util.py
@@ -17,6 +17,7 @@ import click
 from flask import current_app
 
 import annif
+from annif import cli_util
 from annif.config import AnnifConfigCFG
 from annif.exception import OperationFailedException
 from annif.project import Access, AnnifProject
@@ -347,18 +348,27 @@ def _update_projects_section(text, configs):
 
 
 def _create_projects_section(configs):
-    content = f"{AUTOUPDATING_START}\n## Projects\n"
-
-    template = "{0:<19} {1:<23} {2:<15} {3:<8}\n"
-    header = template.format("Project ID", "Project Name", "Vocabulary ID", "Language")
-    content += "```\n" + header + "-" * len(header.strip()) + "\n"
-
-    for proj_id in configs.project_ids:
-        project = configs[proj_id]
-        content += template.format(
+    column_headings = (
+        "Project ID",
+        "Project Name",
+        "Vocabulary ID",
+        "Language",
+    )
+    table = [
+        (
             proj_id,
-            project["name"],
-            project["vocab"],
-            project["language"],
+            configs[proj_id]["name"],
+            configs[proj_id]["vocab"],
+            configs[proj_id]["language"],
         )
+        for proj_id in configs.project_ids
+    ]
+    template = cli_util.make_list_template(column_headings, *table) + "\n"
+
+    header = template.format(*column_headings)
+
+    content = f"{AUTOUPDATING_START}\n## Projects\n"
+    content += "```\n" + header + "-" * len(header.strip()) + "\n"
+    for row in table:
+        content += template.format(*row)
     return content + "```\n" + AUTOUPDATING_END

--- a/tests/test_hfh_util.py
+++ b/tests/test_hfh_util.py
@@ -204,9 +204,8 @@ def test_upsert_modelcard_update_existing(read_text, glob, load, push_to_hub, pr
     load.assert_called_once_with(repo_id)
 
     card = load.return_value
-    retained_project_list_content = (
-        "dummy-en            Dummy English           dummy           en"
-    )
+    retained_project_list_content = "dummy-en    Dummy English  dummy          en      "
+
     assert retained_project_list_content in card.text
     assert sorted(card.data.language) == ["en", "fi"]
     card.push_to_hub.assert_called_once_with(
@@ -227,8 +226,8 @@ def test_update_modelcard_projects_section_append_new():
 <!--- start-of-autoupdating-part --->
 ## Projects
 ```
-Project ID          Project Name            Vocabulary ID   Language
---------------------------------------------------------------------
+Project ID  Project Name  Vocabulary ID  Language
+-------------------------------------------------
 ```
 <!--- end-of-autoupdating-part --->"""
 
@@ -250,8 +249,8 @@ def test_update_modelcard_projects_section_update_existing():
 <!--- start-of-autoupdating-part --->
 ## Projects
 ```
-Project ID          Project Name            Vocabulary ID   Language
---------------------------------------------------------------------
+Project ID  Project Name  Vocabulary ID  Language
+-------------------------------------------------
 ```
 <!--- end-of-autoupdating-part --->\n"""
 
@@ -266,9 +265,9 @@ Project ID          Project Name            Vocabulary ID   Language
 <!--- start-of-autoupdating-part --->
 ## Projects
 ```
-Project ID          Project Name            Vocabulary ID   Language
---------------------------------------------------------------------
-dummy-fi            Dummy Finnish           dummy           fi      \n```
+Project ID  Project Name   Vocabulary ID  Language
+--------------------------------------------------
+dummy-fi    Dummy Finnish  dummy          fi      \n```
 <!--- end-of-autoupdating-part --->
 """
 


### PR DESCRIPTION
The project IDs and names can be of varying widths, so the fields should also be variable. The functionality is similar to the `annif list-projects` output formatting, implemented in #694. 