### PR TITLE
Ensure compatibility with MLLM models trained using Annif 1.2 or older

### DIFF
--- a/annif/lexical/tokenset.py
+++ b/annif/lexical/tokenset.py
@@ -41,6 +41,13 @@ class TokenSet:
 
         return other._tokens.issubset(self._tokens)
 
+    def __setstate__(self, state):
+        # Convert _tokens to a frozenset if it's a set.
+        # Might happen when using models saved using Annif 1.2 or older.
+        self.__dict__ = state
+        if isinstance(self._tokens, set):
+            self._tokens = frozenset(self._tokens)
+
 
 class TokenSetIndex:
     """A searchable index of TokenSets (representing vocabulary terms)"""

--- a/annif/lexical/tokenset.py
+++ b/annif/lexical/tokenset.py
@@ -46,7 +46,7 @@ class TokenSet:
         # Might happen when using models saved using Annif 1.2 or older.
         self.__dict__ = state
         if isinstance(self._tokens, set):
-            self._tokens = frozenset(self._tokens)
+            self._tokens = frozenset(self._tokens)  # pragma: no cover
 
 
 class TokenSetIndex:


### PR DESCRIPTION
This adds a check to ensure that MLLM TokenSet objects use frozenset to store tokens. In models prior to Annif 1.3, the tokens were stored in a mutable set. The `__setstate__` method is called during unpickling and handles the conversion so that older models will still work.

We could drop this later on if compatibility with older models is no longer relevant, for example if there is another reason that they will stop working anyway.

- Related to #822 
- Post fix to #825