### PR TITLE
Upgrade to EstNLTK 1.7.4; simplify license section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,19 +228,14 @@ the dependencies included under `annif/static/css` and `annif/static/js`,
 which have their own licenses; see the file headers for details.
 
 Please note that the [YAKE](https://github.com/LIAAD/yake) library is
-licensed under [GPLv3](https://www.gnu.org/licenses/gpl-3.0.txt) and the
-[EstNLTK-core](https://github.com/estnltk/estnltk/tree/main/estnltk_core)
-library is licensed under
-[GPLv2](https://www.gnu.org/licenses/old-licenses/gpl-2.0.html), while Annif
-itself is licensed under the Apache License 2.0. It is commonly accepted
-that the GPLv3 and Apache 2.0 licenses are compatible at least in one
-direction (GPLv3 is more restrictive than the Apache License), while the
-compatibility between GPLv2 and Apache 2.0 licenses is a more difficult
-question with arguments made both for and against license compatibility;
-obviously it also depends on the legal environment. The Annif developers
-make no legal claims; we simply provide the software and allow the user to
-install these optional extensions if they consider it appropriate. Depending
-on legal interpretation, the terms of the GPL (for example the requirement
-to publish corresponding source code when publishing an executable
-application) may be considered to apply to the whole of Annif+extensions if
-you decide to install the optional Yake and/or EstNLTK dependencies.
+licensed under [GPLv3](https://www.gnu.org/licenses/gpl-3.0.txt), while
+Annif itself is licensed under the Apache License 2.0. It is commonly
+accepted that the GPLv3 and Apache 2.0 licenses are compatible at least in
+one direction (GPLv3 is more restrictive than the Apache License); obviously
+it also depends on the legal environment. The Annif developers make no legal
+claims - we simply provide the software and allow the user to install
+optional extensions if they consider it appropriate. Depending on legal
+interpretation, the terms of the GPL (for example the requirement to publish
+corresponding source code when publishing an executable application) may be
+considered to apply to the whole of Annif+extensions if you decide to
+install the optional YAKE dependency.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ huggingface-hub = "~0.25.1"
 
 fasttext-wheel = { version = "0.9.2", optional = true }
 voikko = { version = "0.5.*", optional = true }
-estnltk = { version = "1.7.3", optional = true }
+estnltk = { version = "1.7.4", optional = true }
 tensorflow-cpu = { version = "~2.17.0", optional = true }
 lmdb = { version = "~1.5.1", optional = true }
 omikuji = { version = "0.5.*", optional = true }


### PR DESCRIPTION
This PR upgrades the optional EstNLTK dependency from version 1.7.3 to 1.7.4. 

The functionality relevant for Annif is unaffected, but the new EstNLTK release is [now dual-licensed](https://github.com/estnltk/estnltk/issues/123#issuecomment-2612637697) (GPLv2 + Apache 2.0), which simplifies the legal situation. Thus, the License section in the top level README can be shortened, as it doesn't have to consider GPLv2 compatibility.