### PR TITLE
Add vocabulary information to REST API

### DIFF
--- a/annif/openapi/annif.yaml
+++ b/annif/openapi/annif.yaml
@@ -18,6 +18,19 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiInfo'
+  /vocabs:
+    get:
+      tags:
+      - Vocabulary information
+      summary: get a list of vocabularies
+      operationId: annif.rest.list_vocabs
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VocabularyList'
   /projects:
     get:
       tags:
@@ -249,6 +262,35 @@ components:
           type: string
           example: my-backend
       description: A backend of a project
+    Vocabulary:
+      required:
+      - vocab_id
+      type: object
+      properties:
+        vocab_id:
+          type: string
+          example: yso
+        languages:
+          type: array
+          items:
+            type: string
+            example: en
+        size:
+          type: integer
+          example: 1000
+          nullable: true
+        loaded:
+          type: boolean
+          example: true
+      description: A subject vocabulary
+    VocabularyList:
+      type: object
+      properties:
+        vocabs:
+          type: array
+          items:
+            $ref: '#/components/schemas/Vocabulary'
+      description: A list of subject vocabularies
     Project:
       required:
       - backend
@@ -268,6 +310,13 @@ components:
           example: en
         backend:
           $ref: '#/components/schemas/ProjectBackend'
+        vocab:
+          $ref: '#/components/schemas/Vocabulary'
+          nullable: true
+        vocab_language:
+          type: string
+          example: en
+          nullable: true
         is_trained:
           type: boolean
           example: true

--- a/annif/project.py
+++ b/annif/project.py
@@ -305,11 +305,24 @@ class AnnifProject(DatadirMixin):
 
     def dump(self) -> dict[str, str | dict | bool | datetime | None]:
         """return this project as a dict"""
+
+        try:
+            vocab = {
+                "vocab_id": self.vocab.vocab_id,
+                "languages": sorted(self.vocab.languages),
+            }
+            vocab_lang = self.vocab_lang
+        except ConfigurationException:
+            vocab = None
+            vocab_lang = None
+
         return {
             "project_id": self.project_id,
             "name": self.name,
             "language": self.language,
             "backend": {"backend_id": self.config.get("backend")},
+            "vocab": vocab,
+            "vocab_language": vocab_lang,
             "is_trained": self.is_trained,
             "modification_time": self.modification_time,
         }

--- a/annif/rest.py
+++ b/annif/rest.py
@@ -59,6 +59,18 @@ def language_not_supported_error(lang: str) -> ConnexionResponse:
     )
 
 
+def list_vocabs() -> tuple:
+    """return a dict with vocabulariess formatted according to OpenAPI spec"""
+
+    result = {
+        "vocabs": [
+            vocab.dump()
+            for vocab in annif.registry.get_vocabs(min_access=Access.public).values()
+        ]
+    }
+    return result, 200, {"Content-Type": "application/json"}
+
+
 def list_projects() -> tuple:
     """return a dict with projects formatted according to OpenAPI spec"""
 

--- a/annif/rest.py
+++ b/annif/rest.py
@@ -60,7 +60,7 @@ def language_not_supported_error(lang: str) -> ConnexionResponse:
 
 
 def list_vocabs() -> tuple:
-    """return a dict with vocabulariess formatted according to OpenAPI spec"""
+    """return a dict with vocabularies formatted according to OpenAPI spec"""
 
     result = {
         "vocabs": [

--- a/annif/vocab.py
+++ b/annif/vocab.py
@@ -109,7 +109,10 @@ class AnnifVocabulary(DatadirMixin):
 
     @property
     def languages(self) -> list[str]:
-        return self.subjects.languages
+        try:
+            return self.subjects.languages
+        except NotInitializedException:
+            return []
 
     def load_vocabulary(
         self,
@@ -136,3 +139,22 @@ class AnnifVocabulary(DatadirMixin):
     def as_graph(self) -> Graph:
         """return the vocabulary as an rdflib graph"""
         return self.skos.graph
+
+    def dump(self) -> dict[str, str | list | int | bool]:
+        """return this vocabulary as a dict"""
+
+        try:
+            languages = list(sorted(self.languages))
+            size = len(self)
+            loaded = True
+        except NotInitializedException:
+            languages = []
+            size = None
+            loaded = False
+
+        return {
+            "vocab_id": self.vocab_id,
+            "languages": languages,
+            "size": size,
+            "loaded": loaded,
+        }

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -75,6 +75,11 @@ def test_get_project_fi_dump(registry):
         "backend": {
             "backend_id": "dummy",
         },
+        "vocab": {
+            "vocab_id": "dummy",
+            "languages": ["en", "fi"],
+        },
+        "vocab_language": "fi",
         "is_trained": True,
         "modification_time": None,
     }


### PR DESCRIPTION
This PR adds information about vocabularies to the REST API, making it on par with the CLI for these aspects.

It implements the first three ideas from #837:

> - /projects/{projectId} could expose the vocabulary ID of a single project
> - /projects/ could expose the vocabulary IDs of all returned projects
> - there could be a /vocabs/ method that lists all vocabs along with basic information (similar to annif list-vocabs)

In addition to vocabulary ID, also the supported languages of the vocabulary and the current vocabulary language are exposed in the /projects and /projects/{projectId} methods. These could be useful for performing subsequent suggest calls, because they affect what languages can be requested for subject terms.

The /vocabs method returns all information about the vocabularies, including vocabulary size and loaded status.

The reasons for implementing this:

- parity between the CLI and the REST API
- Finto AI, with the recent https://github.com/NatLibFi/FintoAI/pull/21, would benefit from knowing the vocabulary ID of a project - now it has to guess it from the project ID

Fixes #837