### PR TITLE
Fix DeprecationWarning: avoid use of datetime.utcfromtimestamp

### DIFF
--- a/annif/backend/backend.py
+++ b/annif/backend/backend.py
@@ -71,13 +71,11 @@ class AnnifBackend(metaclass=abc.ABCMeta):
     @property
     def modification_time(self) -> datetime | None:
         mtimes = [
-            datetime.utcfromtimestamp(os.path.getmtime(p))
+            datetime.fromtimestamp(os.path.getmtime(p), tz=timezone.utc)
             for p in self._model_file_paths
         ]
         most_recent = max(mtimes, default=None)
-        if most_recent is None:
-            return None
-        return most_recent.replace(tzinfo=timezone.utc)
+        return most_recent
 
     def _get_backend_params(
         self,


### PR DESCRIPTION
This PR fixes a DeprecationWarning in backend/backend.py:

```
  /home/oisuomin/git/Annif/annif/backend/backend.py:74: DeprecationWarning: datetime.datetime.utcfromtimestamp() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.fromtimestamp(timestamp, datetime.UTC).
    datetime.utcfromtimestamp(os.path.getmtime(p))
```

The `modification_time` property has been modified to avoid the use of `datetime.utcfromtimestamp` which is going away in the future.