### PR TITLE
Fix Swagger UI 500 error `Failed to load API definition.`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 [tool.poetry.dependencies]
 python = ">=3.9,<3.13"
 
-connexion = { version = "~3.2.0", extras = ["flask", "uvicorn", "swagger-ui"] }
+connexion = { version = "~3.1.0", extras = ["flask", "uvicorn", "swagger-ui"] }
 click = "8.1.*"
 click-log = "0.4.*"
 joblib = "1.4.*"


### PR DESCRIPTION
There is a [bug in Connexion 3.2.0](https://github.com/spec-first/connexion/issues/2029) affecting Swagger UI: Just after Annif startup its Swagger UI (`/v1/ui`) works, but if any other(?) API request has been made, a 500 error is thrown when trying to access it.

A workaround for now is to downgrade to Connexion ~3.1.0.