### PR TITLE
Add superclass constructor call to LMDBSequence, to prevent TensorFlow warning

### DIFF
--- a/annif/backend/nn_ensemble.py
+++ b/annif/backend/nn_ensemble.py
@@ -55,6 +55,7 @@ class LMDBSequence(Sequence):
     """A sequence of samples stored in a LMDB database."""
 
     def __init__(self, txn, batch_size):
+        super().__init__()
         self._txn = txn
         cursor = txn.cursor()
         if cursor.last():


### PR DESCRIPTION
This one-line PR fixes a TensorFlow warning about a missing call to a superclass constructor, for example when running the test suite:

```
tests/test_backend_nn_ensemble.py::test_nn_ensemble_train_and_learn
tests/test_backend_nn_ensemble.py::test_nn_ensemble_train_cached
tests/test_backend_nn_ensemble.py::test_nn_ensemble_train_and_learn_params
  /home/oisuomin/.cache/pypoetry/virtualenvs/annif-3KgT0m3n-py3.12/lib/python3.12/site-packages/keras/src/trainers/data_adapters/py_dataset_adapter.py:121: UserWarning: Your `PyDataset` class should call `super().__init__(**kwargs)` in its constructor. `**kwargs` can include `workers`, `use_multiprocessing`, `max_queue_size`. Do not pass these arguments to `fit()`, as they will be ignored.
    self._warn_if_super_not_called()
```

The warning message is a bit cryptic because it talks about PyDataset. The nn_ensemble backend doesn't implement a PyDataset, but instead defines the LMDBSequence class that implements Sequence. We forgot to call the superclass constructor in this implementation. Maybe this was a requirement introduced in newer TensorFlow versions?

This was reported by @TobiasNx [on annif-users](https://groups.google.com/g/annif-users/c/X-0bjzNyo98/m/OJ2ZouuHBgAJ).