### PR TITLE
Make sure permissions of saved files adhere to umask setting

### DIFF
--- a/annif/backend/nn_ensemble.py
+++ b/annif/backend/nn_ensemble.py
@@ -272,7 +272,7 @@ class NNEnsembleBackend(backend.AnnifLearningBackend, ensemble.BaseEnsembleBacke
         lmdb_path = os.path.join(self.datadir, self.LMDB_FILE)
         if not cached and os.path.exists(lmdb_path):
             shutil.rmtree(lmdb_path)
-        return lmdb.open(lmdb_path, map_size=lmdb_map_size, writemap=True)
+        return lmdb.open(lmdb_path, map_size=lmdb_map_size, writemap=True, mode=0o775)
 
     def _fit_model(
         self,

--- a/annif/util.py
+++ b/annif/util.py
@@ -48,7 +48,7 @@ def atomic_save(
         newname = fn.replace(tempfilename, os.path.join(dirname, filename))
         logger.debug("renaming temporary file %s to %s", fn, newname)
         os.rename(fn, newname)
-        umask = os.umask(0o666)
+        umask = os.umask(0o777)
         os.umask(umask)
         os.chmod(newname, 0o666 & ~umask)
 

--- a/annif/util.py
+++ b/annif/util.py
@@ -48,6 +48,9 @@ def atomic_save(
         newname = fn.replace(tempfilename, os.path.join(dirname, filename))
         logger.debug("renaming temporary file %s to %s", fn, newname)
         os.rename(fn, newname)
+        umask = os.umask(0o666)
+        os.umask(umask)
+        os.chmod(newname, 0o666 & ~umask)
 
 
 def cleanup_uri(uri: str) -> str:

--- a/tests/test_backend_nn_ensemble.py
+++ b/tests/test_backend_nn_ensemble.py
@@ -114,10 +114,8 @@ def test_nn_ensemble_train_and_learn(registry, tmpdir):
         # verify LMDB database creation and expected permissions when using umask 0007
         assert datadir.join("nn-train.mdb").exists()
         assert datadir.join("nn-train.mdb").stat().mode & 0o777 == 0o770
-        assert datadir.join("nn-train.mdb").join("data.mdb").exists()
-        assert (
-            datadir.join("nn-train.mdb").join("data.mdb").stat().mode & 0o777 == 0o660
-        )
+        assert datadir.join("nn-train.mdb/data.mdb").exists()
+        assert datadir.join("nn-train.mdb/data.mdb").stat().mode & 0o777 == 0o660
 
     # check adam default learning_rate:
     assert nn_ensemble._model.optimizer.learning_rate.value == 0.001

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,6 +1,50 @@
 """Unit tests for Annif utility functions"""
 
+import os
+from contextlib import contextmanager
+
+import pytest
+
 import annif.util
+
+
+@contextmanager
+def umask_context(mask):
+    """Context manager to temporarily set umask"""
+    original_umask = os.umask(0)  # Get current umask
+    os.umask(mask)  # Set new umask
+    try:
+        yield
+    finally:
+        os.umask(original_umask)  # Restore original umask
+
+
+class MockSaveable:
+    def save(self, filename):
+        with open(filename, "w") as f:
+            f.write("data")
+
+
+# parametrize to verify that file permissions are set correctly using commonly used umask values
+@pytest.mark.parametrize(
+    "umask,mode", [(0o002, 0o664), (0o022, 0o644), (0o027, 0o640), (0o077, 0o600)]
+)
+def test_atomic_save(tmpdir, umask, mode):
+    obj = MockSaveable()
+    dirname = str(tmpdir)
+    filename = "myfile"
+
+    with umask_context(umask):
+        annif.util.atomic_save(obj, dirname, filename)
+
+    final_path = tmpdir.join(filename)
+    assert final_path.exists()
+
+    # verify file content
+    assert final_path.read_text(encoding="utf-8") == "data"
+
+    # verify file permissions
+    assert final_path.stat().mode & 0o777 == mode
 
 
 def test_boolean():

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -11,7 +11,7 @@ import annif.util
 @contextmanager
 def umask_context(mask):
     """Context manager to temporarily set umask"""
-    original_umask = os.umask(0)  # Get current umask
+    original_umask = os.umask(0o777)  # Get current umask
     os.umask(mask)  # Set new umask
     try:
         yield

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,22 +1,10 @@
 """Unit tests for Annif utility functions"""
 
-import os
-from contextlib import contextmanager
-
 import pytest
 
 import annif.util
 
-
-@contextmanager
-def umask_context(mask):
-    """Context manager to temporarily set umask"""
-    original_umask = os.umask(0o777)  # Get current umask
-    os.umask(mask)  # Set new umask
-    try:
-        yield
-    finally:
-        os.umask(original_umask)  # Restore original umask
+from .util import umask_context
 
 
 class MockSaveable:

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -25,7 +25,8 @@ class MockSaveable:
             f.write("data")
 
 
-# parametrize to verify that file permissions are set correctly using commonly used umask values
+# parametrize test to verify that file permissions are set correctly
+# using commonly used umask values
 @pytest.mark.parametrize(
     "umask,mode", [(0o002, 0o664), (0o022, 0o644), (0o027, 0o640), (0o077, 0o600)]
 )

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,0 +1,15 @@
+"""utility functions used by unit tests"""
+
+import os
+from contextlib import contextmanager
+
+
+@contextmanager
+def umask_context(mask):
+    """Context manager to temporarily set umask"""
+    original_umask = os.umask(0o777)  # Get current umask
+    os.umask(mask)  # Set new umask
+    try:
+        yield
+    finally:
+        os.umask(original_umask)  # Restore original umask


### PR DESCRIPTION
Fixes #829 

Many types of files saved by Annif using the `atomic_save()` operation had tighter permissions than expected. This is because they were first saved as temporary files, then renamed.

This PR makes sure that the file permissions respect the umask setting. The unit test verifies that this works using different commonly used umask values.