### PR TITLE
Fix Docker image builds by using non-package mode for initial dependencies installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,7 @@ RUN apt-get update && apt-get upgrade -y && \
 	rm -rf /var/lib/apt/lists/* /usr/include/*
 
 WORKDIR /Annif
-RUN pip install --upgrade pip poetry --no-cache-dir && \
-	pip install poetry
+RUN pip install --upgrade pip "poetry~=1.8" --no-cache-dir
 
 COPY pyproject.toml setup.cfg README.md LICENSE.txt CITATION.cff projects.cfg.dist /Annif/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,13 +17,13 @@ RUN apt-get update && apt-get upgrade -y && \
 	rm -rf /var/lib/apt/lists/* /usr/include/*
 
 WORKDIR /Annif
-RUN pip install --upgrade pip "poetry~=1.8" --no-cache-dir
+RUN pip install --upgrade pip "poetry~=2.0" --no-cache-dir
 
 COPY pyproject.toml setup.cfg README.md LICENSE.txt CITATION.cff projects.cfg.dist /Annif/
 
 # First round of installation for Docker layer caching:
 RUN echo "Installing dependencies for optional features: $optional_dependencies" \
-	&& poetry install -E "$optional_dependencies" \
+	&& poetry install -E "$optional_dependencies" --no-root \
 	&& rm -rf /root/.cache/pypoetry  # No need for cache because of poetry.lock
 
 # Download nltk data


### PR DESCRIPTION
[Poetry 2.0](https://github.com/python-poetry/poetry/releases/tag/2.0.0) was released 2 weeks ago, and Annif installation with it in Docker image builds fail, see e.g. [this CICD run](https://github.com/NatLibFi/Annif/actions/runs/12829526553/job/35775761546) . 

The error message is just `failed to solve: ...` when installing optional dependencies, but in [this comment](https://github.com/python-poetry/poetry/issues/10030#issuecomment-2591257057) it is stated that with Poetry 2.0 all the source code is needed to exist when running `poetry install`, not just `pyproject.toml` etc. files.

~How about just pinning Poetry to version \~=1.8 in Dockerfile for now? (Poetry has already been [pinned in CICD pipeline](https://github.com/NatLibFi/Annif/blob/8f13d7db9717007411981806ec95313a2c4bd689/.github/workflows/cicd.yml#L13).)~

Edit: There is [`--no-root` option](https://python-poetry.org/docs/basic-usage/#installing-dependencies-only) to `poetry install` for installing only dependencies from `pyproject.toml`, and when using it the source is not needed as with Poetry v1. So, lets us it, but also pin Poetry to ~=2.0. 