### PR TITLE
Resolve 413 errors by setting Flask's `MAX_FORM_MEMORY_SIZE` limit to 20 MB

### DIFF
--- a/annif/default_config.py
+++ b/annif/default_config.py
@@ -14,6 +14,7 @@ class Config(object):
     PROJECTS_CONFIG_PATH = os.environ.get("ANNIF_PROJECTS", default="")
     DATADIR = os.environ.get("ANNIF_DATADIR", default="data")
     INITIALIZE_PROJECTS = False
+    MAX_FORM_MEMORY_SIZE = None  # Disable Flask's limit
 
 
 class ProductionConfig(Config):

--- a/annif/default_config.py
+++ b/annif/default_config.py
@@ -14,7 +14,7 @@ class Config(object):
     PROJECTS_CONFIG_PATH = os.environ.get("ANNIF_PROJECTS", default="")
     DATADIR = os.environ.get("ANNIF_DATADIR", default="data")
     INITIALIZE_PROJECTS = False
-    MAX_FORM_MEMORY_SIZE = None  # Disable Flask's limit
+    MAX_FORM_MEMORY_SIZE = 20_000_000  # Increase from Flask's default limit
 
 
 class ProductionConfig(Config):


### PR DESCRIPTION
When evaluating the new, to-be-published YSO projects, the requests whose body exceeded 500 KB resulted to `413 Client Error: Request Entity Too Large for url` error, which did not happen on the previous projects update round on May.

The cause was the limit introduced in [Werkzeug 3.1.0](https://github.com/pallets/werkzeug/releases/tag/3.1.0) (https://github.com/pallets/werkzeug/pull/2965):
>  - Request.max_form_memory_size defaults to 500kB instead of unlimited. Non-file form fields over this size will cause a RequestEntityTooLarge error. [#2964](https://github.com/pallets/werkzeug/issues/2964)

In [Flask 3.1](https://github.com/pallets/flask/releases/tag/3.1.0) there is a new config setting [`MAX_FORM_MEMORY_SIZE`](https://flask.palletsprojects.com/en/stable/config/#MAX_FORM_MEMORY_SIZE) to set a value for this limit.

This PR uses the setting to ~disable the limit altogether~ increase the value from the default (500 KB) to 20 MB.

In any case, on production Annif should be run behind e.g. NGINX, which can be used to set request size limits more tightly.
