### PR TITLE
Support exclude/include rules for vocabulary concepts

### DIFF
--- a/annif/default_config.py
+++ b/annif/default_config.py
@@ -43,6 +43,10 @@ class TestingInvalidProjectsConfig(TestingConfig):
     PROJECTS_CONFIG_PATH = "tests/projects_invalid.cfg"
 
 
+class TestingInvalid2ProjectsConfig(TestingConfig):
+    PROJECTS_CONFIG_PATH = "tests/projects_invalid2.cfg"
+
+
 class TestingTOMLConfig(TestingConfig):
     PROJECTS_CONFIG_PATH = "tests/projects.toml"
 

--- a/annif/project.py
+++ b/annif/project.py
@@ -218,9 +218,7 @@ class AnnifProject(DatadirMixin):
     def subjects(self) -> SubjectIndex:
         if self._subject_index is None:
             self._subject_index = self.vocab.subjects
-            exclude_uris = kwargs_to_exclude_uris(
-                self.vocab.as_graph(), self._vocab_kwargs
-            )
+            exclude_uris = kwargs_to_exclude_uris(self.vocab, self._vocab_kwargs)
             if exclude_uris:
                 self._subject_index = SubjectIndexFilter(
                     self._subject_index, exclude=exclude_uris

--- a/annif/project.py
+++ b/annif/project.py
@@ -21,7 +21,7 @@ from annif.exception import (
     NotSupportedException,
 )
 from annif.util import parse_args
-from annif.vocab import SubjectIndexFilter
+from annif.vocab import SubjectIndexFilter, kwargs_to_exclude_uris
 
 if TYPE_CHECKING:
     from collections import defaultdict
@@ -218,10 +218,10 @@ class AnnifProject(DatadirMixin):
     def subjects(self) -> SubjectIndex:
         if self._subject_index is None:
             self._subject_index = self.vocab.subjects
-            if "exclude" in self._vocab_kwargs:
-                exclude_list = self._vocab_kwargs["exclude"].split("|")
+            exclude_uris = kwargs_to_exclude_uris(self._vocab_kwargs)
+            if exclude_uris:
                 self._subject_index = SubjectIndexFilter(
-                    self._subject_index, exclude=exclude_list
+                    self._subject_index, exclude=exclude_uris
                 )
         return self._subject_index
 

--- a/annif/project.py
+++ b/annif/project.py
@@ -218,7 +218,9 @@ class AnnifProject(DatadirMixin):
     def subjects(self) -> SubjectIndex:
         if self._subject_index is None:
             self._subject_index = self.vocab.subjects
-            exclude_uris = kwargs_to_exclude_uris(self._vocab_kwargs)
+            exclude_uris = kwargs_to_exclude_uris(
+                self.vocab.as_graph(), self._vocab_kwargs
+            )
             if exclude_uris:
                 self._subject_index = SubjectIndexFilter(
                     self._subject_index, exclude=exclude_uris

--- a/annif/vocab/__init__.py
+++ b/annif/vocab/__init__.py
@@ -1,5 +1,6 @@
 """Annif vocabulary functionality"""
 
+from .rules import kwargs_to_exclude_uris
 from .skos import VocabFileSKOS
 from .subject_file import VocabFileCSV, VocabFileTSV
 from .subject_index import SubjectIndexFile, SubjectIndexFilter
@@ -8,6 +9,7 @@ from .vocab import AnnifVocabulary
 
 __all__ = [
     "AnnifVocabulary",
+    "kwargs_to_exclude_uris",
     "Subject",
     "SubjectIndex",
     "SubjectIndexFile",

--- a/annif/vocab/rules.py
+++ b/annif/vocab/rules.py
@@ -1,0 +1,10 @@
+"""Support for exclude/include rules for subject vocabularies"""
+
+
+def kwargs_to_exclude_uris(kwargs: dict[str, str]) -> set[str]:
+    exclude_uris = set()
+    for key, value in kwargs.items():
+        vals = value.split("|")
+        if key == "exclude":
+            exclude_uris.update(vals)
+    return exclude_uris

--- a/annif/vocab/rules.py
+++ b/annif/vocab/rules.py
@@ -5,6 +5,8 @@ from rdflib.namespace import SKOS
 
 from annif.exception import ConfigurationException
 
+from .vocab import AnnifVocabulary
+
 
 def uris_by_type(graph: Graph, type: str) -> list[str]:
     return [str(uri) for uri in graph.subjects(RDF.type, URIRef(type))]
@@ -33,28 +35,30 @@ def remove_uris(
             uris_set.discard(uri)
 
 
-def kwargs_to_exclude_uris(graph: Graph, kwargs: dict[str, str]) -> set[str]:
+def kwargs_to_exclude_uris(vocab: AnnifVocabulary, kwargs: dict[str, str]) -> set[str]:
     exclude_uris = set()
     actions = {
         "exclude": lambda vals: exclude_uris.update(
-            vals if "*" not in vals else uris_by_type(graph, SKOS.Concept)
+            vals if "*" not in vals else uris_by_type(vocab.as_graph(), SKOS.Concept)
         ),
-        "exclude_type": lambda vals: add_uris(graph, uris_by_type, exclude_uris, vals),
+        "exclude_type": lambda vals: add_uris(
+            vocab.as_graph(), uris_by_type, exclude_uris, vals
+        ),
         "exclude_scheme": lambda vals: add_uris(
-            graph, uris_by_scheme, exclude_uris, vals
+            vocab.as_graph(), uris_by_scheme, exclude_uris, vals
         ),
         "exclude_collection": lambda vals: add_uris(
-            graph, uris_by_collection, exclude_uris, vals
+            vocab.as_graph(), uris_by_collection, exclude_uris, vals
         ),
         "include": lambda vals: exclude_uris.difference_update(vals),
         "include_type": lambda vals: remove_uris(
-            graph, uris_by_type, exclude_uris, vals
+            vocab.as_graph(), uris_by_type, exclude_uris, vals
         ),
         "include_scheme": lambda vals: remove_uris(
-            graph, uris_by_scheme, exclude_uris, vals
+            vocab.as_graph(), uris_by_scheme, exclude_uris, vals
         ),
         "include_collection": lambda vals: remove_uris(
-            graph, uris_by_collection, exclude_uris, vals
+            vocab.as_graph(), uris_by_collection, exclude_uris, vals
         ),
     }
 

--- a/annif/vocab/rules.py
+++ b/annif/vocab/rules.py
@@ -1,5 +1,7 @@
 """Support for exclude/include rules for subject vocabularies"""
 
+from annif.exception import ConfigurationException
+
 
 def kwargs_to_exclude_uris(kwargs: dict[str, str]) -> set[str]:
     exclude_uris = set()
@@ -7,4 +9,6 @@ def kwargs_to_exclude_uris(kwargs: dict[str, str]) -> set[str]:
         vals = value.split("|")
         if key == "exclude":
             exclude_uris.update(vals)
+        else:
+            raise ConfigurationException(f"unknown vocab keyword argument {key}")
     return exclude_uris

--- a/annif/vocab/rules.py
+++ b/annif/vocab/rules.py
@@ -3,35 +3,47 @@
 from rdflib import RDF, Graph, URIRef
 from rdflib.namespace import SKOS
 
+import annif
 from annif.exception import ConfigurationException
 
 from .vocab import AnnifVocabulary
 
-
-def uris_by_type(graph: Graph, type: str) -> list[str]:
-    return [str(uri) for uri in graph.subjects(RDF.type, URIRef(type))]
+logger = annif.logger
 
 
-def uris_by_scheme(graph: Graph, type: str) -> list[str]:
-    return [str(uri) for uri in graph.subjects(SKOS.inScheme, URIRef(type))]
+def uris_by_type(graph: Graph, type: str, action: str) -> list[str]:
+    uris = [str(uri) for uri in graph.subjects(RDF.type, URIRef(type))]
+    if not uris:
+        logger.warning(f"{action}: no concepts found with type {type}")
+    return uris
 
 
-def uris_by_collection(graph: Graph, type: str) -> list[str]:
-    return [str(uri) for uri in graph.objects(URIRef(type), SKOS.member)]
+def uris_by_scheme(graph: Graph, scheme: str, action: str) -> list[str]:
+    uris = [str(uri) for uri in graph.subjects(SKOS.inScheme, URIRef(scheme))]
+    if not uris:
+        logger.warning(f"{action}: no concepts found in scheme {scheme}")
+    return uris
+
+
+def uris_by_collection(graph: Graph, collection: str, action: str) -> list[str]:
+    uris = [str(uri) for uri in graph.objects(URIRef(collection), SKOS.member)]
+    if not uris:
+        logger.warning(f"{action}: no concepts found in collection {collection}")
+    return uris
 
 
 def add_uris(
-    graph: Graph, uris_func: callable, uris_set: set[str], vals: list[str]
+    graph: Graph, uris_func: callable, uris_set: set[str], vals: list[str], action: str
 ) -> None:
     for val in vals:
-        uris_set.update(uris_func(graph, val))
+        uris_set.update(uris_func(graph, val, action))
 
 
 def remove_uris(
-    graph: Graph, uris_func: callable, uris_set: set[str], vals: list[str]
+    graph: Graph, uris_func: callable, uris_set: set[str], vals: list[str], action: str
 ) -> None:
     for val in vals:
-        for uri in uris_func(graph, val):
+        for uri in uris_func(graph, val, action):
             uris_set.discard(uri)
 
 
@@ -39,26 +51,36 @@ def kwargs_to_exclude_uris(vocab: AnnifVocabulary, kwargs: dict[str, str]) -> se
     exclude_uris = set()
     actions = {
         "exclude": lambda vals: exclude_uris.update(
-            vals if "*" not in vals else uris_by_type(vocab.as_graph(), SKOS.Concept)
+            vals
+            if "*" not in vals
+            else uris_by_type(vocab.as_graph(), SKOS.Concept, "exclude")
         ),
         "exclude_type": lambda vals: add_uris(
-            vocab.as_graph(), uris_by_type, exclude_uris, vals
+            vocab.as_graph(), uris_by_type, exclude_uris, vals, "exclude_type"
         ),
         "exclude_scheme": lambda vals: add_uris(
-            vocab.as_graph(), uris_by_scheme, exclude_uris, vals
+            vocab.as_graph(), uris_by_scheme, exclude_uris, vals, "exclude_scheme"
         ),
         "exclude_collection": lambda vals: add_uris(
-            vocab.as_graph(), uris_by_collection, exclude_uris, vals
+            vocab.as_graph(),
+            uris_by_collection,
+            exclude_uris,
+            vals,
+            "exclude_collection",
         ),
         "include": lambda vals: exclude_uris.difference_update(vals),
         "include_type": lambda vals: remove_uris(
-            vocab.as_graph(), uris_by_type, exclude_uris, vals
+            vocab.as_graph(), uris_by_type, exclude_uris, vals, "include_type"
         ),
         "include_scheme": lambda vals: remove_uris(
-            vocab.as_graph(), uris_by_scheme, exclude_uris, vals
+            vocab.as_graph(), uris_by_scheme, exclude_uris, vals, "include_scheme"
         ),
         "include_collection": lambda vals: remove_uris(
-            vocab.as_graph(), uris_by_collection, exclude_uris, vals
+            vocab.as_graph(),
+            uris_by_collection,
+            exclude_uris,
+            vals,
+            "include_collection",
         ),
     }
 

--- a/annif/vocab/rules.py
+++ b/annif/vocab/rules.py
@@ -18,39 +18,51 @@ def uris_by_collection(graph: Graph, type: str) -> list[str]:
     return [str(uri) for uri in graph.objects(URIRef(type), SKOS.member)]
 
 
+def add_uris(
+    graph: Graph, uris_func: callable, uris_set: set[str], vals: list[str]
+) -> None:
+    for val in vals:
+        uris_set.update(uris_func(graph, val))
+
+
+def remove_uris(
+    graph: Graph, uris_func: callable, uris_set: set[str], vals: list[str]
+) -> None:
+    for val in vals:
+        for uri in uris_func(graph, val):
+            uris_set.discard(uri)
+
+
 def kwargs_to_exclude_uris(graph: Graph, kwargs: dict[str, str]) -> set[str]:
     exclude_uris = set()
+    actions = {
+        "exclude": lambda vals: exclude_uris.update(
+            vals if "*" not in vals else uris_by_type(graph, SKOS.Concept)
+        ),
+        "exclude_type": lambda vals: add_uris(graph, uris_by_type, exclude_uris, vals),
+        "exclude_scheme": lambda vals: add_uris(
+            graph, uris_by_scheme, exclude_uris, vals
+        ),
+        "exclude_collection": lambda vals: add_uris(
+            graph, uris_by_collection, exclude_uris, vals
+        ),
+        "include": lambda vals: exclude_uris.difference_update(vals),
+        "include_type": lambda vals: remove_uris(
+            graph, uris_by_type, exclude_uris, vals
+        ),
+        "include_scheme": lambda vals: remove_uris(
+            graph, uris_by_scheme, exclude_uris, vals
+        ),
+        "include_collection": lambda vals: remove_uris(
+            graph, uris_by_collection, exclude_uris, vals
+        ),
+    }
+
     for key, value in kwargs.items():
         vals = value.split("|")
-        if key == "exclude":
-            if "*" in vals:
-                exclude_uris.update(uris_by_type(graph, SKOS.Concept))
-            else:
-                exclude_uris.update(vals)
-        elif key == "exclude_type":
-            for val in vals:
-                exclude_uris.update(uris_by_type(graph, val))
-        elif key == "exclude_scheme":
-            for val in vals:
-                exclude_uris.update(uris_by_scheme(graph, val))
-        elif key == "exclude_collection":
-            for val in vals:
-                exclude_uris.update(uris_by_collection(graph, val))
-        elif key == "include":
-            for val in vals:
-                exclude_uris.remove(val)
-        elif key == "include_type":
-            for val in vals:
-                for uri in uris_by_type(graph, val):
-                    exclude_uris.remove(uri)
-        elif key == "include_scheme":
-            for val in vals:
-                for uri in uris_by_scheme(graph, val):
-                    exclude_uris.remove(uri)
-        elif key == "include_collection":
-            for val in vals:
-                for uri in uris_by_collection(graph, val):
-                    exclude_uris.remove(uri)
+        if key in actions:
+            actions[key](vals)
         else:
             raise ConfigurationException(f"unknown vocab keyword argument {key}")
+
     return exclude_uris

--- a/annif/vocab/rules.py
+++ b/annif/vocab/rules.py
@@ -23,7 +23,10 @@ def kwargs_to_exclude_uris(graph: Graph, kwargs: dict[str, str]) -> set[str]:
     for key, value in kwargs.items():
         vals = value.split("|")
         if key == "exclude":
-            exclude_uris.update(vals)
+            if "*" in vals:
+                exclude_uris.update(uris_by_type(graph, SKOS.Concept))
+            else:
+                exclude_uris.update(vals)
         elif key == "exclude_type":
             for val in vals:
                 exclude_uris.update(uris_by_type(graph, val))
@@ -33,6 +36,21 @@ def kwargs_to_exclude_uris(graph: Graph, kwargs: dict[str, str]) -> set[str]:
         elif key == "exclude_collection":
             for val in vals:
                 exclude_uris.update(uris_by_collection(graph, val))
+        elif key == "include":
+            for val in vals:
+                exclude_uris.remove(val)
+        elif key == "include_type":
+            for val in vals:
+                for uri in uris_by_type(graph, val):
+                    exclude_uris.remove(uri)
+        elif key == "include_scheme":
+            for val in vals:
+                for uri in uris_by_scheme(graph, val):
+                    exclude_uris.remove(uri)
+        elif key == "include_collection":
+            for val in vals:
+                for uri in uris_by_collection(graph, val):
+                    exclude_uris.remove(uri)
         else:
             raise ConfigurationException(f"unknown vocab keyword argument {key}")
     return exclude_uris

--- a/annif/vocab/subject_index.py
+++ b/annif/vocab/subject_index.py
@@ -112,9 +112,9 @@ class SubjectIndexFilter(SubjectIndex):
     """SubjectIndex implementation that filters another SubjectIndex based
     on a list of subject URIs to exclude."""
 
-    def __init__(self, subject_index: SubjectIndex, exclude: list[str]):
+    def __init__(self, subject_index: SubjectIndex, exclude: set[str]):
         self._subject_index = subject_index
-        self._exclude = set(exclude)
+        self._exclude = exclude
 
     def __len__(self) -> int:
         return len(self._subject_index)

--- a/tests/corpora/archaeology/extract-yso-archaeology.rq
+++ b/tests/corpora/archaeology/extract-yso-archaeology.rq
@@ -1,15 +1,20 @@
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 CONSTRUCT {
-  ?c a skos:Concept .
+  ?c a ?type .
+  ?c skos:inScheme ?scheme .
   ?c skos:prefLabel ?prefLabel .
   ?c skos:altLabel ?altLabel .
   ?c ?rel ?c2 .
   ?coll a skos:Collection .
   ?coll skos:member ?c .
+  # extra scheme for testing exlude rules
+  <http://www.yso.fi/onto/yso/p1265> skos:inScheme <http://www.yso.fi/onto/yso/test-scheme> .
 }
 WHERE {
   ?c a skos:Concept .
+  ?c a ?type .
   <http://www.yso.fi/onto/yso/p26593> skos:member ?c .
+  OPTIONAL { ?c skos:inScheme ?scheme }
   ?c skos:prefLabel ?prefLabel .
   OPTIONAL { ?c skos:altLabel ?altLabel }
   OPTIONAL {

--- a/tests/corpora/archaeology/yso-archaeology.rdf
+++ b/tests/corpora/archaeology/yso-archaeology.rdf
@@ -27,7 +27,7 @@
     xmlns:tsrmeta="http://www.yso.fi/onto/tsr-meta/"
     xmlns:ns3="http://metadataregistry.org/uri/profile/regap/"
     xmlns:koko="http://www.yso.fi/onto/koko/"
-    xmlns:yso-update="http://www.yso.fi/onto/yso-update/"
+    xmlns:ysoupdate="http://www.yso.fi/onto/yso-update/"
     xmlns:taometa="http://www.yso.fi/onto/tao-meta/"
     xmlns:terometa="http://www.yso.fi/onto/tero-meta/"
     xmlns:sotometa="http://www.yso.fi/onto/soto-meta/"
@@ -63,6 +63,8 @@
         <skos:prefLabel xml:lang="fi">muinaismuistoalueet</skos:prefLabel>
         <skos:altLabel xml:lang="fi">muinaisjäännösalueet</skos:altLabel>
         <skos:prefLabel xml:lang="en">historic sites</skos:prefLabel>
+        <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+        <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
       </skos:Concept>
     </skos:member>
     <skos:member>
@@ -72,6 +74,8 @@
         <skos:altLabel xml:lang="sv">Mesa Verde</skos:altLabel>
         <skos:altLabel xml:lang="sv">Mesa Verde (nationalpark)</skos:altLabel>
         <skos:prefLabel xml:lang="sv">Mesa Verde nationalpark</skos:prefLabel>
+        <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+        <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Individual"/>
       </skos:Concept>
     </skos:member>
   </skos:Collection>
@@ -82,6 +86,8 @@
         <skos:prefLabel xml:lang="sv">lerkärl</skos:prefLabel>
         <skos:altLabel xml:lang="en">clay dishes</skos:altLabel>
         <skos:prefLabel xml:lang="fi">saviastiat</skos:prefLabel>
+        <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+        <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
       </skos:Concept>
     </skos:member>
   </skos:Collection>
@@ -91,6 +97,8 @@
         <skos:prefLabel xml:lang="sv">forntidsdräkter</skos:prefLabel>
         <skos:prefLabel xml:lang="en">ancient costume reconstructions</skos:prefLabel>
         <skos:prefLabel xml:lang="fi">muinaispuvut</skos:prefLabel>
+        <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+        <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
       </skos:Concept>
     </skos:member>
   </skos:Collection>
@@ -100,8 +108,9 @@
         <skos:prefLabel xml:lang="sv">förhistorisk konst</skos:prefLabel>
         <skos:prefLabel xml:lang="fi">esihistoriallinen taide</skos:prefLabel>
         <skos:narrower>
-          <skos:Concept rdf:about="http://www.yso.fi/onto/yso/p13027">
+          <yso-meta:Concept rdf:about="http://www.yso.fi/onto/yso/p13027">
             <skos:altLabel xml:lang="fi">luolamaalaukset</skos:altLabel>
+            <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
             <skos:broader rdf:resource="http://www.yso.fi/onto/yso/p12463"/>
             <skos:altLabel xml:lang="sv">grottkonst</skos:altLabel>
             <skos:related>
@@ -114,35 +123,43 @@
                     <skos:related rdf:resource="http://www.yso.fi/onto/yso/p5340"/>
                     <skos:altLabel xml:lang="sv">arkeologiska utgrävningar</skos:altLabel>
                     <skos:prefLabel xml:lang="sv">utgrävningar</skos:prefLabel>
+                    <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+                    <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
                   </skos:Concept>
                 </skos:related>
                 <skos:narrower>
-                  <skos:Concept rdf:about="http://www.yso.fi/onto/yso/p10417">
-                    <skos:prefLabel xml:lang="fi">muinaisesineet</skos:prefLabel>
+                  <yso-meta:Concept rdf:about="http://www.yso.fi/onto/yso/p10417">
                     <skos:prefLabel xml:lang="en">antiquities</skos:prefLabel>
-                    <skos:altLabel xml:lang="en">relics of antiquity</skos:altLabel>
+                    <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
                     <skos:narrower>
-                      <skos:Concept rdf:about="http://www.yso.fi/onto/yso/p10416">
-                        <skos:prefLabel xml:lang="sv">skattfynd</skos:prefLabel>
-                        <skos:prefLabel xml:lang="en">treasure finds</skos:prefLabel>
+                      <skos:Concept rdf:about="http://www.yso.fi/onto/yso/p10415">
+                        <skos:prefLabel xml:lang="fi">rahalöydöt</skos:prefLabel>
+                        <skos:prefLabel xml:lang="sv">myntfynd</skos:prefLabel>
                         <skos:related>
-                          <skos:Concept rdf:about="http://www.yso.fi/onto/yso/p10415">
-                            <skos:prefLabel xml:lang="fi">rahalöydöt</skos:prefLabel>
-                            <skos:prefLabel xml:lang="sv">myntfynd</skos:prefLabel>
-                            <skos:related rdf:resource="http://www.yso.fi/onto/yso/p10416"/>
+                          <skos:Concept rdf:about="http://www.yso.fi/onto/yso/p10416">
+                            <skos:prefLabel xml:lang="sv">skattfynd</skos:prefLabel>
+                            <skos:prefLabel xml:lang="en">treasure finds</skos:prefLabel>
+                            <skos:related rdf:resource="http://www.yso.fi/onto/yso/p10415"/>
                             <skos:broader rdf:resource="http://www.yso.fi/onto/yso/p10417"/>
-                            <skos:prefLabel xml:lang="en">coin finds</skos:prefLabel>
+                            <skos:prefLabel xml:lang="fi">aarrelöydöt</skos:prefLabel>
+                            <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+                            <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
                           </skos:Concept>
                         </skos:related>
                         <skos:broader rdf:resource="http://www.yso.fi/onto/yso/p10417"/>
-                        <skos:prefLabel xml:lang="fi">aarrelöydöt</skos:prefLabel>
+                        <skos:prefLabel xml:lang="en">coin finds</skos:prefLabel>
+                        <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+                        <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
                       </skos:Concept>
                     </skos:narrower>
-                    <skos:narrower rdf:resource="http://www.yso.fi/onto/yso/p10415"/>
+                    <skos:prefLabel xml:lang="fi">muinaisesineet</skos:prefLabel>
                     <skos:broader rdf:resource="http://www.yso.fi/onto/yso/p5340"/>
-                    <skos:altLabel xml:lang="sv">fornsaker</skos:altLabel>
+                    <skos:narrower rdf:resource="http://www.yso.fi/onto/yso/p10416"/>
+                    <skos:altLabel xml:lang="en">relics of antiquity</skos:altLabel>
+                    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
                     <skos:prefLabel xml:lang="sv">fornföremål</skos:prefLabel>
-                  </skos:Concept>
+                    <skos:altLabel xml:lang="sv">fornsaker</skos:altLabel>
+                  </yso-meta:Concept>
                 </skos:narrower>
                 <skos:altLabel xml:lang="sv">fornminnen</skos:altLabel>
                 <skos:prefLabel xml:lang="fi">muinaisjäännökset</skos:prefLabel>
@@ -158,9 +175,13 @@
                         <skos:broader rdf:resource="http://www.yso.fi/onto/yso/p580"/>
                         <skos:altLabel xml:lang="fi">kuppikivet</skos:altLabel>
                         <skos:prefLabel xml:lang="sv">offerstenar</skos:prefLabel>
+                        <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+                        <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
                       </skos:Concept>
                     </skos:narrower>
                     <skos:prefLabel xml:lang="sv">offerplatser</skos:prefLabel>
+                    <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+                    <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
                   </skos:Concept>
                 </skos:related>
                 <skos:related>
@@ -169,18 +190,22 @@
                     <skos:prefLabel xml:lang="sv">labyrinter</skos:prefLabel>
                     <skos:related rdf:resource="http://www.yso.fi/onto/yso/p5340"/>
                     <skos:narrower>
-                      <skos:Concept rdf:about="http://www.yso.fi/onto/yso/p27547">
+                      <yso-meta:Concept rdf:about="http://www.yso.fi/onto/yso/p27547">
                         <skos:prefLabel xml:lang="sv">jungfrudanser</skos:prefLabel>
-                        <skos:prefLabel xml:lang="en">troy towns</skos:prefLabel>
-                        <skos:altLabel xml:lang="sv">trojaborgar</skos:altLabel>
                         <skos:altLabel xml:lang="en">jatulintarhat</skos:altLabel>
-                        <skos:related rdf:resource="http://www.yso.fi/onto/yso/p5340"/>
-                        <skos:broader rdf:resource="http://www.yso.fi/onto/yso/p14174"/>
-                        <skos:altLabel xml:lang="sv">trojeborgar</skos:altLabel>
                         <skos:prefLabel xml:lang="fi">jatulintarhat</skos:prefLabel>
-                      </skos:Concept>
+                        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+                        <skos:related rdf:resource="http://www.yso.fi/onto/yso/p5340"/>
+                        <skos:prefLabel xml:lang="en">troy towns</skos:prefLabel>
+                        <skos:altLabel xml:lang="sv">trojeborgar</skos:altLabel>
+                        <skos:broader rdf:resource="http://www.yso.fi/onto/yso/p14174"/>
+                        <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+                        <skos:altLabel xml:lang="sv">trojaborgar</skos:altLabel>
+                      </yso-meta:Concept>
                     </skos:narrower>
                     <skos:prefLabel xml:lang="fi">labyrintit</skos:prefLabel>
+                    <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+                    <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
                   </skos:Concept>
                 </skos:related>
                 <skos:altLabel xml:lang="sv">fasta fornlämningar</skos:altLabel>
@@ -190,11 +215,13 @@
                     <skos:prefLabel xml:lang="sv">runstenar</skos:prefLabel>
                     <skos:related rdf:resource="http://www.yso.fi/onto/yso/p5340"/>
                     <skos:related>
-                      <skos:Concept rdf:about="http://www.yso.fi/onto/yso/p29406">
+                      <yso-meta:Concept rdf:about="http://www.yso.fi/onto/yso/p29406">
+                        <skos:altLabel xml:lang="sv">runforskning</skos:altLabel>
                         <skos:prefLabel xml:lang="fi">runologia</skos:prefLabel>
-                        <skos:prefLabel xml:lang="sv">runologi</skos:prefLabel>
                         <skos:altLabel xml:lang="fi">riimututkimus</skos:altLabel>
                         <skos:related rdf:resource="http://www.yso.fi/onto/yso/p14588"/>
+                        <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+                        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
                         <skos:related>
                           <skos:Concept rdf:about="http://www.yso.fi/onto/yso/p6218">
                             <skos:prefLabel xml:lang="fi">riimukirjoitus</skos:prefLabel>
@@ -203,13 +230,17 @@
                             <skos:related rdf:resource="http://www.yso.fi/onto/yso/p29406"/>
                             <skos:altLabel xml:lang="sv">runskrift</skos:altLabel>
                             <skos:prefLabel xml:lang="en">runic writing</skos:prefLabel>
+                            <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+                            <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
                           </skos:Concept>
                         </skos:related>
-                        <skos:altLabel xml:lang="sv">runforskning</skos:altLabel>
                         <skos:prefLabel xml:lang="en">runology</skos:prefLabel>
-                      </skos:Concept>
+                        <skos:prefLabel xml:lang="sv">runologi</skos:prefLabel>
+                      </yso-meta:Concept>
                     </skos:related>
                     <skos:prefLabel xml:lang="en">runestones</skos:prefLabel>
+                    <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+                    <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
                   </skos:Concept>
                 </skos:related>
                 <skos:related>
@@ -223,6 +254,8 @@
                         <skos:prefLabel xml:lang="sv">vrak</skos:prefLabel>
                         <skos:related rdf:resource="http://www.yso.fi/onto/yso/p8869"/>
                         <skos:prefLabel xml:lang="fi">hylyt</skos:prefLabel>
+                        <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+                        <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
                       </skos:Concept>
                     </skos:related>
                     <skos:related>
@@ -239,6 +272,7 @@
                               <skos:Concept rdf:about="http://www.yso.fi/onto/yso/p1265">
                                 <skos:altLabel xml:lang="fi">muinaistutkimus</skos:altLabel>
                                 <skos:altLabel xml:lang="sv">fornforskning</skos:altLabel>
+                                <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
                                 <skos:prefLabel xml:lang="sv"
                                 >arkeologi</skos:prefLabel>
                                 <skos:narrower>
@@ -258,6 +292,8 @@
                                         >classical period</skos:altLabel>
                                         <skos:prefLabel xml:lang="fi"
                                         >antiikki</skos:prefLabel>
+                                        <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+                                        <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
                                       </skos:Concept>
                                     </skos:related>
                                     <skos:broader rdf:resource="http://www.yso.fi/onto/yso/p1265"/>
@@ -265,6 +301,8 @@
                                     >klassillinen arkeologia</skos:altLabel>
                                     <skos:prefLabel xml:lang="fi"
                                     >klassinen arkeologia</skos:prefLabel>
+                                    <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+                                    <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
                                   </skos:Concept>
                                 </skos:narrower>
                                 <skos:altLabel xml:lang="fi">esihistoriallinen arkeologia</skos:altLabel>
@@ -279,6 +317,8 @@
                                     >historiallisen ajan arkeologia</skos:altLabel>
                                     <skos:prefLabel xml:lang="sv"
                                     >historisk arkeologi</skos:prefLabel>
+                                    <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+                                    <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
                                   </skos:Concept>
                                 </skos:narrower>
                                 <skos:narrower>
@@ -290,6 +330,8 @@
                                     <skos:broader rdf:resource="http://www.yso.fi/onto/yso/p1265"/>
                                     <skos:prefLabel xml:lang="fi"
                                     >ympäristöarkeologia</skos:prefLabel>
+                                    <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+                                    <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
                                   </skos:Concept>
                                 </skos:narrower>
                                 <skos:narrower>
@@ -301,25 +343,30 @@
                                     <skos:broader rdf:resource="http://www.yso.fi/onto/yso/p1265"/>
                                     <skos:prefLabel xml:lang="en"
                                     >industrial archaeology</skos:prefLabel>
+                                    <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+                                    <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
                                   </skos:Concept>
                                 </skos:narrower>
                                 <skos:related>
                                   <skos:Concept rdf:about="http://www.yso.fi/onto/yso/p28252">
+                                    <skos:altLabel xml:lang="sv"
+                                    >deltagande arkeologi</skos:altLabel>
+                                    <skos:related rdf:resource="http://www.yso.fi/onto/yso/p1265"/>
                                     <skos:prefLabel xml:lang="sv"
                                     >publik arkeologi</skos:prefLabel>
+                                    <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
+                                    <skos:altLabel xml:lang="en"
+                                    >public archaeology</skos:altLabel>
+                                    <skos:prefLabel xml:lang="en"
+                                    >community archaeology</skos:prefLabel>
                                     <skos:prefLabel xml:lang="fi"
                                     >yhteisöarkeologia</skos:prefLabel>
                                     <skos:altLabel xml:lang="sv"
-                                    >deltagande arkeologi</skos:altLabel>
-                                    <skos:altLabel xml:lang="en"
-                                    >public archaeology</skos:altLabel>
-                                    <skos:related rdf:resource="http://www.yso.fi/onto/yso/p1265"/>
-                                    <skos:altLabel xml:lang="sv"
                                     >samskapande arkeologi</skos:altLabel>
-                                    <skos:prefLabel xml:lang="en"
-                                    >community archaeology</skos:prefLabel>
+                                    <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
                                   </skos:Concept>
                                 </skos:related>
+                                <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/test-scheme"/>
                                 <skos:narrower>
                                   <skos:Concept rdf:about="http://www.yso.fi/onto/yso/p20339">
                                     <skos:prefLabel xml:lang="sv"
@@ -329,6 +376,8 @@
                                     <skos:broader rdf:resource="http://www.yso.fi/onto/yso/p1265"/>
                                     <skos:prefLabel xml:lang="en"
                                     >experimental archeology</skos:prefLabel>
+                                    <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+                                    <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
                                   </skos:Concept>
                                 </skos:narrower>
                                 <skos:narrower>
@@ -340,6 +389,8 @@
                                     <skos:broader rdf:resource="http://www.yso.fi/onto/yso/p1265"/>
                                     <skos:prefLabel xml:lang="sv"
                                     >molekylärarkeologi</skos:prefLabel>
+                                    <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+                                    <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
                                   </skos:Concept>
                                 </skos:narrower>
                                 <skos:prefLabel xml:lang="fi"
@@ -359,6 +410,8 @@
                                     >växtarkeologi</skos:altLabel>
                                     <skos:prefLabel xml:lang="fi"
                                     >arkeobotaniikka</skos:prefLabel>
+                                    <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+                                    <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
                                   </skos:Concept>
                                 </skos:narrower>
                                 <skos:narrower>
@@ -370,8 +423,11 @@
                                     <skos:broader rdf:resource="http://www.yso.fi/onto/yso/p1265"/>
                                     <skos:prefLabel xml:lang="fi"
                                     >kaupunkiarkeologia</skos:prefLabel>
+                                    <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+                                    <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
                                   </skos:Concept>
                                 </skos:narrower>
+                                <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
                                 <skos:prefLabel xml:lang="en"
                                 >archaeology</skos:prefLabel>
                                 <skos:narrower rdf:resource="http://www.yso.fi/onto/yso/p8868"/>
@@ -379,14 +435,21 @@
                               </skos:Concept>
                             </skos:broader>
                             <skos:prefLabel xml:lang="fi">vedenalainen arkeologia</skos:prefLabel>
+                            <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+                            <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
                           </skos:Concept>
                         </skos:broader>
                         <skos:prefLabel xml:lang="fi">meriarkeologia</skos:prefLabel>
+                        <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+                        <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
                       </skos:Concept>
                     </skos:related>
                     <skos:prefLabel xml:lang="sv">skeppsfynd</skos:prefLabel>
+                    <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+                    <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
                   </skos:Concept>
                 </skos:related>
+                <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
                 <skos:narrower>
                   <skos:Concept rdf:about="http://www.yso.fi/onto/yso/p7347">
                     <skos:prefLabel xml:lang="en">ancient castles</skos:prefLabel>
@@ -397,10 +460,14 @@
                         <skos:prefLabel xml:lang="fi">linnavuoret</skos:prefLabel>
                         <skos:related rdf:resource="http://www.yso.fi/onto/yso/p7347"/>
                         <skos:prefLabel xml:lang="en">hill forts</skos:prefLabel>
+                        <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+                        <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
                       </skos:Concept>
                     </skos:related>
                     <skos:broader rdf:resource="http://www.yso.fi/onto/yso/p5340"/>
                     <skos:prefLabel xml:lang="fi">muinaislinnat</skos:prefLabel>
+                    <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+                    <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
                   </skos:Concept>
                 </skos:narrower>
                 <skos:related rdf:resource="http://www.yso.fi/onto/yso/p27547"/>
@@ -421,13 +488,19 @@
                             <skos:prefLabel xml:lang="sv">kraniologi</skos:prefLabel>
                             <skos:broader rdf:resource="http://www.yso.fi/onto/yso/p5338"/>
                             <skos:prefLabel xml:lang="fi">kraniologia</skos:prefLabel>
+                            <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+                            <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
                           </skos:Concept>
                         </skos:narrower>
                         <skos:altLabel xml:lang="fi">luuoppi</skos:altLabel>
                         <skos:prefLabel xml:lang="sv">osteologi</skos:prefLabel>
+                        <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+                        <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
                       </skos:Concept>
                     </skos:related>
                     <skos:prefLabel xml:lang="fi">luulöydöt</skos:prefLabel>
+                    <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+                    <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
                   </skos:Concept>
                 </skos:related>
                 <skos:related rdf:resource="http://www.yso.fi/onto/yso/p13027"/>
@@ -437,6 +510,8 @@
                     <skos:prefLabel xml:lang="en">sphinxes</skos:prefLabel>
                     <skos:related rdf:resource="http://www.yso.fi/onto/yso/p5340"/>
                     <skos:prefLabel xml:lang="sv">sfinxer</skos:prefLabel>
+                    <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+                    <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
                   </skos:Concept>
                 </skos:related>
                 <skos:related>
@@ -454,11 +529,13 @@
                         <skos:altLabel xml:lang="fi">hautaesineet</skos:altLabel>
                         <skos:related rdf:resource="http://www.yso.fi/onto/yso/p5713"/>
                         <skos:prefLabel xml:lang="fi">hauta-antimet</skos:prefLabel>
+                        <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
                         <skos:altLabel xml:lang="sv">gravföremål</skos:altLabel>
+                        <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
                       </skos:Concept>
                     </skos:related>
                     <skos:related>
-                      <skos:Concept rdf:about="http://www.yso.fi/onto/yso/p5714">
+                      <yso-meta:Concept rdf:about="http://www.yso.fi/onto/yso/p5714">
                         <skos:prefLabel xml:lang="en">prehistoric graves</skos:prefLabel>
                         <skos:narrower>
                           <skos:Concept rdf:about="http://www.yso.fi/onto/yso/p6477">
@@ -466,6 +543,8 @@
                             <skos:prefLabel xml:lang="sv">skelettgravar</skos:prefLabel>
                             <skos:broader rdf:resource="http://www.yso.fi/onto/yso/p5714"/>
                             <skos:prefLabel xml:lang="en">non-cremated burial deposit</skos:prefLabel>
+                            <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+                            <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
                           </skos:Concept>
                         </skos:narrower>
                         <skos:narrower>
@@ -475,6 +554,8 @@
                             <skos:broader rdf:resource="http://www.yso.fi/onto/yso/p5714"/>
                             <skos:altLabel xml:lang="en">mounds (prehistoric graves)</skos:altLabel>
                             <skos:prefLabel xml:lang="en">barrows (prehistoric graves)</skos:prefLabel>
+                            <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+                            <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
                           </skos:Concept>
                         </skos:narrower>
                         <skos:prefLabel xml:lang="fi">muinaishaudat</skos:prefLabel>
@@ -485,7 +566,7 @@
                             <skos:related rdf:resource="http://www.yso.fi/onto/yso/p5340"/>
                             <skos:related rdf:resource="http://www.yso.fi/onto/yso/p5714"/>
                             <skos:related>
-                              <skos:Concept rdf:about="http://www.yso.fi/onto/yso/p8506">
+                              <yso-meta:Concept rdf:about="http://www.yso.fi/onto/yso/p8506">
                                 <skos:prefLabel xml:lang="en"
                                 >graves</skos:prefLabel>
                                 <skos:related rdf:resource="http://www.yso.fi/onto/yso/p8508"/>
@@ -503,6 +584,8 @@
                                     <skos:broader rdf:resource="http://www.yso.fi/onto/yso/p8506"/>
                                     <skos:prefLabel xml:lang="en"
                                     >cremation graves</skos:prefLabel>
+                                    <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+                                    <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
                                   </skos:Concept>
                                 </skos:narrower>
                                 <skos:narrower>
@@ -514,8 +597,12 @@
                                     <skos:broader rdf:resource="http://www.yso.fi/onto/yso/p8506"/>
                                     <skos:prefLabel xml:lang="en"
                                     >burial chambers</skos:prefLabel>
+                                    <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+                                    <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
                                   </skos:Concept>
                                 </skos:narrower>
+                                <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+                                <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
                                 <skos:prefLabel xml:lang="sv"
                                 >gravar</skos:prefLabel>
                                 <skos:narrower>
@@ -529,21 +616,29 @@
                                     >mass burials</skos:altLabel>
                                     <skos:prefLabel xml:lang="en"
                                     >mass graves</skos:prefLabel>
+                                    <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+                                    <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
                                   </skos:Concept>
                                 </skos:narrower>
-                              </skos:Concept>
+                              </yso-meta:Concept>
                             </skos:related>
                             <skos:prefLabel xml:lang="en">burial sites</skos:prefLabel>
+                            <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+                            <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
                           </skos:Concept>
                         </skos:related>
+                        <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
                         <skos:related rdf:resource="http://www.yso.fi/onto/yso/p17863"/>
                         <skos:related rdf:resource="http://www.yso.fi/onto/yso/p5713"/>
-                        <skos:related rdf:resource="http://www.yso.fi/onto/yso/p5340"/>
                         <skos:prefLabel xml:lang="sv">forngravar</skos:prefLabel>
+                        <skos:related rdf:resource="http://www.yso.fi/onto/yso/p5340"/>
+                        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
                         <skos:broader rdf:resource="http://www.yso.fi/onto/yso/p8506"/>
-                      </skos:Concept>
+                      </yso-meta:Concept>
                     </skos:related>
                     <skos:prefLabel xml:lang="sv">gravfynd</skos:prefLabel>
+                    <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+                    <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
                   </skos:Concept>
                 </skos:related>
                 <skos:related>
@@ -567,6 +662,8 @@
                                 <skos:related rdf:resource="http://www.yso.fi/onto/yso/p7804"/>
                                 <skos:prefLabel xml:lang="fi"
                                 >termoluminesenssi</skos:prefLabel>
+                                <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+                                <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
                               </skos:Concept>
                             </skos:related>
                             <skos:related>
@@ -578,12 +675,13 @@
                                 <skos:related rdf:resource="http://www.yso.fi/onto/yso/p7804"/>
                                 <skos:prefLabel xml:lang="sv"
                                 >stratigrafi</skos:prefLabel>
+                                <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+                                <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
                               </skos:Concept>
                             </skos:related>
                             <skos:prefLabel xml:lang="en">age estimation</skos:prefLabel>
                             <skos:related rdf:resource="http://www.yso.fi/onto/yso/p20619"/>
                             <skos:prefLabel xml:lang="fi">iänmääritys</skos:prefLabel>
-                            <skos:prefLabel xml:lang="sv">åldersbestämning</skos:prefLabel>
                             <skos:related>
                               <skos:Concept rdf:about="http://www.yso.fi/onto/yso/p7785">
                                 <skos:prefLabel xml:lang="en"
@@ -603,34 +701,47 @@
                                     >tree-ring dating</skos:altLabel>
                                     <skos:prefLabel xml:lang="fi"
                                     >dendrokronologia</skos:prefLabel>
+                                    <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+                                    <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
                                   </skos:Concept>
                                 </skos:narrower>
                                 <skos:prefLabel xml:lang="sv"
                                 >kronologi</skos:prefLabel>
+                                <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+                                <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
                               </skos:Concept>
                             </skos:related>
                             <skos:narrower>
                               <skos:Concept rdf:about="http://www.yso.fi/onto/yso/p19077">
                                 <skos:prefLabel xml:lang="fi"
                                 >radiohiiliajoitus</skos:prefLabel>
+                                <skos:altLabel xml:lang="fi">C 14 -menetelmä</skos:altLabel>
+                                <skos:altLabel xml:lang="sv">C-datering</skos:altLabel>
+                                <skos:prefLabel xml:lang="sv"
+                                >kol-14-datering</skos:prefLabel>
+                                <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
+                                <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
                                 <skos:prefLabel xml:lang="en"
                                 >radiocarbon dating</skos:prefLabel>
                                 <skos:altLabel xml:lang="sv">C 14-metoden</skos:altLabel>
                                 <skos:altLabel xml:lang="sv">kol-fjorton-datering</skos:altLabel>
-                                <skos:altLabel xml:lang="sv">C-datering</skos:altLabel>
                                 <skos:broader rdf:resource="http://www.yso.fi/onto/yso/p7804"/>
-                                <skos:altLabel xml:lang="fi">C 14 -menetelmä</skos:altLabel>
-                                <skos:prefLabel xml:lang="sv"
-                                >kol-14-datering</skos:prefLabel>
                               </skos:Concept>
                             </skos:narrower>
+                            <skos:prefLabel xml:lang="sv">åldersbestämning</skos:prefLabel>
+                            <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+                            <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
                             <skos:related rdf:resource="http://www.yso.fi/onto/yso/p7784"/>
                           </skos:Concept>
                         </skos:related>
                         <skos:prefLabel xml:lang="fi">siitepölyanalyysi</skos:prefLabel>
+                        <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+                        <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
                       </skos:Concept>
                     </skos:related>
                     <skos:prefLabel xml:lang="en">macrofossils</skos:prefLabel>
+                    <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+                    <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
                   </skos:Concept>
                 </skos:related>
                 <skos:related>
@@ -639,6 +750,8 @@
                     <skos:prefLabel xml:lang="sv">pyramider</skos:prefLabel>
                     <skos:related rdf:resource="http://www.yso.fi/onto/yso/p5340"/>
                     <skos:prefLabel xml:lang="fi">pyramidit</skos:prefLabel>
+                    <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+                    <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
                   </skos:Concept>
                 </skos:related>
                 <skos:related>
@@ -647,6 +760,8 @@
                     <skos:prefLabel xml:lang="en">bog finds</skos:prefLabel>
                     <skos:related rdf:resource="http://www.yso.fi/onto/yso/p5340"/>
                     <skos:prefLabel xml:lang="fi">suolöydöt</skos:prefLabel>
+                    <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+                    <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
                   </skos:Concept>
                 </skos:related>
                 <skos:altLabel xml:lang="fi">kiinteät muinaisjäännökset</skos:altLabel>
@@ -659,6 +774,8 @@
                     <skos:prefLabel xml:lang="en">obelisks</skos:prefLabel>
                     <skos:related rdf:resource="http://www.yso.fi/onto/yso/p5340"/>
                     <skos:prefLabel xml:lang="sv">obelisker</skos:prefLabel>
+                    <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+                    <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
                   </skos:Concept>
                 </skos:related>
                 <skos:related rdf:resource="http://www.yso.fi/onto/yso/p5714"/>
@@ -677,6 +794,8 @@
                             <skos:prefLabel xml:lang="en">hieroglyphs</skos:prefLabel>
                             <skos:related rdf:resource="http://www.yso.fi/onto/yso/p2192"/>
                             <skos:prefLabel xml:lang="sv">hieroglyfer</skos:prefLabel>
+                            <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+                            <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
                           </skos:Concept>
                         </skos:related>
                         <skos:related rdf:resource="http://www.yso.fi/onto/yso/p2193"/>
@@ -687,9 +806,13 @@
                             <skos:related rdf:resource="http://www.yso.fi/onto/yso/p2192"/>
                             <skos:altLabel xml:lang="fi">assyrologia</skos:altLabel>
                             <skos:prefLabel xml:lang="en">assyriology</skos:prefLabel>
+                            <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+                            <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
                           </skos:Concept>
                         </skos:related>
                         <skos:prefLabel xml:lang="sv">egyptologi</skos:prefLabel>
+                        <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+                        <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
                       </skos:Concept>
                     </skos:related>
                     <skos:related>
@@ -699,47 +822,59 @@
                         <skos:related rdf:resource="http://www.yso.fi/onto/yso/p2193"/>
                         <skos:altLabel xml:lang="fi">balsamointi</skos:altLabel>
                         <skos:prefLabel xml:lang="en">embalming</skos:prefLabel>
+                        <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+                        <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
                       </skos:Concept>
                     </skos:related>
                     <skos:prefLabel xml:lang="sv">mumier</skos:prefLabel>
+                    <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+                    <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
                   </skos:Concept>
                 </skos:related>
                 <skos:prefLabel xml:lang="sv">fornlämningar</skos:prefLabel>
-                <skos:related rdf:resource="http://www.yso.fi/onto/yso/p8508"/>
                 <skos:altLabel xml:lang="sv">fornfynd</skos:altLabel>
+                <skos:related rdf:resource="http://www.yso.fi/onto/yso/p8508"/>
                 <skos:altLabel xml:lang="fi">muinaismuistot</skos:altLabel>
+                <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
               </skos:Concept>
             </skos:related>
             <skos:related>
-              <skos:Concept rdf:about="http://www.yso.fi/onto/yso/p27963">
-                <skos:prefLabel xml:lang="fi">kalliopiirrokset</skos:prefLabel>
+              <yso-meta:Concept rdf:about="http://www.yso.fi/onto/yso/p27963">
                 <skos:prefLabel xml:lang="en">petroglyphs</skos:prefLabel>
-                <skos:altLabel xml:lang="sv">berginristningar</skos:altLabel>
+                <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
                 <skos:related rdf:resource="http://www.yso.fi/onto/yso/p13027"/>
+                <skos:altLabel xml:lang="sv">petroglyfer</skos:altLabel>
+                <skos:altLabel xml:lang="sv">berginristningar</skos:altLabel>
+                <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
                 <skos:related>
                   <skos:Concept rdf:about="http://www.yso.fi/onto/yso/p27964">
-                    <skos:prefLabel xml:lang="en">rock paintings</skos:prefLabel>
-                    <skos:prefLabel xml:lang="sv">hällmålningar</skos:prefLabel>
-                    <skos:altLabel xml:lang="sv">grottmålningar</skos:altLabel>
-                    <skos:altLabel xml:lang="sv">klippmålningar</skos:altLabel>
-                    <skos:related rdf:resource="http://www.yso.fi/onto/yso/p13027"/>
-                    <skos:related rdf:resource="http://www.yso.fi/onto/yso/p27963"/>
                     <skos:altLabel xml:lang="sv">bergmålningar</skos:altLabel>
+                    <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+                    <skos:altLabel xml:lang="sv">grottmålningar</skos:altLabel>
+                    <skos:prefLabel xml:lang="en">rock paintings</skos:prefLabel>
+                    <skos:altLabel xml:lang="sv">klippmålningar</skos:altLabel>
+                    <skos:related rdf:resource="http://www.yso.fi/onto/yso/p27963"/>
+                    <skos:related rdf:resource="http://www.yso.fi/onto/yso/p13027"/>
+                    <skos:prefLabel xml:lang="sv">hällmålningar</skos:prefLabel>
                     <skos:prefLabel xml:lang="fi">kalliomaalaukset</skos:prefLabel>
+                    <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
                   </skos:Concept>
                 </skos:related>
-                <skos:altLabel xml:lang="sv">petroglyfer</skos:altLabel>
+                <skos:prefLabel xml:lang="fi">kalliopiirrokset</skos:prefLabel>
                 <skos:prefLabel xml:lang="sv">hällristningar</skos:prefLabel>
-              </skos:Concept>
+              </yso-meta:Concept>
             </skos:related>
             <skos:related rdf:resource="http://www.yso.fi/onto/yso/p27964"/>
             <skos:altLabel xml:lang="sv">hällkonst</skos:altLabel>
             <skos:prefLabel xml:lang="fi">kalliotaide</skos:prefLabel>
             <skos:prefLabel xml:lang="en">rock art</skos:prefLabel>
+            <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
             <skos:prefLabel xml:lang="sv">bergkonst</skos:prefLabel>
-          </skos:Concept>
+          </yso-meta:Concept>
         </skos:narrower>
         <skos:prefLabel xml:lang="en">prehistoric art</skos:prefLabel>
+        <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+        <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
       </skos:Concept>
     </skos:member>
     <skos:member rdf:resource="http://www.yso.fi/onto/yso/p13027"/>
@@ -758,6 +893,8 @@
         <skos:prefLabel xml:lang="en">European Convention on the Protection of the Archaeological Heritage</skos:prefLabel>
         <skos:altLabel xml:lang="fi">Maltan yleissopimus</skos:altLabel>
         <skos:prefLabel xml:lang="fi">Eurooppalainen yleissopimus arkeologisen perinnön suojelusta</skos:prefLabel>
+        <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+        <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Individual"/>
       </skos:Concept>
     </skos:member>
   </skos:Collection>
@@ -775,10 +912,14 @@
             <skos:prefLabel xml:lang="sv">strandförskjutning</skos:prefLabel>
             <skos:related rdf:resource="http://www.yso.fi/onto/yso/p25576"/>
             <skos:prefLabel xml:lang="fi">rannansiirtyminen</skos:prefLabel>
+            <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+            <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
           </skos:Concept>
         </skos:related>
         <skos:altLabel xml:lang="sv">forntida stränder</skos:altLabel>
         <skos:prefLabel xml:lang="en">raised shorelines</skos:prefLabel>
+        <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+        <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
       </skos:Concept>
     </skos:member>
     <skos:member rdf:resource="http://www.yso.fi/onto/yso/p11052"/>
@@ -788,6 +929,7 @@
       <skos:Concept rdf:about="http://www.yso.fi/onto/yso/p4622">
         <skos:prefLabel xml:lang="en">prehistory</skos:prefLabel>
         <skos:prefLabel xml:lang="sv">förhistoria</skos:prefLabel>
+        <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
         <skos:altLabel xml:lang="sv">förhistorisk tid</skos:altLabel>
         <skos:narrower>
           <skos:Concept rdf:about="http://www.yso.fi/onto/yso/p2558">
@@ -797,6 +939,8 @@
                 <skos:prefLabel xml:lang="sv">vikingatiden</skos:prefLabel>
                 <skos:broader rdf:resource="http://www.yso.fi/onto/yso/p2558"/>
                 <skos:prefLabel xml:lang="fi">viikinkiaika</skos:prefLabel>
+                <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+                <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
               </skos:Concept>
             </skos:narrower>
             <skos:prefLabel xml:lang="fi">rautakausi</skos:prefLabel>
@@ -806,6 +950,8 @@
                 <skos:prefLabel xml:lang="en">Age of the Crusades</skos:prefLabel>
                 <skos:broader rdf:resource="http://www.yso.fi/onto/yso/p2558"/>
                 <skos:prefLabel xml:lang="sv">korstågstiden</skos:prefLabel>
+                <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+                <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
               </skos:Concept>
             </skos:narrower>
             <skos:narrower>
@@ -814,6 +960,8 @@
                 <skos:prefLabel xml:lang="sv">romersk järnålder</skos:prefLabel>
                 <skos:broader rdf:resource="http://www.yso.fi/onto/yso/p2558"/>
                 <skos:prefLabel xml:lang="fi">roomalainen rautakausi</skos:prefLabel>
+                <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+                <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
               </skos:Concept>
             </skos:narrower>
             <skos:narrower>
@@ -822,6 +970,8 @@
                 <skos:prefLabel xml:lang="sv">folkvandringstiden</skos:prefLabel>
                 <skos:broader rdf:resource="http://www.yso.fi/onto/yso/p2558"/>
                 <skos:prefLabel xml:lang="en">migration period</skos:prefLabel>
+                <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+                <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
               </skos:Concept>
             </skos:narrower>
             <skos:narrower>
@@ -830,6 +980,8 @@
                 <skos:prefLabel xml:lang="en">Vendel Period</skos:prefLabel>
                 <skos:broader rdf:resource="http://www.yso.fi/onto/yso/p2558"/>
                 <skos:prefLabel xml:lang="fi">merovingiaika</skos:prefLabel>
+                <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+                <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
               </skos:Concept>
             </skos:narrower>
             <skos:prefLabel xml:lang="sv">järnåldern</skos:prefLabel>
@@ -845,10 +997,14 @@
                     <skos:related rdf:resource="http://www.yso.fi/onto/yso/p4626"/>
                     <skos:broader rdf:resource="http://www.yso.fi/onto/yso/p4622"/>
                     <skos:prefLabel xml:lang="sv">bronsåldern</skos:prefLabel>
+                    <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+                    <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
                   </skos:Concept>
                 </skos:related>
                 <skos:broader rdf:resource="http://www.yso.fi/onto/yso/p4622"/>
                 <skos:prefLabel xml:lang="sv">tidig metallålder</skos:prefLabel>
+                <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+                <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
               </skos:Concept>
             </skos:related>
             <skos:narrower>
@@ -857,8 +1013,11 @@
                 <skos:prefLabel xml:lang="fi">esiroomalainen rautakausi</skos:prefLabel>
                 <skos:broader rdf:resource="http://www.yso.fi/onto/yso/p2558"/>
                 <skos:prefLabel xml:lang="sv">förromersk järnålder</skos:prefLabel>
+                <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+                <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
               </skos:Concept>
             </skos:narrower>
+            <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
             <skos:related>
               <skos:Concept rdf:about="http://www.yso.fi/onto/yso/p29717">
                 <skos:prefLabel xml:lang="sv">Latènekulturen</skos:prefLabel>
@@ -867,6 +1026,8 @@
                 <skos:related rdf:resource="http://www.yso.fi/onto/yso/p2558"/>
                 <skos:altLabel xml:lang="en">La Tene period</skos:altLabel>
                 <skos:prefLabel xml:lang="en">La Tène period</skos:prefLabel>
+                <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+                <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
               </skos:Concept>
             </skos:related>
             <skos:related>
@@ -875,31 +1036,31 @@
                 <skos:prefLabel xml:lang="fi">Hallstattin kulttuuri</skos:prefLabel>
                 <skos:related rdf:resource="http://www.yso.fi/onto/yso/p2558"/>
                 <skos:prefLabel xml:lang="sv">Hallstattkulturen</skos:prefLabel>
+                <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+                <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
               </skos:Concept>
             </skos:related>
             <skos:prefLabel xml:lang="en">Iron Age</skos:prefLabel>
             <skos:broader rdf:resource="http://www.yso.fi/onto/yso/p4622"/>
+            <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
           </skos:Concept>
         </skos:narrower>
         <skos:prefLabel xml:lang="fi">esihistoria</skos:prefLabel>
+        <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
         <skos:narrower>
           <skos:Concept rdf:about="http://www.yso.fi/onto/yso/p4624">
-            <skos:prefLabel xml:lang="en">Stone Age</skos:prefLabel>
             <skos:prefLabel xml:lang="sv">stenåldern</skos:prefLabel>
+            <skos:prefLabel xml:lang="en">Stone Age</skos:prefLabel>
+            <skos:broader rdf:resource="http://www.yso.fi/onto/yso/p4622"/>
+            <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
             <skos:narrower>
               <skos:Concept rdf:about="http://www.yso.fi/onto/yso/p12484">
                 <skos:prefLabel xml:lang="sv">paleolitisk tid</skos:prefLabel>
                 <skos:prefLabel xml:lang="fi">paleoliittinen kausi</skos:prefLabel>
                 <skos:broader rdf:resource="http://www.yso.fi/onto/yso/p4624"/>
                 <skos:prefLabel xml:lang="en">Paleolithic period</skos:prefLabel>
-              </skos:Concept>
-            </skos:narrower>
-            <skos:narrower>
-              <skos:Concept rdf:about="http://www.yso.fi/onto/yso/p20471">
-                <skos:prefLabel xml:lang="fi">mesoliittinen kausi</skos:prefLabel>
-                <skos:prefLabel xml:lang="sv">mesolitisk tid</skos:prefLabel>
-                <skos:broader rdf:resource="http://www.yso.fi/onto/yso/p4624"/>
-                <skos:prefLabel xml:lang="en">Mesolithic period</skos:prefLabel>
+                <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+                <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
               </skos:Concept>
             </skos:narrower>
             <skos:narrower>
@@ -908,10 +1069,22 @@
                 <skos:prefLabel xml:lang="sv">neolitisk tid</skos:prefLabel>
                 <skos:broader rdf:resource="http://www.yso.fi/onto/yso/p4624"/>
                 <skos:prefLabel xml:lang="fi">neoliittinen kausi</skos:prefLabel>
+                <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+                <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
               </skos:Concept>
             </skos:narrower>
-            <skos:broader rdf:resource="http://www.yso.fi/onto/yso/p4622"/>
+            <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
             <skos:prefLabel xml:lang="fi">kivikausi</skos:prefLabel>
+            <skos:narrower>
+              <skos:Concept rdf:about="http://www.yso.fi/onto/yso/p20471">
+                <skos:prefLabel xml:lang="fi">mesoliittinen kausi</skos:prefLabel>
+                <skos:prefLabel xml:lang="sv">mesolitisk tid</skos:prefLabel>
+                <skos:broader rdf:resource="http://www.yso.fi/onto/yso/p4624"/>
+                <skos:prefLabel xml:lang="en">Mesolithic period</skos:prefLabel>
+                <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+                <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
+              </skos:Concept>
+            </skos:narrower>
           </skos:Concept>
         </skos:narrower>
         <skos:altLabel xml:lang="fi">esihistoriallinen aika</skos:altLabel>
@@ -925,6 +1098,8 @@
         <skos:prefLabel xml:lang="sv">assyriologer</skos:prefLabel>
         <skos:prefLabel xml:lang="fi">assyriologit</skos:prefLabel>
         <skos:prefLabel xml:lang="en">Assyriologists</skos:prefLabel>
+        <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+        <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
       </skos:Concept>
     </skos:member>
     <skos:member>
@@ -938,17 +1113,23 @@
             <skos:broader rdf:resource="http://www.yso.fi/onto/yso/p6479"/>
             <skos:altLabel xml:lang="sv">normanner</skos:altLabel>
             <skos:prefLabel xml:lang="sv">normander</skos:prefLabel>
+            <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+            <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
           </skos:Concept>
         </skos:narrower>
         <skos:prefLabel xml:lang="sv">vikingar</skos:prefLabel>
+        <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+        <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
       </skos:Concept>
     </skos:member>
     <skos:member>
       <skos:Concept rdf:about="http://www.yso.fi/onto/yso/p26858">
         <skos:prefLabel xml:lang="en">ziggurats</skos:prefLabel>
         <skos:altLabel xml:lang="sv">zikkurat</skos:altLabel>
+        <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
         <skos:prefLabel xml:lang="fi">zikkuratit</skos:prefLabel>
         <skos:altLabel xml:lang="sv">ziqqurrat</skos:altLabel>
+        <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
         <skos:prefLabel xml:lang="sv">ziqqurat</skos:prefLabel>
         <skos:altLabel xml:lang="fi">zigguratit</skos:altLabel>
         <skos:altLabel xml:lang="sv">trappstegspyramider</skos:altLabel>
@@ -962,6 +1143,8 @@
         <skos:prefLabel xml:lang="sv">folkvandringarna</skos:prefLabel>
         <skos:prefLabel xml:lang="en">migration of peoples</skos:prefLabel>
         <skos:prefLabel xml:lang="fi">kansainvaellukset</skos:prefLabel>
+        <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+        <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
       </skos:Concept>
     </skos:member>
     <skos:member rdf:resource="http://www.yso.fi/onto/yso/p7785"/>
@@ -975,10 +1158,14 @@
             <skos:prefLabel xml:lang="sv">sigill</skos:prefLabel>
             <skos:related rdf:resource="http://www.yso.fi/onto/yso/p8810"/>
             <skos:prefLabel xml:lang="fi">sinetit</skos:prefLabel>
+            <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+            <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
           </skos:Concept>
         </skos:related>
         <skos:altLabel xml:lang="sv">sigillvetenskap</skos:altLabel>
         <skos:prefLabel xml:lang="sv">sigillografi</skos:prefLabel>
+        <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+        <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
       </skos:Concept>
     </skos:member>
     <skos:member rdf:resource="http://www.yso.fi/onto/yso/p18569"/>
@@ -990,6 +1177,8 @@
         <skos:prefLabel xml:lang="sv">vikingafärder</skos:prefLabel>
         <skos:prefLabel xml:lang="fi">viikinkiretket</skos:prefLabel>
         <skos:prefLabel xml:lang="en">Viking raids</skos:prefLabel>
+        <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+        <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
       </skos:Concept>
     </skos:member>
     <skos:member rdf:resource="http://www.yso.fi/onto/yso/p14174"/>
@@ -1000,6 +1189,8 @@
         <skos:altLabel xml:lang="sv">bosättningshistoria</skos:altLabel>
         <skos:altLabel xml:lang="sv">kolonisationshistoria</skos:altLabel>
         <skos:prefLabel xml:lang="en">settlement history</skos:prefLabel>
+        <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+        <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
       </skos:Concept>
     </skos:member>
     <skos:member rdf:resource="http://www.yso.fi/onto/yso/p7346"/>
@@ -1011,9 +1202,8 @@
         <skos:prefLabel xml:lang="sv">mykensk kultur</skos:prefLabel>
         <skos:broader>
           <skos:Concept rdf:about="http://www.yso.fi/onto/yso/p7429">
-            <skos:prefLabel xml:lang="fi">aigeialainen kulttuuri</skos:prefLabel>
-            <skos:prefLabel xml:lang="sv">egeisk kultur</skos:prefLabel>
-            <skos:altLabel xml:lang="fi">kreetalais-mykeneläinen kulttuuri</skos:altLabel>
+            <skos:altLabel xml:lang="sv">kretensisk-mykensk kultur</skos:altLabel>
+            <skos:prefLabel xml:lang="en">Aegean culture</skos:prefLabel>
             <skos:narrower rdf:resource="http://www.yso.fi/onto/yso/p10073"/>
             <skos:narrower>
               <skos:Concept rdf:about="http://www.yso.fi/onto/yso/p7428">
@@ -1021,13 +1211,20 @@
                 <skos:prefLabel xml:lang="en">Minoan culture</skos:prefLabel>
                 <skos:broader rdf:resource="http://www.yso.fi/onto/yso/p7429"/>
                 <skos:prefLabel xml:lang="sv">minoisk kultur</skos:prefLabel>
+                <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+                <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
               </skos:Concept>
             </skos:narrower>
-            <skos:altLabel xml:lang="sv">kretensisk-mykensk kultur</skos:altLabel>
-            <skos:prefLabel xml:lang="en">Aegean culture</skos:prefLabel>
+            <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+            <skos:prefLabel xml:lang="sv">egeisk kultur</skos:prefLabel>
+            <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
+            <skos:prefLabel xml:lang="fi">aigeialainen kulttuuri</skos:prefLabel>
+            <skos:altLabel xml:lang="fi">kreetalais-mykeneläinen kulttuuri</skos:altLabel>
           </skos:Concept>
         </skos:broader>
         <skos:prefLabel xml:lang="fi">mykeneläinen kulttuuri</skos:prefLabel>
+        <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+        <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
       </skos:Concept>
     </skos:member>
     <skos:member>
@@ -1049,27 +1246,35 @@
                     <skos:prefLabel xml:lang="fi">piirtokirjoitukset</skos:prefLabel>
                     <skos:prefLabel xml:lang="sv">inskrifter</skos:prefLabel>
                     <skos:related>
-                      <skos:Concept rdf:about="http://www.yso.fi/onto/yso/p21084">
-                        <skos:prefLabel xml:lang="fi">hautakirjoitukset</skos:prefLabel>
+                      <yso-meta:Concept rdf:about="http://www.yso.fi/onto/yso/p21084">
+                        <skos:related rdf:resource="http://www.yso.fi/onto/yso/p10986"/>
+                        <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+                        <skos:altLabel xml:lang="sv">epitafier</skos:altLabel>
                         <skos:prefLabel xml:lang="sv">gravinskrifter</skos:prefLabel>
                         <skos:altLabel xml:lang="en">tombstone inscriptions</skos:altLabel>
-                        <skos:altLabel xml:lang="sv">epitafier</skos:altLabel>
+                        <skos:prefLabel xml:lang="fi">hautakirjoitukset</skos:prefLabel>
                         <skos:altLabel xml:lang="fi">epitafit</skos:altLabel>
-                        <skos:related rdf:resource="http://www.yso.fi/onto/yso/p10986"/>
-                        <skos:altLabel xml:lang="sv">gravskrifter</skos:altLabel>
                         <skos:prefLabel xml:lang="en">epitaphs</skos:prefLabel>
-                      </skos:Concept>
+                        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+                        <skos:altLabel xml:lang="sv">gravskrifter</skos:altLabel>
+                      </yso-meta:Concept>
                     </skos:related>
                     <skos:related rdf:resource="http://www.yso.fi/onto/yso/p8714"/>
                     <skos:altLabel xml:lang="fi">inskriptiot</skos:altLabel>
                     <skos:prefLabel xml:lang="en">inscriptions</skos:prefLabel>
+                    <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+                    <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
                   </skos:Concept>
                 </skos:related>
                 <skos:altLabel xml:lang="fi">epigrafiikka</skos:altLabel>
                 <skos:prefLabel xml:lang="fi">epigrafia</skos:prefLabel>
+                <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+                <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
               </skos:Concept>
             </skos:related>
             <skos:prefLabel xml:lang="sv">paleografi</skos:prefLabel>
+            <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+            <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
           </skos:Concept>
         </skos:related>
         <skos:related>
@@ -1078,9 +1283,13 @@
             <skos:prefLabel xml:lang="fi">papyrukset</skos:prefLabel>
             <skos:related rdf:resource="http://www.yso.fi/onto/yso/p8713"/>
             <skos:prefLabel xml:lang="en">papyri</skos:prefLabel>
+            <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+            <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
           </skos:Concept>
         </skos:related>
         <skos:prefLabel xml:lang="en">papyrology</skos:prefLabel>
+        <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+        <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
       </skos:Concept>
     </skos:member>
     <skos:member rdf:resource="http://www.yso.fi/onto/yso/p2195"/>
@@ -1091,6 +1300,8 @@
         <skos:prefLabel xml:lang="sv">Induskulturen</skos:prefLabel>
         <skos:prefLabel xml:lang="fi">Indus-kulttuuri</skos:prefLabel>
         <skos:prefLabel xml:lang="en">Indus culture</skos:prefLabel>
+        <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+        <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
       </skos:Concept>
     </skos:member>
     <skos:member rdf:resource="http://www.yso.fi/onto/yso/p7428"/>
@@ -1099,6 +1310,8 @@
         <skos:prefLabel xml:lang="sv">fenicisk kultur</skos:prefLabel>
         <skos:prefLabel xml:lang="en">Phoenician culture</skos:prefLabel>
         <skos:prefLabel xml:lang="fi">foinikialainen kulttuuri</skos:prefLabel>
+        <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+        <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
       </skos:Concept>
     </skos:member>
     <skos:member>
@@ -1106,6 +1319,8 @@
         <skos:prefLabel xml:lang="fi">egyptologit</skos:prefLabel>
         <skos:prefLabel xml:lang="sv">egyptologer</skos:prefLabel>
         <skos:prefLabel xml:lang="en">Egyptologists</skos:prefLabel>
+        <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+        <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
       </skos:Concept>
     </skos:member>
     <skos:member rdf:resource="http://www.yso.fi/onto/yso/p2557"/>
@@ -1116,6 +1331,8 @@
         <skos:prefLabel xml:lang="en">Great Wall of China</skos:prefLabel>
         <skos:altLabel xml:lang="sv">Kinesiska muren</skos:altLabel>
         <skos:prefLabel xml:lang="sv">kinesiska muren</skos:prefLabel>
+        <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+        <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Individual"/>
       </skos:Concept>
     </skos:member>
     <skos:member>
@@ -1123,6 +1340,8 @@
         <skos:prefLabel xml:lang="sv">etruskologi</skos:prefLabel>
         <skos:prefLabel xml:lang="fi">etruskologia</skos:prefLabel>
         <skos:prefLabel xml:lang="en">etruscology</skos:prefLabel>
+        <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+        <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
       </skos:Concept>
     </skos:member>
     <skos:member>
@@ -1132,6 +1351,8 @@
         <skos:altLabel xml:lang="sv">östliga handelsvägar</skos:altLabel>
         <skos:altLabel xml:lang="fi">idäntiet</skos:altLabel>
         <skos:prefLabel xml:lang="sv">handelsvägar</skos:prefLabel>
+        <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+        <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
       </skos:Concept>
     </skos:member>
     <skos:member>
@@ -1141,6 +1362,8 @@
         <skos:altLabel xml:lang="sv">bosättningsorter</skos:altLabel>
         <skos:altLabel xml:lang="sv">boningsorter</skos:altLabel>
         <skos:prefLabel xml:lang="sv">boplatser</skos:prefLabel>
+        <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+        <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
       </skos:Concept>
     </skos:member>
     <skos:member rdf:resource="http://www.yso.fi/onto/yso/p8714"/>
@@ -1156,6 +1379,8 @@
         <skos:prefLabel xml:lang="fi">kykladinen kulttuuri</skos:prefLabel>
         <skos:altLabel xml:lang="sv">cykladisk kultur</skos:altLabel>
         <skos:prefLabel xml:lang="en">Cycladic culture</skos:prefLabel>
+        <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+        <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
       </skos:Concept>
     </skos:member>
     <skos:member rdf:resource="http://www.yso.fi/onto/yso/p29706"/>
@@ -1166,6 +1391,8 @@
         <skos:prefLabel xml:lang="sv">epigram</skos:prefLabel>
         <skos:prefLabel xml:lang="fi">epigrammit</skos:prefLabel>
         <skos:prefLabel xml:lang="en">epigrams</skos:prefLabel>
+        <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+        <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
       </skos:Concept>
     </skos:member>
   </skos:Collection>
@@ -1186,6 +1413,8 @@
         <skos:prefLabel xml:lang="sv">lag om fornminnen</skos:prefLabel>
         <skos:altLabel xml:lang="sv">fornminneslagen</skos:altLabel>
         <skos:prefLabel xml:lang="fi">muinaismuistolaki</skos:prefLabel>
+        <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+        <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Individual"/>
       </skos:Concept>
     </skos:member>
     <skos:member rdf:resource="http://www.yso.fi/onto/yso/p23677"/>
@@ -1222,6 +1451,8 @@
         <skos:prefLabel xml:lang="sv">bronsspeglar</skos:prefLabel>
         <skos:prefLabel xml:lang="fi">pronssipeilit</skos:prefLabel>
         <skos:prefLabel xml:lang="en">bronze mirrors</skos:prefLabel>
+        <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+        <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
       </skos:Concept>
     </skos:member>
   </skos:Collection>
@@ -1234,6 +1465,8 @@
     <skos:prefLabel xml:lang="fi">arkeologit</skos:prefLabel>
     <skos:prefLabel xml:lang="en">archaeologists</skos:prefLabel>
     <skos:prefLabel xml:lang="sv">arkeologer</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+    <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
   </skos:Concept>
   <skos:Collection rdf:about="http://www.yso.fi/onto/yso/p26533">
     <skos:member rdf:resource="http://www.yso.fi/onto/yso/p29706"/>
@@ -1256,6 +1489,8 @@
     <skos:prefLabel xml:lang="en">phosphate analysis</skos:prefLabel>
     <skos:prefLabel xml:lang="sv">fosfatanalys</skos:prefLabel>
     <skos:prefLabel xml:lang="fi">fosfaattianalyysi</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+    <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
   </skos:Concept>
   <skos:Collection rdf:about="http://www.yso.fi/onto/yso/p26532">
     <skos:member rdf:resource="http://www.yso.fi/onto/yso/p23386"/>
@@ -1275,6 +1510,8 @@
         <skos:altLabel xml:lang="sv">aDNA</skos:altLabel>
         <skos:altLabel xml:lang="en">fossil DNA</skos:altLabel>
         <skos:prefLabel xml:lang="en">ancient DNA</skos:prefLabel>
+        <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+        <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
       </skos:Concept>
     </skos:member>
   </skos:Collection>
@@ -1293,6 +1530,8 @@
         <skos:broader rdf:resource="http://www.yso.fi/onto/yso/p4740"/>
         <skos:altLabel xml:lang="fi">vasarakirveskulttuuri</skos:altLabel>
         <skos:prefLabel xml:lang="sv">snörkeramiska kulturen</skos:prefLabel>
+        <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+        <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
       </skos:Concept>
     </skos:narrower>
     <skos:narrower>
@@ -1301,6 +1540,8 @@
         <skos:prefLabel xml:lang="en">Kunda culture</skos:prefLabel>
         <skos:broader rdf:resource="http://www.yso.fi/onto/yso/p4740"/>
         <skos:prefLabel xml:lang="sv">Kundakulturen</skos:prefLabel>
+        <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+        <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
       </skos:Concept>
     </skos:narrower>
     <skos:narrower>
@@ -1309,14 +1550,19 @@
         <skos:prefLabel xml:lang="fi">megaliittikulttuuri</skos:prefLabel>
         <skos:broader rdf:resource="http://www.yso.fi/onto/yso/p4740"/>
         <skos:prefLabel xml:lang="en">Megalithic culture</skos:prefLabel>
+        <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+        <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
       </skos:Concept>
     </skos:narrower>
+    <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
     <skos:narrower>
       <skos:Concept rdf:about="http://www.yso.fi/onto/yso/p11111">
         <skos:prefLabel xml:lang="fi">kuoppakeraaminen kulttuuri</skos:prefLabel>
         <skos:prefLabel xml:lang="sv">gropkeramiska kulturen</skos:prefLabel>
         <skos:broader rdf:resource="http://www.yso.fi/onto/yso/p4740"/>
         <skos:prefLabel xml:lang="en">Pitted Ware culture</skos:prefLabel>
+        <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+        <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
       </skos:Concept>
     </skos:narrower>
     <skos:narrower>
@@ -1325,6 +1571,8 @@
         <skos:prefLabel xml:lang="sv">kamkeramiska kulturen</skos:prefLabel>
         <skos:broader rdf:resource="http://www.yso.fi/onto/yso/p4740"/>
         <skos:prefLabel xml:lang="en">Comb Ceramic culture</skos:prefLabel>
+        <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+        <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
       </skos:Concept>
     </skos:narrower>
     <skos:prefLabel xml:lang="fi">kivikautiset kulttuurit</skos:prefLabel>
@@ -1334,6 +1582,8 @@
         <skos:prefLabel xml:lang="sv">Komsakulturen</skos:prefLabel>
         <skos:broader rdf:resource="http://www.yso.fi/onto/yso/p4740"/>
         <skos:prefLabel xml:lang="fi">Komsan kulttuuri</skos:prefLabel>
+        <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+        <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
       </skos:Concept>
     </skos:narrower>
     <skos:narrower>
@@ -1342,14 +1592,19 @@
         <skos:prefLabel xml:lang="sv">Kiukaiskulturen</skos:prefLabel>
         <skos:broader rdf:resource="http://www.yso.fi/onto/yso/p4740"/>
         <skos:prefLabel xml:lang="fi">Kiukaisten kulttuuri</skos:prefLabel>
+        <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+        <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
       </skos:Concept>
     </skos:narrower>
+    <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
     <skos:narrower>
       <skos:Concept rdf:about="http://www.yso.fi/onto/yso/p10826">
         <skos:prefLabel xml:lang="en">Askola culture</skos:prefLabel>
         <skos:prefLabel xml:lang="fi">Askolan kulttuuri</skos:prefLabel>
         <skos:broader rdf:resource="http://www.yso.fi/onto/yso/p4740"/>
         <skos:prefLabel xml:lang="sv">Askolakulturen</skos:prefLabel>
+        <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+        <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
       </skos:Concept>
     </skos:narrower>
     <skos:prefLabel xml:lang="en">Stone Age cultures</skos:prefLabel>
@@ -1359,6 +1614,8 @@
         <skos:prefLabel xml:lang="en">Suomusjärvi culture</skos:prefLabel>
         <skos:broader rdf:resource="http://www.yso.fi/onto/yso/p4740"/>
         <skos:prefLabel xml:lang="sv">Suomusjärvikulturen</skos:prefLabel>
+        <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+        <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
       </skos:Concept>
     </skos:narrower>
   </skos:Concept>
@@ -1371,8 +1628,12 @@
         <skos:prefLabel xml:lang="sv">asbestkeramik</skos:prefLabel>
         <skos:related rdf:resource="http://www.yso.fi/onto/yso/p1421"/>
         <skos:prefLabel xml:lang="fi">asbestikeramiikka</skos:prefLabel>
+        <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+        <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
       </skos:Concept>
     </skos:related>
     <skos:prefLabel xml:lang="sv">textilkeramik</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://www.yso.fi/onto/yso/"/>
+    <rdf:type rdf:resource="http://www.yso.fi/onto/yso-meta/Concept"/>
   </skos:Concept>
 </rdf:RDF>

--- a/tests/corpora/archaeology/yso-archaeology.ttl
+++ b/tests/corpora/archaeology/yso-archaeology.ttl
@@ -1,704 +1,840 @@
-@prefix kulometa: <http://www.yso.fi/onto/kulo-meta/> .
-@prefix ysa-meta: <http://www.yso.fi/onto/ysa-meta/> .
-@prefix owl:   <http://www.w3.org/2002/07/owl#> .
-@prefix ysa:   <http://www.yso.fi/onto/ysa/> .
-@prefix xhv:   <http://www.w3.org/1999/xhtml/vocab#> .
-@prefix gtkmeta: <http://www.yso.fi/onto/gtk-meta/> .
-@prefix skos:  <http://www.w3.org/2004/02/skos/core#> .
-@prefix allars: <http://www.yso.fi/onto/allars/> .
-@prefix ns2:   <http://spinrdf.org/spin#> .
-@prefix ns1:   <http://spinrdf.org/sp#> .
-@prefix yso-update: <http://www.yso.fi/onto/yso-update/> .
-@prefix ns3:   <http://metadataregistry.org/uri/profile/regap/> .
-@prefix taometa: <http://www.yso.fi/onto/tao-meta/> .
-@prefix kitometa: <http://www.yso.fi/onto/kito-meta/> .
-@prefix yso:   <http://www.yso.fi/onto/yso/> .
+@prefix afometa:       <http://www.yso.fi/onto/afo-meta/> .
+@prefix allars:        <http://www.yso.fi/onto/allars/> .
+@prefix allars-meta:   <http://www.yso.fi/onto/allars-meta/> .
+@prefix dc:            <http://purl.org/dc/elements/1.1/> .
+@prefix dcam:          <http://purl.org/dc/dcam/> .
+@prefix dct:           <http://purl.org/dc/terms/> .
+@prefix dcterms:       <http://purl.org/dc/terms/> .
+@prefix dsv:           <http://purl.org/iso25964/DataSet/Versioning#> .
+@prefix foaf:          <http://xmlns.com/foaf/0.1/> .
+@prefix gtkmeta:       <http://www.yso.fi/onto/gtk-meta/> .
+@prefix isothes:       <http://purl.org/iso25964/skos-thes#> .
+@prefix juho:          <http://www.yso.fi/onto/juho/> .
+@prefix juhometa:      <http://www.yso.fi/onto/juho-meta/> .
+@prefix jupometa:      <http://www.yso.fi/onto/jupo-meta/> .
+@prefix kauno:         <http://www.yso.fi/onto/kauno/> .
+@prefix kaunometa:     <http://www.yso.fi/onto/kauno-meta/> .
+@prefix kitometa:      <http://www.yso.fi/onto/kito-meta/> .
+@prefix koko:          <http://www.yso.fi/onto/koko/> .
+@prefix koko-meta:     <http://www.yso.fi/onto/koko-meta/> .
+@prefix ktometa:       <http://www.yso.fi/onto/kto-meta/> .
+@prefix kulometa:      <http://www.yso.fi/onto/kulo-meta/> .
+@prefix lcsh:          <http://id.loc.gov/authorities/subjects> .
+@prefix liitometa:     <http://www.yso.fi/onto/liito-meta/> .
+@prefix lukemeta:      <http://www.yso.fi/onto/luke-meta/> .
+@prefix maometa:       <http://www.yso.fi/onto/mao-meta/> .
+@prefix merometa:      <http://www.yso.fi/onto/mero-meta/> .
+@prefix musometa:      <http://www.yso.fi/onto/muso-meta/> .
+@prefix ns1:           <http://spinrdf.org/sp#> .
+@prefix ns2:           <http://spinrdf.org/spin#> .
+@prefix ns3:           <http://metadataregistry.org/uri/profile/regap/> .
+@prefix oikometa:      <http://www.yso.fi/onto/oiko-meta/> .
+@prefix om:            <http://www.yso.fi/onto/yso-peilaus/2007-03-02/> .
+@prefix owl:           <http://www.w3.org/2002/07/owl#> .
+@prefix puhometa:      <http://www.yso.fi/onto/puho-meta/> .
+@prefix rdau:          <http://rdaregistry.info/Elements/u/> .
+@prefix rdf:           <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:          <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sd:            <http://www.w3.org/ns/sparql-service-description#> .
+@prefix sh:            <http://purl.org/skos-history/> .
+@prefix skos:          <http://www.w3.org/2004/02/skos/core#> .
+@prefix skosext:       <http://purl.org/finnonto/schema/skosext#> .
+@prefix sotometa:      <http://www.yso.fi/onto/soto-meta/> .
+@prefix taometa:       <http://www.yso.fi/onto/tao-meta/> .
+@prefix termed:        <termed:property:> .
+@prefix terometa:      <http://www.yso.fi/onto/tero-meta/> .
+@prefix tsrmeta:       <http://www.yso.fi/onto/tsr-meta/> .
+@prefix valometa:      <http://www.yso.fi/onto/valo-meta/> .
+@prefix xhv:           <http://www.w3.org/1999/xhtml/vocab#> .
+@prefix xml:           <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd:           <http://www.w3.org/2001/XMLSchema#> .
+@prefix ysa:           <http://www.yso.fi/onto/ysa/> .
+@prefix ysa-meta:      <http://www.yso.fi/onto/ysa-meta/> .
+@prefix yso:           <http://www.yso.fi/onto/yso/> .
+@prefix yso-kehitys:   <http://www.yso.fi/onto/yso-kehitys/> .
+@prefix yso-meta:      <http://www.yso.fi/onto/yso-meta/> .
+@prefix yso-meta1:     <http://www.yso.fi/onto/yso-meta/2007-03-02/> .
 @prefix yso-translate: <http://www.yso.fi/onto/yso-translate/> .
-@prefix foaf:  <http://xmlns.com/foaf/0.1/> .
-@prefix juho:  <http://www.yso.fi/onto/juho/> .
-@prefix juhometa: <http://www.yso.fi/onto/juho-meta/> .
-@prefix musometa: <http://www.yso.fi/onto/muso-meta/> .
-@prefix skosext: <http://purl.org/finnonto/schema/skosext#> .
-@prefix oikometa: <http://www.yso.fi/onto/oiko-meta/> .
-@prefix lukemeta: <http://www.yso.fi/onto/luke-meta/> .
-@prefix zbwext: <http://zbw.eu/namespaces/zbw-extensions/> .
-@prefix maometa: <http://www.yso.fi/onto/mao-meta/> .
-@prefix termed: <termed:property:> .
-@prefix lcsh:  <http://id.loc.gov/authorities/subjects> .
-@prefix dcam:  <http://purl.org/dc/dcam/> .
-@prefix dsv:   <http://purl.org/iso25964/DataSet/Versioning#> .
-@prefix terometa: <http://www.yso.fi/onto/tero-meta/> .
-@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
-@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
-@prefix kaunometa: <http://www.yso.fi/onto/kauno-meta/> .
-@prefix yso-meta: <http://www.yso.fi/onto/yso-meta/> .
-@prefix yso-kehitys: <http://www.yso.fi/onto/yso-kehitys/> .
-@prefix sd:    <http://www.w3.org/ns/sparql-service-description#> .
-@prefix tsrmeta: <http://www.yso.fi/onto/tsr-meta/> .
-@prefix puhometa: <http://www.yso.fi/onto/puho-meta/> .
-@prefix valometa: <http://www.yso.fi/onto/valo-meta/> .
-@prefix rdau:  <http://rdaregistry.info/Elements/u/> .
-@prefix dct:   <http://purl.org/dc/terms/> .
-@prefix sh:    <http://purl.org/skos-history/> .
-@prefix ktometa: <http://www.yso.fi/onto/kto-meta/> .
-@prefix merometa: <http://www.yso.fi/onto/mero-meta/> .
-@prefix isothes: <http://purl.org/iso25964/skos-thes#> .
-@prefix yso-meta1: <http://www.yso.fi/onto/yso-meta/2007-03-02/> .
-@prefix om:    <http://www.yso.fi/onto/yso-peilaus/2007-03-02/> .
-@prefix sotometa: <http://www.yso.fi/onto/soto-meta/> .
-@prefix koko-meta: <http://www.yso.fi/onto/koko-meta/> .
-@prefix liitometa: <http://www.yso.fi/onto/liito-meta/> .
-@prefix jupometa: <http://www.yso.fi/onto/jupo-meta/> .
-@prefix kauno: <http://www.yso.fi/onto/kauno/> .
-@prefix allars-meta: <http://www.yso.fi/onto/allars-meta/> .
-@prefix afometa: <http://www.yso.fi/onto/afo-meta/> .
-@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-@prefix koko:  <http://www.yso.fi/onto/koko/> .
-@prefix dc:    <http://purl.org/dc/elements/1.1/> .
+@prefix yso-update:    <http://www.yso.fi/onto/yso-update/> .
+@prefix ysokehitys:    <http://www.yso.fi/onto/yso-kehitys/> .
+@prefix ysometa:       <http://www.yso.fi/onto/yso-meta/2007-03-02/> .
+@prefix ysotranslate:  <http://www.yso.fi/onto/yso-translate/> .
+@prefix ysoupdate:     <http://www.yso.fi/onto/yso-update/> .
+@prefix zbwext:        <http://zbw.eu/namespaces/zbw-extensions/> .
 
-yso:p12484  a           skos:Concept ;
+yso:p12484  rdf:type    skos:Concept , yso-meta:Concept ;
         skos:broader    yso:p4624 ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "paleolitisk tid"@sv , "paleoliittinen kausi"@fi , "Paleolithic period"@en .
 
-yso:p4626  a            skos:Concept ;
+yso:p4626  rdf:type     skos:Concept , yso-meta:Concept ;
         skos:broader    yso:p4622 ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "Early Metal Age"@en , "varhaismetallikausi"@fi , "tidig metallålder"@sv ;
         skos:related    yso:p2558 , yso:p4625 .
 
-yso:p12463  a           skos:Concept ;
+yso:p12463  rdf:type    skos:Concept , yso-meta:Concept ;
+        skos:inScheme   yso: ;
         skos:narrower   yso:p13027 ;
         skos:prefLabel  "förhistorisk konst"@sv , "esihistoriallinen taide"@fi , "prehistoric art"@en .
 
-yso:p29406  a           skos:Concept ;
-        skos:altLabel   "riimututkimus"@fi , "runforskning"@sv ;
-        skos:prefLabel  "runologia"@fi , "runologi"@sv , "runology"@en ;
+yso:p29406  rdf:type    yso-meta:Concept , skos:Concept ;
+        skos:altLabel   "runforskning"@sv , "riimututkimus"@fi ;
+        skos:inScheme   yso: ;
+        skos:prefLabel  "runologia"@fi , "runology"@en , "runologi"@sv ;
         skos:related    yso:p14588 , yso:p6218 .
 
-yso:p12179  a           skos:Concept ;
+yso:p12179  rdf:type    skos:Concept , yso-meta:Concept ;
         skos:altLabel   "balsamointi"@fi ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "balsamering"@sv , "palsamointi"@fi , "embalming"@en ;
         skos:related    yso:p2193 .
 
-yso:p26540  a        skos:Collection ;
+yso:p26540  rdf:type  skos:Collection ;
         skos:member  yso:p4622 , yso:p12738 , yso:p24443 , yso:p6479 , yso:p26858 , yso:p19740 , yso:p1894 , yso:p7785 , yso:p8810 , yso:p18569 , yso:p20280 , yso:p2192 , yso:p7141 , yso:p15031 , yso:p14174 , yso:p16323 , yso:p7346 , yso:p8307 , yso:p3973 , yso:p10073 , yso:p8713 , yso:p2195 , yso:p10986 , yso:p2193 , yso:p6780 , yso:p7428 , yso:p8888 , yso:p1747 , yso:p2557 , yso:p7347 , yso:p22768 , yso:p13721 , yso:p1209 , yso:p14303 , yso:p8714 , yso:p12179 , yso:p27547 , yso:p8712 , yso:p2194 , yso:p7429 , yso:p21820 , yso:p10295 , yso:p29706 .
 
-yso:p8869  a            skos:Concept ;
+yso:p8869  rdf:type     skos:Concept , yso-meta:Concept ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "laivalöydöt"@fi , "ship finds"@en , "skeppsfynd"@sv ;
         skos:related    yso:p5340 , yso:p8993 , yso:p8867 .
 
-yso:p2557  a            skos:Concept ;
+yso:p2557  rdf:type     skos:Concept , yso-meta:Concept ;
         skos:broader    yso:p2558 ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "ristiretkiaika"@fi , "Age of the Crusades"@en , "korstågstiden"@sv .
 
-yso:p2194  a            skos:Concept ;
+yso:p2194  rdf:type     skos:Concept , yso-meta:Concept ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "hieroglyfit"@fi , "hieroglyphs"@en , "hieroglyfer"@sv ;
         skos:related    yso:p2192 .
 
-yso:p12897  a           skos:Concept ;
+yso:p12897  rdf:type    skos:Concept , yso-meta:Concept ;
         skos:altLabel   "muinaisjäännösalueet"@fi ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "fornminnesområden"@sv , "muinaismuistoalueet"@fi , "historic sites"@en .
 
-yso:p1209  a            skos:Concept ;
+yso:p1209  rdf:type     skos:Concept , yso-meta:Concept ;
         skos:altLabel   "östliga handelsvägar"@sv , "idäntiet"@fi ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "trade routes"@en , "kauppatiet"@fi , "handelsvägar"@sv .
 
-yso:p14173  a           skos:Concept ;
+yso:p14173  rdf:type    skos:Concept , yso-meta:Concept ;
         skos:altLabel   "arkeologiset kaivaukset"@fi , "arkeologiska utgrävningar"@sv ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "kaivaukset"@fi , "excavations"@en , "utgrävningar"@sv ;
         skos:related    yso:p5340 .
 
-yso:p13564  a           skos:Concept ;
+yso:p13564  rdf:type    skos:Concept , yso-meta:Concept ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "thermoluminescence"@en , "termoluminiscens"@sv , "termoluminesenssi"@fi ;
         skos:related    yso:p7804 .
 
-yso:p7429  a            skos:Concept ;
-        skos:altLabel   "kreetalais-mykeneläinen kulttuuri"@fi , "kretensisk-mykensk kultur"@sv ;
+yso:p7429  rdf:type     skos:Concept , yso-meta:Concept ;
+        skos:altLabel   "kretensisk-mykensk kultur"@sv , "kreetalais-mykeneläinen kulttuuri"@fi ;
+        skos:inScheme   yso: ;
         skos:narrower   yso:p10073 , yso:p7428 ;
-        skos:prefLabel  "aigeialainen kulttuuri"@fi , "egeisk kultur"@sv , "Aegean culture"@en .
+        skos:prefLabel  "Aegean culture"@en , "egeisk kultur"@sv , "aigeialainen kulttuuri"@fi .
 
-yso:p7784  a            skos:Concept ;
+yso:p7784  rdf:type     skos:Concept , yso-meta:Concept ;
         skos:altLabel   "tree-ring dating"@en ;
         skos:broader    yso:p7785 ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "dendrokronologi"@sv , "dendrochronology"@en , "dendrokronologia"@fi ;
         skos:related    yso:p7804 .
 
-yso:p26569  a        skos:Collection ;
+yso:p26569  rdf:type  skos:Collection ;
         skos:member  yso:p7141 , yso:p8307 , yso:p8810 .
 
-yso:p8714  a            skos:Concept ;
+yso:p8714  rdf:type     skos:Concept , yso-meta:Concept ;
         skos:altLabel   "epigrafiikka"@fi ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "epigraphy"@en , "epigrafi"@sv , "epigrafia"@fi ;
         skos:related    yso:p8712 , yso:p10986 .
 
-yso:p19258  a           skos:Concept ;
+yso:p19258  rdf:type    skos:Concept , yso-meta:Concept ;
         skos:broader    yso:p4740 ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "Suomusjärven kulttuuri"@fi , "Suomusjärvi culture"@en , "Suomusjärvikulturen"@sv .
 
-yso:p6436  a            skos:Concept ;
+yso:p6436  rdf:type     skos:Concept , yso-meta:Concept ;
         skos:broader    yso:p2558 ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "Pre-Roman Iron Age"@en , "esiroomalainen rautakausi"@fi , "förromersk järnålder"@sv .
 
-yso:p11052  a           skos:Concept ;
+yso:p11052  rdf:type    skos:Concept , yso-meta:Concept ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "shorelevel displacement"@en , "strandförskjutning"@sv , "rannansiirtyminen"@fi ;
         skos:related    yso:p25576 .
 
-yso:p25576  a           skos:Concept ;
+yso:p25576  rdf:type    skos:Concept , yso-meta:Concept ;
         skos:altLabel   "forntida stränder"@sv ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "muinaisrannat"@fi , "fornstränder"@sv , "raised shorelines"@en ;
         skos:related    yso:p11052 .
 
-yso:p21412  a           skos:Concept ;
+yso:p21412  rdf:type    skos:Concept , yso-meta:Concept ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "makrofossiilit"@fi , "makrofossiler"@sv , "macrofossils"@en ;
         skos:related    yso:p5340 , yso:p20619 .
 
-yso:p29706  a           skos:Concept ;
+yso:p29706  rdf:type    skos:Concept , yso-meta:Concept ;
         skos:altLabel   "kasviarkeologia"@fi , "växtarkeologi"@sv ;
         skos:broader    yso:p1265 ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "archaeobotany"@en , "arkeobotanik"@sv , "arkeobotaniikka"@fi .
 
-yso:p5714  a            skos:Concept ;
+yso:p5714  rdf:type     yso-meta:Concept , skos:Concept ;
         skos:broader    yso:p8506 ;
+        skos:inScheme   yso: ;
         skos:narrower   yso:p6477 , yso:p5842 ;
         skos:prefLabel  "prehistoric graves"@en , "muinaishaudat"@fi , "forngravar"@sv ;
         skos:related    yso:p8508 , yso:p17863 , yso:p5713 , yso:p5340 .
 
-yso:p26577  a        skos:Collection ;
+yso:p26577  rdf:type  skos:Collection ;
         skos:member  yso:p8993 .
 
-yso:p22768  a           skos:Concept ;
+yso:p22768  rdf:type    skos:Concept , yso-meta:Individual ;
         skos:altLabel   "Kinesiska muren"@sv ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "Kiinan muuri"@fi , "Great Wall of China"@en , "kinesiska muren"@sv .
 
-yso:p26535  a        skos:Collection ;
+yso:p26535  rdf:type  skos:Collection ;
         skos:member  yso:p2714 , yso:p25576 , yso:p7804 , yso:p20619 , yso:p11052 , yso:p19077 .
 
-yso:p28955  a           skos:Concept ;
+yso:p28955  rdf:type    skos:Concept , yso-meta:Concept ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "bronsspeglar"@sv , "pronssipeilit"@fi , "bronze mirrors"@en .
 
-yso:p20619  a           skos:Concept ;
+yso:p20619  rdf:type    skos:Concept , yso-meta:Concept ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "pollenanalys"@sv , "pollen analysis"@en , "siitepölyanalyysi"@fi ;
         skos:related    yso:p21412 , yso:p7804 .
 
-yso:p5338  a            skos:Concept ;
+yso:p5338  rdf:type     skos:Concept , yso-meta:Concept ;
         skos:altLabel   "luuoppi"@fi ;
+        skos:inScheme   yso: ;
         skos:narrower   yso:p19353 ;
         skos:prefLabel  "osteologia"@fi , "osteology"@en , "osteologi"@sv ;
         skos:related    yso:p5337 .
 
-yso:p26564  a        skos:Collection ;
+yso:p26564  rdf:type  skos:Collection ;
         skos:member  yso:p14374 .
 
-yso:p29572  a           skos:Concept ;
+yso:p29572  rdf:type    skos:Concept , yso-meta:Concept ;
         skos:altLabel   "hautalahjat"@fi , "burial objects"@en , "gravgods"@sv , "hautaesineet"@fi , "gravföremål"@sv ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "grave goods"@en , "gravgåvor"@sv , "hauta-antimet"@fi ;
         skos:related    yso:p5713 .
 
-yso:p23677  a           skos:Concept ;
+yso:p23677  rdf:type    skos:Concept , yso-meta:Individual ;
         skos:altLabel   "Maltan yleissopimus"@fi ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "Europeisk konvention om skydd för det arkeologiska arvet"@sv , "European Convention on the Protection of the Archaeological Heritage"@en , "Eurooppalainen yleissopimus arkeologisen perinnön suojelusta"@fi .
 
-yso:p6218  a            skos:Concept ;
+yso:p6218  rdf:type     skos:Concept , yso-meta:Concept ;
         skos:altLabel   "runor"@sv , "runskrift"@sv ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "riimukirjoitus"@fi , "runinskrift"@sv , "runic writing"@en ;
         skos:related    yso:p29406 .
 
-yso:p10417  a           skos:Concept ;
+yso:p10417  rdf:type    yso-meta:Concept , skos:Concept ;
         skos:altLabel   "relics of antiquity"@en , "fornsaker"@sv ;
         skos:broader    yso:p5340 ;
-        skos:narrower   yso:p10416 , yso:p10415 ;
-        skos:prefLabel  "muinaisesineet"@fi , "antiquities"@en , "fornföremål"@sv .
+        skos:inScheme   yso: ;
+        skos:narrower   yso:p10415 , yso:p10416 ;
+        skos:prefLabel  "antiquities"@en , "muinaisesineet"@fi , "fornföremål"@sv .
 
-yso:p8993  a            skos:Concept ;
+yso:p8993  rdf:type     skos:Concept , yso-meta:Concept ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "shipwrecks (objects)"@en , "vrak"@sv , "hylyt"@fi ;
         skos:related    yso:p8869 .
 
-yso:p29672  a           skos:Concept ;
+yso:p29672  rdf:type    skos:Concept , yso-meta:Concept ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "Hallstatt period"@en , "Hallstattin kulttuuri"@fi , "Hallstattkulturen"@sv ;
         skos:related    yso:p2558 .
 
-yso:p19353  a           skos:Concept ;
+yso:p19353  rdf:type    skos:Concept , yso-meta:Concept ;
         skos:broader    yso:p5338 ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "craniology"@en , "kraniologi"@sv , "kraniologia"@fi .
 
-yso:p21820  a           skos:Concept ;
+yso:p21820  rdf:type    skos:Concept , yso-meta:Concept ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "papyrer"@sv , "papyrukset"@fi , "papyri"@en ;
         skos:related    yso:p8713 .
 
-yso:p6289  a            skos:Concept ;
+yso:p6289  rdf:type     skos:Concept , yso-meta:Concept ;
         skos:altLabel   "clay dishes"@en ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "pottery"@en , "lerkärl"@sv , "saviastiat"@fi .
 
-yso:p26551  a        skos:Collection ;
+yso:p26551  rdf:type  skos:Collection ;
         skos:member  yso:p23386 , yso:p8508 , yso:p29572 , yso:p580 , yso:p21482 , yso:p8506 .
 
-yso:p26530  a        skos:Collection ;
+yso:p26530  rdf:type  skos:Collection ;
         skos:member  yso:p6289 .
 
-yso:p7148  a            skos:Concept ;
+yso:p7148  rdf:type     skos:Concept , yso-meta:Concept ;
         skos:broader    yso:p4740 ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "Kiukainen culture"@en , "Kiukaiskulturen"@sv , "Kiukaisten kulttuuri"@fi .
 
-yso:p4624  a            skos:Concept ;
+yso:p4624  rdf:type     skos:Concept , yso-meta:Concept ;
         skos:broader    yso:p4622 ;
-        skos:narrower   yso:p12484 , yso:p20471 , yso:p9285 ;
-        skos:prefLabel  "Stone Age"@en , "stenåldern"@sv , "kivikausi"@fi .
+        skos:inScheme   yso: ;
+        skos:narrower   yso:p12484 , yso:p9285 , yso:p20471 ;
+        skos:prefLabel  "stenåldern"@sv , "Stone Age"@en , "kivikausi"@fi .
 
-yso:p9505  a         skos:Collection ;
+yso:p9505  rdf:type  skos:Collection ;
         skos:member  yso:p2932 .
 
-yso:p26580  a        skos:Collection ;
+yso:p26580  rdf:type  skos:Collection ;
         skos:member  yso:p25576 , yso:p11052 .
 
-yso:p26559  a        skos:Collection ;
+yso:p26559  rdf:type  skos:Collection ;
         skos:member  yso:p27358 , yso:p23677 .
 
-yso:p8888  a            skos:Concept ;
+yso:p8888  rdf:type     skos:Concept , yso-meta:Concept ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "fenicisk kultur"@sv , "Phoenician culture"@en , "foinikialainen kulttuuri"@fi .
 
-yso:p19077  a           skos:Concept ;
-        skos:altLabel   "C 14-metoden"@sv , "kol-fjorton-datering"@sv , "C-datering"@sv , "C 14 -menetelmä"@fi ;
+yso:p19077  rdf:type    skos:Concept , yso-meta:Concept ;
+        skos:altLabel   "C 14 -menetelmä"@fi , "C-datering"@sv , "C 14-metoden"@sv , "kol-fjorton-datering"@sv ;
         skos:broader    yso:p7804 ;
-        skos:prefLabel  "radiohiiliajoitus"@fi , "radiocarbon dating"@en , "kol-14-datering"@sv .
+        skos:inScheme   yso: ;
+        skos:prefLabel  "radiohiiliajoitus"@fi , "kol-14-datering"@sv , "radiocarbon dating"@en .
 
-yso:p2192  a            skos:Concept ;
+yso:p2192  rdf:type     skos:Concept , yso-meta:Concept ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "egyptologia"@fi , "Egyptology"@en , "egyptologi"@sv ;
         skos:related    yso:p2194 , yso:p2193 , yso:p2195 .
 
-yso:p8867  a            skos:Concept ;
+yso:p8867  rdf:type     skos:Concept , yso-meta:Concept ;
         skos:broader    yso:p8868 ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "marinarkeologi"@sv , "marine archaeology"@en , "meriarkeologia"@fi ;
         skos:related    yso:p8869 .
 
-yso:p20280  a           skos:Concept ;
+yso:p20280  rdf:type    skos:Concept , yso-meta:Concept ;
         skos:altLabel   "normanner"@sv ;
         skos:broader    yso:p6479 ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "Normans"@en , "normannit"@fi , "normander"@sv .
 
-yso:p29546  a           skos:Concept ;
+yso:p29546  rdf:type    skos:Concept , yso-meta:Concept ;
         skos:altLabel   "aDNA"@fi , "aDNA"@sv , "fossil DNA"@en ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "muinais-DNA"@fi , "arkeologiskt dna"@sv , "ancient DNA"@en .
 
-yso:p29717  a           skos:Concept ;
+yso:p29717  rdf:type    skos:Concept , yso-meta:Concept ;
         skos:altLabel   "La Tenen kulttuuri"@fi , "La Tene period"@en ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "Latènekulturen"@sv , "La Tènen kulttuuri"@fi , "La Tène period"@en ;
         skos:related    yso:p2558 .
 
-yso:p29433  a           skos:Concept ;
+yso:p29433  rdf:type    skos:Concept , yso-meta:Concept ;
         skos:broader    yso:p1265 ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "miljöarkeologi"@sv , "environmental archaeology"@en , "ympäristöarkeologia"@fi .
 
-yso:p8712  a            skos:Concept ;
+yso:p8712  rdf:type     skos:Concept , yso-meta:Concept ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "paleografia"@fi , "paleography"@en , "paleografi"@sv ;
         skos:related    yso:p8713 , yso:p8714 .
 
-yso:p8307  a            skos:Concept ;
+yso:p8307  rdf:type     skos:Concept , yso-meta:Concept ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "sfinksit"@fi , "sphinxes"@en , "sfinxer"@sv ;
         skos:related    yso:p5340 .
 
-yso:p20096  a           skos:Concept ;
+yso:p20096  rdf:type    skos:Concept , yso-meta:Concept ;
         skos:broader    yso:p2558 ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "kansainvaellusaika"@fi , "folkvandringstiden"@sv , "migration period"@en .
 
-yso:p19740  a           skos:Concept ;
+yso:p19740  rdf:type    skos:Concept , yso-meta:Concept ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "obeliskit"@fi , "obelisks"@en , "obelisker"@sv ;
         skos:related    yso:p5340 .
 
-yso:p12627  a           skos:Concept ;
+yso:p12627  rdf:type    skos:Concept , yso-meta:Concept ;
         skos:broader    yso:p2558 ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "merovingertiden"@sv , "Vendel Period"@en , "merovingiaika"@fi .
 
-yso:p27547  a           skos:Concept ;
-        skos:altLabel   "trojaborgar"@sv , "jatulintarhat"@en , "trojeborgar"@sv ;
+yso:p27547  rdf:type    yso-meta:Concept , skos:Concept ;
+        skos:altLabel   "jatulintarhat"@en , "trojeborgar"@sv , "trojaborgar"@sv ;
         skos:broader    yso:p14174 ;
-        skos:prefLabel  "jungfrudanser"@sv , "troy towns"@en , "jatulintarhat"@fi ;
+        skos:inScheme   yso: ;
+        skos:prefLabel  "jungfrudanser"@sv , "jatulintarhat"@fi , "troy towns"@en ;
         skos:related    yso:p5340 .
 
-yso:p4740  a            skos:Concept ;
+yso:p4740  rdf:type     skos:Concept , yso-meta:Concept ;
+        skos:inScheme   yso: ;
         skos:narrower   yso:p13489 , yso:p12651 , yso:p14800 , yso:p11111 , yso:p7751 , yso:p4739 , yso:p7148 , yso:p10826 , yso:p19258 ;
         skos:prefLabel  "stenålderskulturer"@sv , "kivikautiset kulttuurit"@fi , "Stone Age cultures"@en .
 
-yso:p1265  a            skos:Concept ;
+yso:p1265  rdf:type     skos:Concept , yso-meta:Concept ;
         skos:altLabel   "muinaistutkimus"@fi , "fornforskning"@sv , "esihistoriallinen arkeologia"@fi , "förhistorisk arkeologi"@sv , "muinaistiede"@fi , "fornkunskap"@sv ;
+        skos:inScheme   yso: , yso:test-scheme ;
         skos:narrower   yso:p11348 , yso:p16476 , yso:p29433 , yso:p18838 , yso:p20339 , yso:p18211 , yso:p29706 , yso:p1264 , yso:p8868 ;
         skos:prefLabel  "arkeologi"@sv , "arkeologia"@fi , "archaeology"@en ;
         skos:related    yso:p28252 .
 
-yso:p26533  a        skos:Collection ;
+yso:p26533  rdf:type  skos:Collection ;
         skos:member  yso:p29706 .
 
-yso:p16323  a           skos:Concept ;
+yso:p16323  rdf:type    skos:Concept , yso-meta:Concept ;
         skos:altLabel   "bosättningshistoria"@sv , "kolonisationshistoria"@sv ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "bebyggelsehistoria"@sv , "asutushistoria"@fi , "settlement history"@en .
 
-yso:p21084  a           skos:Concept ;
-        skos:altLabel   "tombstone inscriptions"@en , "epitafier"@sv , "epitafit"@fi , "gravskrifter"@sv ;
-        skos:prefLabel  "hautakirjoitukset"@fi , "gravinskrifter"@sv , "epitaphs"@en ;
+yso:p21084  rdf:type    yso-meta:Concept , skos:Concept ;
+        skos:altLabel   "epitafier"@sv , "tombstone inscriptions"@en , "epitafit"@fi , "gravskrifter"@sv ;
+        skos:inScheme   yso: ;
+        skos:prefLabel  "gravinskrifter"@sv , "hautakirjoitukset"@fi , "epitaphs"@en ;
         skos:related    yso:p10986 .
 
-yso:p26541  a        skos:Collection ;
+yso:p26541  rdf:type  skos:Collection ;
         skos:member  yso:p23677 .
 
-yso:p14800  a           skos:Concept ;
+yso:p14800  rdf:type    skos:Concept , yso-meta:Concept ;
         skos:broader    yso:p4740 ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "megalitkulturen"@sv , "megaliittikulttuuri"@fi , "Megalithic culture"@en .
 
-yso:p2558  a            skos:Concept ;
+yso:p2558  rdf:type     skos:Concept , yso-meta:Concept ;
         skos:broader    yso:p4622 ;
+        skos:inScheme   yso: ;
         skos:narrower   yso:p12738 , yso:p2557 , yso:p4831 , yso:p20096 , yso:p12627 , yso:p6436 ;
         skos:prefLabel  "rautakausi"@fi , "järnåldern"@sv , "Iron Age"@en ;
         skos:related    yso:p4626 , yso:p29717 , yso:p29672 .
 
-yso:p2195  a            skos:Concept ;
+yso:p2195  rdf:type     skos:Concept , yso-meta:Concept ;
         skos:altLabel   "assyrologia"@fi ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "assyriologia"@fi , "assyriologi"@sv , "assyriology"@en ;
         skos:related    yso:p2192 .
 
-yso:p10073  a           skos:Concept ;
+yso:p10073  rdf:type    skos:Concept , yso-meta:Concept ;
         skos:broader    yso:p7429 ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "Mycenaean culture"@en , "mykensk kultur"@sv , "mykeneläinen kulttuuri"@fi .
 
-yso:p10415  a           skos:Concept ;
+yso:p10415  rdf:type    skos:Concept , yso-meta:Concept ;
         skos:broader    yso:p10417 ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "rahalöydöt"@fi , "myntfynd"@sv , "coin finds"@en ;
         skos:related    yso:p10416 .
 
-yso:p19180  a           skos:Concept ;
+yso:p19180  rdf:type    skos:Concept , yso-meta:Individual ;
         skos:altLabel   "Mesa Verde"@sv , "Mesa Verde (nationalpark)"@sv ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "Mesa Verde"@fi , "Mesa Verde National Park"@en , "Mesa Verde nationalpark"@sv .
 
-yso:p14174  a           skos:Concept ;
+yso:p14174  rdf:type    skos:Concept , yso-meta:Concept ;
+        skos:inScheme   yso: ;
         skos:narrower   yso:p27547 ;
         skos:prefLabel  "labyrinths"@en , "labyrinter"@sv , "labyrintit"@fi ;
         skos:related    yso:p5340 .
 
-yso:p14303  a           skos:Concept ;
+yso:p14303  rdf:type    skos:Concept , yso-meta:Concept ;
         skos:altLabel   "bosättningsorter"@sv , "boningsorter"@sv ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "asuinpaikat"@fi , "places of residence"@en , "boplatser"@sv .
 
-yso:p7785  a            skos:Concept ;
+yso:p7785  rdf:type     skos:Concept , yso-meta:Concept ;
+        skos:inScheme   yso: ;
         skos:narrower   yso:p7784 ;
         skos:prefLabel  "chronology"@en , "kronologia"@fi , "kronologi"@sv ;
         skos:related    yso:p7804 .
 
-yso:p6479  a            skos:Concept ;
+yso:p6479  rdf:type     skos:Concept , yso-meta:Concept ;
+        skos:inScheme   yso: ;
         skos:narrower   yso:p20280 ;
         skos:prefLabel  "Vikings"@en , "viikingit"@fi , "vikingar"@sv .
 
-yso:p10849  a           skos:Concept ;
+yso:p10849  rdf:type    skos:Concept , yso-meta:Concept ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "arkeologit"@fi , "archaeologists"@en , "arkeologer"@sv .
 
-yso:p6074  a            skos:Concept ;
+yso:p6074  rdf:type     skos:Concept , yso-meta:Concept ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "mossfynd"@sv , "bog finds"@en , "suolöydöt"@fi ;
         skos:related    yso:p5340 .
 
-yso:p14374  a           skos:Concept ;
+yso:p14374  rdf:type    skos:Concept , yso-meta:Concept ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "epigram"@sv , "epigrammit"@fi , "epigrams"@en .
 
-yso:p12651  a           skos:Concept ;
+yso:p12651  rdf:type    skos:Concept , yso-meta:Concept ;
         skos:broader    yso:p4740 ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "Kundan kulttuuri"@fi , "Kunda culture"@en , "Kundakulturen"@sv .
 
-yso:p4622  a            skos:Concept ;
+yso:p4622  rdf:type     skos:Concept , yso-meta:Concept ;
         skos:altLabel   "förhistorisk tid"@sv , "esihistoriallinen aika"@fi ;
+        skos:inScheme   yso: ;
         skos:narrower   yso:p2558 , yso:p4624 , yso:p4625 , yso:p4626 ;
         skos:prefLabel  "prehistory"@en , "förhistoria"@sv , "esihistoria"@fi .
 
-yso:p11111  a           skos:Concept ;
+yso:p11111  rdf:type    skos:Concept , yso-meta:Concept ;
         skos:broader    yso:p4740 ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "kuoppakeraaminen kulttuuri"@fi , "gropkeramiska kulturen"@sv , "Pitted Ware culture"@en .
 
-yso:p27358  a           skos:Concept ;
+yso:p27358  rdf:type    skos:Concept , yso-meta:Individual ;
         skos:altLabel   "fornminneslagen"@sv ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "Antiquities Act"@en , "lag om fornminnen"@sv , "muinaismuistolaki"@fi .
 
-yso:p26578  a        skos:Collection ;
+yso:p26578  rdf:type  skos:Collection ;
         skos:member  yso:p2932 .
 
-yso:p26557  a        skos:Collection ;
+yso:p26557  rdf:type  skos:Collection ;
         skos:member  yso:p8712 , yso:p2194 , yso:p21820 , yso:p29406 , yso:p8713 , yso:p6218 , yso:p8714 .
 
-yso:p7751  a            skos:Concept ;
+yso:p7751  rdf:type     skos:Concept , yso-meta:Concept ;
         skos:broader    yso:p4740 ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "kampakeraaminen kulttuuri"@fi , "kamkeramiska kulturen"@sv , "Comb Ceramic culture"@en .
 
-yso:p7346  a            skos:Concept ;
+yso:p7346  rdf:type     skos:Concept , yso-meta:Concept ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "borgberg"@sv , "linnavuoret"@fi , "hill forts"@en ;
         skos:related    yso:p7347 .
 
-yso:p27963  a           skos:Concept ;
-        skos:altLabel   "berginristningar"@sv , "petroglyfer"@sv ;
-        skos:prefLabel  "kalliopiirrokset"@fi , "petroglyphs"@en , "hällristningar"@sv ;
+yso:p27963  rdf:type    yso-meta:Concept , skos:Concept ;
+        skos:altLabel   "petroglyfer"@sv , "berginristningar"@sv ;
+        skos:inScheme   yso: ;
+        skos:prefLabel  "petroglyphs"@en , "kalliopiirrokset"@fi , "hällristningar"@sv ;
         skos:related    yso:p13027 , yso:p27964 .
 
-yso:p1894  a            skos:Concept ;
+yso:p1894  rdf:type     skos:Concept , yso-meta:Concept ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "folkvandringarna"@sv , "migration of peoples"@en , "kansainvaellukset"@fi .
 
-yso:p18211  a           skos:Concept ;
+yso:p18211  rdf:type    skos:Concept , yso-meta:Concept ;
         skos:broader    yso:p1265 ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "molecular archaeology"@en , "molekyyliarkeologia"@fi , "molekylärarkeologi"@sv .
 
-yso:p23386  a           skos:Concept ;
+yso:p23386  rdf:type    skos:Concept , yso-meta:Concept ;
         skos:altLabel   "mass burials"@en ;
         skos:broader    yso:p8506 ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "joukkohaudat"@fi , "massgravar"@sv , "mass graves"@en .
 
-yso:p26586  a        skos:Collection ;
+yso:p26586  rdf:type  skos:Collection ;
         skos:member  yso:p28955 .
 
-yso:p12738  a           skos:Concept ;
+yso:p12738  rdf:type    skos:Concept , yso-meta:Concept ;
         skos:broader    yso:p2558 ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "Viking Age"@en , "vikingatiden"@sv , "viikinkiaika"@fi .
 
-yso:p13489  a           skos:Concept ;
+yso:p13489  rdf:type    skos:Concept , yso-meta:Concept ;
         skos:altLabel   "båtyxekulturen"@sv , "vasarakirveskulttuuri"@fi ;
         skos:broader    yso:p4740 ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "nuorakeraaminen kulttuuri"@fi , "Corded Ware culture"@en , "snörkeramiska kulturen"@sv .
 
-yso:p10986  a           skos:Concept ;
+yso:p10986  rdf:type    skos:Concept , yso-meta:Concept ;
         skos:altLabel   "inskriptiot"@fi ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "piirtokirjoitukset"@fi , "inskrifter"@sv , "inscriptions"@en ;
         skos:related    yso:p21084 , yso:p8714 .
 
-yso:p16476  a           skos:Concept ;
+yso:p16476  rdf:type    skos:Concept , yso-meta:Concept ;
         skos:altLabel   "historiallisen ajan arkeologia"@fi ;
         skos:broader    yso:p1265 ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "historical archaeology"@en , "historiallinen arkeologia"@fi , "historisk arkeologi"@sv .
 
-yso:p8810  a            skos:Concept ;
+yso:p8810  rdf:type     skos:Concept , yso-meta:Concept ;
         skos:altLabel   "sigillvetenskap"@sv ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "sinettitiede"@fi , "sphragistics"@en , "sigillografi"@sv ;
         skos:related    yso:p7141 .
 
-yso:p7141  a            skos:Concept ;
+yso:p7141  rdf:type     skos:Concept , yso-meta:Concept ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "seals (labels)"@en , "sigill"@sv , "sinetit"@fi ;
         skos:related    yso:p8810 .
 
-yso:p580  a             skos:Concept ;
+yso:p580  rdf:type      skos:Concept , yso-meta:Concept ;
+        skos:inScheme   yso: ;
         skos:narrower   yso:p4791 ;
         skos:prefLabel  "uhripaikat"@fi , "places of sacrifice"@en , "offerplatser"@sv ;
         skos:related    yso:p5340 .
 
-yso:p2932  a            skos:Concept ;
+yso:p2932  rdf:type     skos:Concept , yso-meta:Concept ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "forntidsdräkter"@sv , "ancient costume reconstructions"@en , "muinaispuvut"@fi .
 
-yso:p26552  a        skos:Collection ;
+yso:p26552  rdf:type  skos:Collection ;
         skos:member  yso:p14174 , yso:p7347 , yso:p26858 , yso:p19740 , yso:p18569 .
 
-yso:p26531  a        skos:Collection ;
+yso:p26531  rdf:type  skos:Collection ;
         skos:member  yso:p29546 .
 
-yso:p1747  a            skos:Concept ;
+yso:p1747  rdf:type     skos:Concept , yso-meta:Concept ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "egyptologit"@fi , "egyptologer"@sv , "Egyptologists"@en .
 
-yso:p11348  a           skos:Concept ;
+yso:p11348  rdf:type    skos:Concept , yso-meta:Concept ;
         skos:altLabel   "klassillinen arkeologia"@fi ;
         skos:broader    yso:p1265 ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "classical archaeology"@en , "klassisk arkeologi"@sv , "klassinen arkeologia"@fi ;
         skos:related    yso:p3973 .
 
-yso:p4625  a            skos:Concept ;
+yso:p4625  rdf:type     skos:Concept , yso-meta:Concept ;
         skos:broader    yso:p4622 ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "Bronze Age"@en , "pronssikausi"@fi , "bronsåldern"@sv ;
         skos:related    yso:p4626 .
 
-yso:p7804  a            skos:Concept ;
+yso:p7804  rdf:type     skos:Concept , yso-meta:Concept ;
+        skos:inScheme   yso: ;
         skos:narrower   yso:p19077 ;
         skos:prefLabel  "age estimation"@en , "iänmääritys"@fi , "åldersbestämning"@sv ;
         skos:related    yso:p13564 , yso:p2714 , yso:p20619 , yso:p7785 , yso:p7784 .
 
-yso:p26581  a        skos:Collection ;
+yso:p26581  rdf:type  skos:Collection ;
         skos:member  yso:p12463 , yso:p13027 , yso:p27964 , yso:p27963 , yso:p3973 .
 
-yso:p26560  a        skos:Collection ;
+yso:p26560  rdf:type  skos:Collection ;
         skos:member  yso:p12897 , yso:p19180 , yso:p29433 .
 
-yso:p9285  a            skos:Concept ;
+yso:p9285  rdf:type     skos:Concept , yso-meta:Concept ;
         skos:broader    yso:p4624 ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "Neolithic period"@en , "neolitisk tid"@sv , "neoliittinen kausi"@fi .
 
-yso:p1421  a            skos:Concept ;
+yso:p1421  rdf:type     skos:Concept , yso-meta:Concept ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "tekstiilikeramiikka"@fi , "textile ceramics"@en , "textilkeramik"@sv ;
         skos:related    yso:p1419 .
 
-yso:p8868  a            skos:Concept ;
+yso:p8868  rdf:type     skos:Concept , yso-meta:Concept ;
         skos:broader    yso:p1265 ;
+        skos:inScheme   yso: ;
         skos:narrower   yso:p8867 ;
         skos:prefLabel  "underwater archaeology"@en , "undervattensarkeologi"@sv , "vedenalainen arkeologia"@fi .
 
-yso:p2193  a            skos:Concept ;
+yso:p2193  rdf:type     skos:Concept , yso-meta:Concept ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "muumiot"@fi , "mummies"@en , "mumier"@sv ;
         skos:related    yso:p5340 , yso:p2192 , yso:p12179 .
 
-yso:p18569  a           skos:Concept ;
+yso:p18569  rdf:type    skos:Concept , yso-meta:Concept ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "pyramids"@en , "pyramider"@sv , "pyramidit"@fi ;
         skos:related    yso:p5340 .
 
-yso:p7428  a            skos:Concept ;
+yso:p7428  rdf:type     skos:Concept , yso-meta:Concept ;
         skos:broader    yso:p7429 ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "minolainen kulttuuri"@fi , "Minoan culture"@en , "minoisk kultur"@sv .
 
-yso:p6477  a            skos:Concept ;
+yso:p6477  rdf:type     skos:Concept , yso-meta:Concept ;
         skos:broader    yso:p5714 ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "ruumishaudat"@fi , "skelettgravar"@sv , "non-cremated burial deposit"@en .
 
-yso:p20339  a           skos:Concept ;
+yso:p20339  rdf:type    skos:Concept , yso-meta:Concept ;
         skos:broader    yso:p1265 ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "experimentell arkeologi"@sv , "kokeellinen arkeologia"@fi , "experimental archeology"@en .
 
-yso:p8713  a            skos:Concept ;
+yso:p8713  rdf:type     skos:Concept , yso-meta:Concept ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "papyrologi"@sv , "papyrologia"@fi , "papyrology"@en ;
         skos:related    yso:p8712 , yso:p21820 .
 
-yso:p15031  a           skos:Concept ;
+yso:p15031  rdf:type    skos:Concept , yso-meta:Concept ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "vikingafärder"@sv , "viikinkiretket"@fi , "Viking raids"@en .
 
-yso:p10826  a           skos:Concept ;
+yso:p10826  rdf:type    skos:Concept , yso-meta:Concept ;
         skos:broader    yso:p4740 ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "Askola culture"@en , "Askolan kulttuuri"@fi , "Askolakulturen"@sv .
 
-yso:p26526  a        skos:Collection ;
+yso:p26526  rdf:type  skos:Collection ;
         skos:member  yso:p12897 , yso:p19180 .
 
-yso:p2714  a            skos:Concept ;
+yso:p2714  rdf:type     skos:Concept , yso-meta:Concept ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "stratigraphy"@en , "stratigrafia"@fi , "stratigrafi"@sv ;
         skos:related    yso:p7804 .
 
-yso:p5713  a            skos:Concept ;
+yso:p5713  rdf:type     skos:Concept , yso-meta:Concept ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "grave findings"@en , "hautalöydöt"@fi , "gravfynd"@sv ;
         skos:related    yso:p5340 , yso:p29572 , yso:p5714 .
 
-yso:p21482  a           skos:Concept ;
+yso:p21482  rdf:type    skos:Concept , yso-meta:Concept ;
         skos:broader    yso:p8506 ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "gravkammare"@sv , "hautakammiot"@fi , "burial chambers"@en .
 
-yso:p13721  a           skos:Concept ;
+yso:p13721  rdf:type    skos:Concept , yso-meta:Concept ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "etruskologi"@sv , "etruskologia"@fi , "etruscology"@en .
 
-yso:p8508  a            skos:Concept ;
+yso:p8508  rdf:type     skos:Concept , yso-meta:Concept ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "kalmistot"@fi , "gravfält"@sv , "burial sites"@en ;
         skos:related    yso:p5340 , yso:p5714 , yso:p8506 .
 
-yso:p4791  a            skos:Concept ;
+yso:p4791  rdf:type     skos:Concept , yso-meta:Concept ;
         skos:altLabel   "kuppikivet"@fi ;
         skos:broader    yso:p580 ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "uhrikivet"@fi , "sacrificial stones"@en , "offerstenar"@sv .
 
-yso:p5337  a            skos:Concept ;
+yso:p5337  rdf:type     skos:Concept , yso-meta:Concept ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "bone finds"@en , "benfynd"@sv , "luulöydöt"@fi ;
         skos:related    yso:p5340 , yso:p5338 .
 
-yso:p5842  a            skos:Concept ;
+yso:p5842  rdf:type     skos:Concept , yso-meta:Concept ;
         skos:altLabel   "mounds (prehistoric graves)"@en ;
         skos:broader    yso:p5714 ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "hiidenkiukaat"@fi , "rösen"@sv , "barrows (prehistoric graves)"@en .
 
-yso:p17863  a           skos:Concept ;
+yso:p17863  rdf:type    skos:Concept , yso-meta:Concept ;
         skos:broader    yso:p8506 ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "polttohaudat"@fi , "brandgravar"@sv , "cremation graves"@en ;
         skos:related    yso:p5714 .
 
-yso:p10416  a           skos:Concept ;
+yso:p10416  rdf:type    skos:Concept , yso-meta:Concept ;
         skos:broader    yso:p10417 ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "skattfynd"@sv , "treasure finds"@en , "aarrelöydöt"@fi ;
         skos:related    yso:p10415 .
 
-yso:p10174  a           skos:Concept ;
+yso:p10174  rdf:type    skos:Concept , yso-meta:Concept ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "phosphate analysis"@en , "fosfatanalys"@sv , "fosfaattianalyysi"@fi .
 
-yso:p26550  a        skos:Collection ;
+yso:p26550  rdf:type  skos:Collection ;
         skos:member  yso:p5338 , yso:p12179 .
 
-yso:p10295  a           skos:Concept ;
+yso:p10295  rdf:type    skos:Concept , yso-meta:Concept ;
         skos:altLabel   "cykladisk kultur"@sv ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "kykladisk kultur"@sv , "kykladinen kulttuuri"@fi , "Cycladic culture"@en .
 
-yso:p28252  a           skos:Concept ;
+yso:p28252  rdf:type    skos:Concept , yso-meta:Concept ;
         skos:altLabel   "deltagande arkeologi"@sv , "public archaeology"@en , "samskapande arkeologi"@sv ;
-        skos:prefLabel  "publik arkeologi"@sv , "yhteisöarkeologia"@fi , "community archaeology"@en ;
+        skos:inScheme   yso: ;
+        skos:prefLabel  "publik arkeologi"@sv , "community archaeology"@en , "yhteisöarkeologia"@fi ;
         skos:related    yso:p1265 .
 
-yso:p24443  a           skos:Concept ;
+yso:p24443  rdf:type    skos:Concept , yso-meta:Concept ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "assyriologer"@sv , "assyriologit"@fi , "Assyriologists"@en .
 
-yso:p14588  a           skos:Concept ;
+yso:p14588  rdf:type    skos:Concept , yso-meta:Concept ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "riimukivet"@fi , "runstenar"@sv , "runestones"@en ;
         skos:related    yso:p5340 , yso:p29406 .
 
-yso:p3973  a            skos:Concept ;
+yso:p3973  rdf:type     skos:Concept , yso-meta:Concept ;
         skos:altLabel   "classical period"@en ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "antiken"@sv , "antiquity"@en , "antiikki"@fi ;
         skos:related    yso:p11348 .
 
-yso:p13027  a           skos:Concept ;
+yso:p13027  rdf:type    yso-meta:Concept , skos:Concept ;
         skos:altLabel   "luolamaalaukset"@fi , "grottkonst"@sv , "hällkonst"@sv ;
         skos:broader    yso:p12463 ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "kalliotaide"@fi , "rock art"@en , "bergkonst"@sv ;
         skos:related    yso:p5340 , yso:p27963 , yso:p27964 .
 
-yso:p26579  a        skos:Collection ;
+yso:p26579  rdf:type  skos:Collection ;
         skos:member  yso:p7784 , yso:p7804 , yso:p29546 .
 
-yso:p6780  a            skos:Concept ;
+yso:p6780  rdf:type     skos:Concept , yso-meta:Concept ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "Induskulturen"@sv , "Indus-kulttuuri"@fi , "Indus culture"@en .
 
-yso:p26537  a        skos:Collection ;
+yso:p26537  rdf:type  skos:Collection ;
         skos:member  yso:p7784 , yso:p7804 .
 
-yso:p1419  a            skos:Concept ;
+yso:p1419  rdf:type     skos:Concept , yso-meta:Concept ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "asbestos-ceramic"@en , "asbestkeramik"@sv , "asbestikeramiikka"@fi ;
         skos:related    yso:p1421 .
 
-yso:p20471  a           skos:Concept ;
+yso:p20471  rdf:type    skos:Concept , yso-meta:Concept ;
         skos:broader    yso:p4624 ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "mesoliittinen kausi"@fi , "mesolitisk tid"@sv , "Mesolithic period"@en .
 
-yso:p7347  a            skos:Concept ;
+yso:p7347  rdf:type     skos:Concept , yso-meta:Concept ;
         skos:broader    yso:p5340 ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "ancient castles"@en , "fornborgar"@sv , "muinaislinnat"@fi ;
         skos:related    yso:p7346 .
 
-yso:p27964  a           skos:Concept ;
-        skos:altLabel   "grottmålningar"@sv , "klippmålningar"@sv , "bergmålningar"@sv ;
+yso:p27964  rdf:type    skos:Concept , yso-meta:Concept ;
+        skos:altLabel   "bergmålningar"@sv , "grottmålningar"@sv , "klippmålningar"@sv ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "rock paintings"@en , "hällmålningar"@sv , "kalliomaalaukset"@fi ;
-        skos:related    yso:p13027 , yso:p27963 .
+        skos:related    yso:p27963 , yso:p13027 .
 
-yso:p28189  a        skos:Collection ;
+yso:p28189  rdf:type  skos:Collection ;
         skos:member  yso:p12463 .
 
-yso:p5340  a            skos:Concept ;
+yso:p5340  rdf:type     skos:Concept , yso-meta:Concept ;
         skos:altLabel   "fornminnen"@sv , "fasta fornlämningar"@sv , "arkeologiska fynd"@sv , "kiinteät muinaisjäännökset"@fi , "muinaislöydöt"@fi , "arkeologiset löydöt"@fi , "fornfynd"@sv , "muinaismuistot"@fi ;
+        skos:inScheme   yso: ;
         skos:narrower   yso:p10417 , yso:p7347 ;
         skos:prefLabel  "muinaisjäännökset"@fi , "prehistoric remains"@en , "fornlämningar"@sv ;
         skos:related    yso:p14173 , yso:p580 , yso:p14174 , yso:p14588 , yso:p8869 , yso:p27547 , yso:p5337 , yso:p13027 , yso:p8307 , yso:p5713 , yso:p21412 , yso:p18569 , yso:p6074 , yso:p19740 , yso:p5714 , yso:p2193 , yso:p8508 .
 
-yso:p1619  a         skos:Collection ;
+yso:p1619  rdf:type  skos:Collection ;
         skos:member  yso:p18569 .
 
-yso:p18838  a           skos:Concept ;
+yso:p18838  rdf:type    skos:Concept , yso-meta:Concept ;
         skos:broader    yso:p1265 ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "industriarkeologi"@sv , "teollisuusarkeologia"@fi , "industrial archaeology"@en .
 
-yso:p26858  a           skos:Concept ;
+yso:p26858  rdf:type    skos:Concept , yso-meta:Concept ;
         skos:altLabel   "zikkurat"@sv , "ziqqurrat"@sv , "zigguratit"@fi , "trappstegspyramider"@sv , "ziggurat"@sv , "zikkurratit"@fi ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "ziggurats"@en , "zikkuratit"@fi , "ziqqurat"@sv .
 
-yso:p4831  a            skos:Concept ;
+yso:p4831  rdf:type     skos:Concept , yso-meta:Concept ;
         skos:broader    yso:p2558 ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "Roman Iron Age"@en , "romersk järnålder"@sv , "roomalainen rautakausi"@fi .
 
-yso:p4739  a            skos:Concept ;
+yso:p4739  rdf:type     skos:Concept , yso-meta:Concept ;
         skos:broader    yso:p4740 ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "Komsa culture"@en , "Komsakulturen"@sv , "Komsan kulttuuri"@fi .
 
-yso:p1264  a            skos:Concept ;
+yso:p1264  rdf:type     skos:Concept , yso-meta:Concept ;
         skos:broader    yso:p1265 ;
+        skos:inScheme   yso: ;
         skos:prefLabel  "urban archaeology"@en , "stadsarkeologi"@sv , "kaupunkiarkeologia"@fi .
 
-yso:p26532  a        skos:Collection ;
+yso:p26532  rdf:type  skos:Collection ;
         skos:member  yso:p23386 , yso:p14174 , yso:p29572 , yso:p580 , yso:p23677 , yso:p8506 , yso:p2932 .
 
-yso:p8506  a            skos:Concept ;
+yso:p8506  rdf:type     yso-meta:Concept , skos:Concept ;
         skos:altLabel   "tombs"@en ;
+        skos:inScheme   yso: ;
         skos:narrower   yso:p5714 , yso:p17863 , yso:p21482 , yso:p23386 ;
         skos:prefLabel  "graves"@en , "haudat"@fi , "gravar"@sv ;
         skos:related    yso:p8508 .

--- a/tests/projects_invalid.cfg
+++ b/tests/projects_invalid.cfg
@@ -1,18 +1,4 @@
-# Project configuration for Annif unit tests
-
-[duplicatedproject]
-name=Dummy with no backend
-language=en
-backend=dummy
-vocab=dummy
-analyzer=snowball(english)
-
-[duplicatedproject]
-name=Dummy with no backend
-language=en
-backend=dummy
-vocab=dummy
-analyzer=snowball(english)
+# Project configuration for Annif unit tests (invalid case: duplicated vocab)
 
 [duplicatedvocab]
 name=Dummy with no backend
@@ -20,11 +6,4 @@ language=en
 backend=dummy
 vocab=dummy
 vocab=dummy
-analyzer=snowball(english)
-
-[invalid-vocab-arg]
-name=Dummy with no backend
-language=en
-backend=dummy
-vocab=dummy(en,foo=bar)
 analyzer=snowball(english)

--- a/tests/projects_invalid.cfg
+++ b/tests/projects_invalid.cfg
@@ -21,3 +21,10 @@ backend=dummy
 vocab=dummy
 vocab=dummy
 analyzer=snowball(english)
+
+[invalid-vocab-arg]
+name=Dummy with no backend
+language=en
+backend=dummy
+vocab=dummy(en,foo=bar)
+analyzer=snowball(english)

--- a/tests/projects_invalid2.cfg
+++ b/tests/projects_invalid2.cfg
@@ -1,0 +1,8 @@
+# Project configuration for Annif unit tests (invalid case: wrong vocab argument)
+
+[invalid-vocab-arg]
+name=Dummy with no backend
+language=en
+backend=dummy
+vocab=dummy(en,foo=bar)
+analyzer=snowball(english)

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -145,6 +145,15 @@ def test_get_project_invalid_config_file():
             annif.registry.get_project("duplicatedvocab")
 
 
+def test_get_project_invalid_vocab_arg():
+    cxapp = annif.create_app(
+        config_name="annif.default_config.TestingInvalidProjectsConfig"
+    )
+    with cxapp.app.app_context():
+        with pytest.raises(ConfigurationException):
+            annif.registry.get_project("invalid_vocab_arg")
+
+
 def test_project_load_vocabulary_tfidf(registry, subject_file, testdatadir):
     project = registry.get_project("tfidf-fi")
     project.vocab.load_vocabulary(subject_file)

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -141,17 +141,22 @@ def test_get_project_invalid_config_file():
         config_name="annif.default_config.TestingInvalidProjectsConfig"
     )
     with cxapp.app.app_context():
-        with pytest.raises(ConfigurationException):
+        with pytest.raises(ConfigurationException) as excinfo:
             annif.registry.get_project("duplicatedvocab")
+        assert "option 'vocab' in section 'duplicatedvocab' already exists" in str(
+            excinfo.value
+        )
 
 
 def test_get_project_invalid_vocab_arg():
     cxapp = annif.create_app(
-        config_name="annif.default_config.TestingInvalidProjectsConfig"
+        config_name="annif.default_config.TestingInvalid2ProjectsConfig"
     )
     with cxapp.app.app_context():
-        with pytest.raises(ConfigurationException):
-            annif.registry.get_project("invalid_vocab_arg")
+        project = annif.registry.get_project("invalid-vocab-arg")
+        with pytest.raises(ConfigurationException) as excinfo:
+            project.subjects
+        assert "unknown vocab keyword argument foo" in str(excinfo.value)
 
 
 def test_project_load_vocabulary_tfidf(registry, subject_file, testdatadir):

--- a/tests/test_vocab_rules.py
+++ b/tests/test_vocab_rules.py
@@ -3,6 +3,36 @@
 from annif.vocab import kwargs_to_exclude_uris
 
 
-def test_vocab_rules_exclude():
-    uris = kwargs_to_exclude_uris({'exclude': 'https://example.org/'})
-    assert uris == {'https://example.org/'}
+def test_vocab_rules_exclude(vocabulary):
+    uris = kwargs_to_exclude_uris(
+        vocabulary.as_graph(), {"exclude": "https://example.org/"}
+    )
+    assert uris == {"https://example.org/"}
+
+
+def test_vocab_rules_exclude_type(vocabulary):
+    uris = kwargs_to_exclude_uris(
+        vocabulary.as_graph(),
+        {"exclude_type": "http://www.yso.fi/onto/yso-meta/Individual"},
+    )
+    # there are 4 concepts of type Individual in yso-archaeology
+    assert len(uris) == 4
+    assert "http://www.yso.fi/onto/yso/p19180" in uris
+
+
+def test_vocab_rules_exclude_scheme(vocabulary):
+    uris = kwargs_to_exclude_uris(
+        vocabulary.as_graph(),
+        {"exclude_scheme": "http://www.yso.fi/onto/yso/test-scheme"},
+    )
+    assert len(uris) == 1
+    assert "http://www.yso.fi/onto/yso/p1265" in uris
+
+
+def test_vocab_rules_exclude_collection(vocabulary):
+    uris = kwargs_to_exclude_uris(
+        vocabulary.as_graph(),
+        {"exclude_collection": "http://www.yso.fi/onto/yso/p26569"},
+    )
+    assert len(uris) == 3
+    assert "http://www.yso.fi/onto/yso/p7141" in uris

--- a/tests/test_vocab_rules.py
+++ b/tests/test_vocab_rules.py
@@ -4,28 +4,26 @@ from annif.vocab import kwargs_to_exclude_uris
 
 
 def test_vocab_rules_exclude(vocabulary):
-    uris = kwargs_to_exclude_uris(
-        vocabulary.as_graph(), {"exclude": "https://example.org/"}
-    )
+    uris = kwargs_to_exclude_uris(vocabulary, {"exclude": "https://example.org/"})
     assert uris == {"https://example.org/"}
 
 
 def test_vocab_rules_exclude_many(vocabulary):
     uris = kwargs_to_exclude_uris(
-        vocabulary.as_graph(),
+        vocabulary,
         {"exclude": "https://example.org/1|https://example.org/2"},
     )
     assert uris == {"https://example.org/1", "https://example.org/2"}
 
 
 def test_vocab_rules_exclude_all(vocabulary):
-    uris = kwargs_to_exclude_uris(vocabulary.as_graph(), {"exclude": "*"})
+    uris = kwargs_to_exclude_uris(vocabulary, {"exclude": "*"})
     assert len(uris) == 130
 
 
 def test_vocab_rules_exclude_type(vocabulary):
     uris = kwargs_to_exclude_uris(
-        vocabulary.as_graph(),
+        vocabulary,
         {"exclude_type": "http://www.yso.fi/onto/yso-meta/Individual"},
     )
     # there are 4 concepts of type Individual in yso-archaeology
@@ -35,7 +33,7 @@ def test_vocab_rules_exclude_type(vocabulary):
 
 def test_vocab_rules_exclude_scheme(vocabulary):
     uris = kwargs_to_exclude_uris(
-        vocabulary.as_graph(),
+        vocabulary,
         {"exclude_scheme": "http://www.yso.fi/onto/yso/test-scheme"},
     )
     assert len(uris) == 1
@@ -44,7 +42,7 @@ def test_vocab_rules_exclude_scheme(vocabulary):
 
 def test_vocab_rules_exclude_collection(vocabulary):
     uris = kwargs_to_exclude_uris(
-        vocabulary.as_graph(),
+        vocabulary,
         {"exclude_collection": "http://www.yso.fi/onto/yso/p26569"},
     )
     assert len(uris) == 3
@@ -53,7 +51,7 @@ def test_vocab_rules_exclude_collection(vocabulary):
 
 def test_vocab_rules_exclude_include_combination(vocabulary):
     uris = kwargs_to_exclude_uris(
-        vocabulary.as_graph(),
+        vocabulary,
         {
             "exclude": "*",
             "include": "|".join(

--- a/tests/test_vocab_rules.py
+++ b/tests/test_vocab_rules.py
@@ -10,6 +10,19 @@ def test_vocab_rules_exclude(vocabulary):
     assert uris == {"https://example.org/"}
 
 
+def test_vocab_rules_exclude_many(vocabulary):
+    uris = kwargs_to_exclude_uris(
+        vocabulary.as_graph(),
+        {"exclude": "https://example.org/1|https://example.org/2"},
+    )
+    assert uris == {"https://example.org/1", "https://example.org/2"}
+
+
+def test_vocab_rules_exclude_all(vocabulary):
+    uris = kwargs_to_exclude_uris(vocabulary.as_graph(), {"exclude": "*"})
+    assert len(uris) == 130
+
+
 def test_vocab_rules_exclude_type(vocabulary):
     uris = kwargs_to_exclude_uris(
         vocabulary.as_graph(),
@@ -36,3 +49,17 @@ def test_vocab_rules_exclude_collection(vocabulary):
     )
     assert len(uris) == 3
     assert "http://www.yso.fi/onto/yso/p7141" in uris
+
+
+def test_vocab_rules_exclude_include_combination(vocabulary):
+    uris = kwargs_to_exclude_uris(
+        vocabulary.as_graph(),
+        {
+            "exclude": "*",
+            "include": "http://www.yso.fi/onto/yso/p6436|http://www.yso.fi/onto/yso/p11052",
+            "include_type": "http://www.yso.fi/onto/yso-meta/Individual",
+            "include_scheme": "http://www.yso.fi/onto/yso/test-scheme",
+            "include_collection": "http://www.yso.fi/onto/yso/p26569",
+        },
+    )
+    assert len(uris) == (130 - 10)

--- a/tests/test_vocab_rules.py
+++ b/tests/test_vocab_rules.py
@@ -56,7 +56,12 @@ def test_vocab_rules_exclude_include_combination(vocabulary):
         vocabulary.as_graph(),
         {
             "exclude": "*",
-            "include": "http://www.yso.fi/onto/yso/p6436|http://www.yso.fi/onto/yso/p11052",
+            "include": "|".join(
+                [
+                    "http://www.yso.fi/onto/yso/p6436",
+                    "http://www.yso.fi/onto/yso/p11052",
+                ]
+            ),
             "include_type": "http://www.yso.fi/onto/yso-meta/Individual",
             "include_scheme": "http://www.yso.fi/onto/yso/test-scheme",
             "include_collection": "http://www.yso.fi/onto/yso/p26569",

--- a/tests/test_vocab_rules.py
+++ b/tests/test_vocab_rules.py
@@ -33,6 +33,16 @@ def test_vocab_rules_exclude_type(vocabulary):
     assert "http://www.yso.fi/onto/yso/p19180" in uris
 
 
+def test_vocab_rules_exclude_type_curie(vocabulary):
+    uris = kwargs_to_exclude_uris(
+        vocabulary,
+        {"exclude_type": "yso-meta:Individual"},
+    )
+    # there are 4 concepts of type Individual in yso-archaeology
+    assert len(uris) == 4
+    assert "http://www.yso.fi/onto/yso/p19180" in uris
+
+
 def test_vocab_rules_exclude_type_nonexistent(vocabulary, caplog):
     with caplog.at_level(logging.WARNING):
         uris = kwargs_to_exclude_uris(
@@ -55,6 +65,15 @@ def test_vocab_rules_exclude_scheme(vocabulary):
     assert "http://www.yso.fi/onto/yso/p1265" in uris
 
 
+def test_vocab_rules_exclude_scheme_curie(vocabulary):
+    uris = kwargs_to_exclude_uris(
+        vocabulary,
+        {"exclude_scheme": "yso:test-scheme"},
+    )
+    assert len(uris) == 1
+    assert "http://www.yso.fi/onto/yso/p1265" in uris
+
+
 def test_vocab_rules_exclude_scheme_nonexistent(vocabulary, caplog):
     with caplog.at_level(logging.WARNING):
         uris = kwargs_to_exclude_uris(
@@ -72,6 +91,15 @@ def test_vocab_rules_exclude_collection(vocabulary):
     uris = kwargs_to_exclude_uris(
         vocabulary,
         {"exclude_collection": "http://www.yso.fi/onto/yso/p26569"},
+    )
+    assert len(uris) == 3
+    assert "http://www.yso.fi/onto/yso/p7141" in uris
+
+
+def test_vocab_rules_exclude_collection_curie(vocabulary):
+    uris = kwargs_to_exclude_uris(
+        vocabulary,
+        {"exclude_collection": "yso:p26569"},
     )
     assert len(uris) == 3
     assert "http://www.yso.fi/onto/yso/p7141" in uris

--- a/tests/test_vocab_rules.py
+++ b/tests/test_vocab_rules.py
@@ -1,0 +1,8 @@
+"""Unit tests for vocabulary exclude rules in Annif"""
+
+from annif.vocab import kwargs_to_exclude_uris
+
+
+def test_vocab_rules_exclude():
+    uris = kwargs_to_exclude_uris({'exclude': 'https://example.org/'})
+    assert uris == {'https://example.org/'}

--- a/tests/test_vocab_rules.py
+++ b/tests/test_vocab_rules.py
@@ -1,5 +1,7 @@
 """Unit tests for vocabulary exclude rules in Annif"""
 
+import logging
+
 from annif.vocab import kwargs_to_exclude_uris
 
 
@@ -31,6 +33,19 @@ def test_vocab_rules_exclude_type(vocabulary):
     assert "http://www.yso.fi/onto/yso/p19180" in uris
 
 
+def test_vocab_rules_exclude_type_nonexistent(vocabulary, caplog):
+    with caplog.at_level(logging.WARNING):
+        uris = kwargs_to_exclude_uris(
+            vocabulary,
+            {"exclude_type": "http://example.org/no-such-type"},
+        )
+    assert len(uris) == 0
+    assert (
+        "exclude_type: no concepts found with type http://example.org/no-such-type"
+        in caplog.text
+    )
+
+
 def test_vocab_rules_exclude_scheme(vocabulary):
     uris = kwargs_to_exclude_uris(
         vocabulary,
@@ -40,6 +55,19 @@ def test_vocab_rules_exclude_scheme(vocabulary):
     assert "http://www.yso.fi/onto/yso/p1265" in uris
 
 
+def test_vocab_rules_exclude_scheme_nonexistent(vocabulary, caplog):
+    with caplog.at_level(logging.WARNING):
+        uris = kwargs_to_exclude_uris(
+            vocabulary,
+            {"exclude_scheme": "http://example.org/no-such-scheme"},
+        )
+    assert len(uris) == 0
+    assert (
+        "exclude_scheme: no concepts found in scheme http://example.org/no-such-scheme"
+        in caplog.text
+    )
+
+
 def test_vocab_rules_exclude_collection(vocabulary):
     uris = kwargs_to_exclude_uris(
         vocabulary,
@@ -47,6 +75,19 @@ def test_vocab_rules_exclude_collection(vocabulary):
     )
     assert len(uris) == 3
     assert "http://www.yso.fi/onto/yso/p7141" in uris
+
+
+def test_vocab_rules_exclude_collection_nonexistent(vocabulary, caplog):
+    with caplog.at_level(logging.WARNING):
+        uris = kwargs_to_exclude_uris(
+            vocabulary,
+            {"exclude_collection": "http://example.org/no-such-collection"},
+        )
+    assert len(uris) == 0
+    assert (
+        "exclude_collection: no concepts found in collection "
+        "http://example.org/no-such-collection" in caplog.text
+    )
 
 
 def test_vocab_rules_exclude_include_combination(vocabulary):


### PR DESCRIPTION
This PR implements support for exclude/include rules going beyond the simple `exclude` rule that was already implemented in PR #840. The following rules are now supported:

* `exclude=*` will exclude all concepts (useful before setting include rules)
* `exclude_type=<type>` excludes all concepts of a given RDF type (can be many, separated by `|`)
* `exclude_scheme=<scheme>` excludes all concepts of a given SKOS concept scheme (can be many, separated by `|`)
* `exclude_collection=<collection>` excludes all concepts that are members of a given SKOS collection (can be many, separated by `|`)
* `include_type`, `include_scheme` and `include_collection` work the same way, but in the other direction (i.e. dropping entries from the list of excluded concepts, which means including them after they have first been excluded by another rule)

These are given as parameters to the `vocab` setting in projects.cfg. The starting point when processing these rules is that no concepts are excluded. The given rules are then applied in the order they are specified. The values can be either CURIEs (shortened URIs) or full URIs. In the case of CURIEs, the prefixes are looked up based on the prefix definitions in the vocabulary SKOS file. Some common prefixes (e.g. `skos`, `rdf`, `rdfs`, `owl`) are also supported internally by rdflib.

Examples:

    # YSO, but without concepts of type yso-meta:Hierarchy (that shouldn't be used for subject indexing)
    vocab=yso(exclude_type=http://www.yso.fi/onto/yso-meta/Hierarchy)
    # or (using a CURIE):
    vocab=yso(exclude_type=yso-meta:Hierarchy)

    # YSO Places only
    vocab=yso(exclude=*,include_scheme=http://www.yso.fi/onto/yso/places)
    # or (using a CURIE):
    vocab=yso(exclude=*,include_scheme=yso:places)

    # STW Thesaurus, but without concepts of type zbwext:Thsys
    vocab=stw(exclude_type=http://zbw.eu/namespaces/zbw-extensions/Thsys)
    # or (using a CURIE):
    vocab=stw(exclude_type=zbwext:Thsys)


I had to make some adjustments to the YSO Archeology subset that is used in the test suite; I added RDF type and SKOS concept scheme information, so that the rules could be tested appropriately.

In this PR, there are also some corrections to and refactoring of the unit tests for invalid project configurations. While working on this, I noticed that some of the tests for invalid project configurations did not actually test for the correct error case; now they should do so!

Fixes #844