### PR TITLE
Smarter initialization of optional analyzers

### DIFF
--- a/annif/analyzer/__init__.py
+++ b/annif/analyzer/__init__.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING
 import annif
 from annif.util import parse_args
 
-from . import simple, simplemma, snowball
+from . import simple, simplemma, snowball, spacy, voikko
 
 if TYPE_CHECKING:
     from annif.analyzer.analyzer import Analyzer
@@ -17,7 +17,10 @@ _analyzers = {}
 
 
 def register_analyzer(analyzer):
-    _analyzers[analyzer.name] = analyzer
+    if analyzer.is_available():
+        _analyzers[analyzer.name] = analyzer
+    else:
+        annif.logger.debug(f"{analyzer.name} analyzer not available, not enabling it")
 
 
 def get_analyzer(analyzerspec: str) -> Analyzer:
@@ -37,18 +40,5 @@ def get_analyzer(analyzerspec: str) -> Analyzer:
 register_analyzer(simple.SimpleAnalyzer)
 register_analyzer(snowball.SnowballAnalyzer)
 register_analyzer(simplemma.SimplemmaAnalyzer)
-
-# Optional analyzers
-try:
-    from . import voikko
-
-    register_analyzer(voikko.VoikkoAnalyzer)
-except ImportError:
-    annif.logger.debug("voikko not available, not enabling voikko analyzer")
-
-try:
-    from . import spacy
-
-    register_analyzer(spacy.SpacyAnalyzer)
-except ImportError:
-    annif.logger.debug("spaCy not available, not enabling spacy analyzer")
+register_analyzer(voikko.VoikkoAnalyzer)
+register_analyzer(spacy.SpacyAnalyzer)

--- a/annif/analyzer/analyzer.py
+++ b/annif/analyzer/analyzer.py
@@ -22,6 +22,11 @@ class Analyzer(metaclass=abc.ABCMeta):
     name = None
     token_min_length = 3  # default value, can be overridden in instances
 
+    @staticmethod
+    def is_available() -> bool:
+        """Return True if the analyzer is available for use, False if not."""
+        return True  # can be overridden in implementations if necessary
+
     def __init__(self, **kwargs) -> None:
         if _KEY_TOKEN_MIN_LENGTH in kwargs:
             self.token_min_length = int(kwargs[_KEY_TOKEN_MIN_LENGTH])

--- a/annif/analyzer/spacy.py
+++ b/annif/analyzer/spacy.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import importlib
+
 import annif.util
 from annif.exception import OperationFailedException
 
@@ -12,6 +14,11 @@ _KEY_LOWERCASE = "lowercase"
 
 class SpacyAnalyzer(analyzer.Analyzer):
     name = "spacy"
+
+    @staticmethod
+    def is_available() -> bool:
+        # return True iff spaCy is installed
+        return importlib.util.find_spec("spacy") is not None
 
     def __init__(self, param: str, **kwargs) -> None:
         import spacy

--- a/annif/analyzer/voikko.py
+++ b/annif/analyzer/voikko.py
@@ -3,14 +3,18 @@
 from __future__ import annotations
 
 import functools
-
-import voikko.libvoikko
+import importlib
 
 from . import analyzer
 
 
 class VoikkoAnalyzer(analyzer.Analyzer):
     name = "voikko"
+
+    @staticmethod
+    def is_available() -> bool:
+        # return True iff Voikko is installed
+        return importlib.util.find_spec("voikko") is not None
 
     def __init__(self, param: str, **kwargs) -> None:
         self.param = param
@@ -26,6 +30,8 @@ class VoikkoAnalyzer(analyzer.Analyzer):
 
     @functools.lru_cache(maxsize=500000)
     def _normalize_word(self, word: str) -> str:
+        import voikko.libvoikko
+
         if self.voikko is None:
             self.voikko = voikko.libvoikko.Voikko(self.param)
         result = self.voikko.analyze(word)

--- a/tests/test_analyzer_spacy.py
+++ b/tests/test_analyzer_spacy.py
@@ -3,9 +3,12 @@
 import pytest
 
 import annif.analyzer
+import annif.analyzer.spacy
 from annif.exception import OperationFailedException
 
-spacy = pytest.importorskip("spacy")
+pytestmark = pytest.mark.skipif(
+    not annif.analyzer.spacy.SpacyAnalyzer.is_available(), reason="spaCy is required"
+)
 
 
 def test_spacy_model_not_found():

--- a/tests/test_analyzer_voikko.py
+++ b/tests/test_analyzer_voikko.py
@@ -3,8 +3,11 @@
 import pytest
 
 import annif.analyzer
+import annif.analyzer.voikko
 
-voikko = pytest.importorskip("annif.analyzer.voikko")
+pytestmark = pytest.mark.skipif(
+    not annif.analyzer.voikko.VoikkoAnalyzer.is_available(), reason="voikko is required"
+)
 
 
 def test_voikko_getstate():


### PR DESCRIPTION
This PR fixes a problem with the initialization of optional analyzers that I noticed while working on the EstNLTK analyzer in PR #818 . For the spaCy analyzer, the code in `analyzer/__init__.py` never noticed the case when spaCy is not installed, because the `import spacy` statement only happens inside a method (due to performance reasons).

This PR adds a new static method `is_available` to all Analyzer implementations and uses that to determine whether the analyzer is available (i.e. the optional dependency is installed) or not. For spaCy and Voikko analyzers, the method is implemented by using importlib.find_spec to see if the necessary modules are available or not. This should be faster than actually importing the module, which can be done at a later time within the methods if it's actually needed. 