### PR TITLE
Drop Python 3.9 support

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -23,7 +23,7 @@ jobs:
     - name: "Prepare: restore caches, install Poetry, set up Python"
       uses: ./.github/actions/prepare
       with:
-        python-version: "3.11"
+        python-version: "3.12"
         poetry-version: ${{ env.POETRY_VERSION }}
     - name: Install Python dev dependencies
       run: |
@@ -47,7 +47,7 @@ jobs:
       id: prepare
       uses: ./.github/actions/prepare
       with:
-        python-version: "3.10"
+        python-version: "3.11"
         poetry-version: ${{ env.POETRY_VERSION }}
     - name: Install Python dependencies
       run: |
@@ -61,7 +61,7 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
     name: test on Python ${{ matrix.python-version }}
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -79,25 +79,19 @@ jobs:
     - name: Install Python dependencies
       run: |
         # Selectively install the optional dependencies for some Python versions
-        # For Python 3.9:
-        if [[ ${{ matrix.python-version }} == '3.9' ]]; then
-          poetry install -E "nn omikuji yake voikko stwfsa";
-        fi
         # For Python 3.10:
         if [[ ${{ matrix.python-version }} == '3.10' ]]; then
-          poetry install -E "fasttext spacy estnltk";
-          # download the small English pretrained spaCy model needed by spacy analyzer
-          poetry run python -m spacy download en_core_web_sm --upgrade-strategy only-if-needed
+          poetry install -E "nn omikuji yake voikko stwfsa";
         fi
         # For Python 3.11:
         if [[ ${{ matrix.python-version }} == '3.11' ]]; then
-          poetry install -E "nn fasttext yake stwfsa voikko spacy";
+          poetry install -E "fasttext spacy estnltk";
           # download the small English pretrained spaCy model needed by spacy analyzer
           poetry run python -m spacy download en_core_web_sm --upgrade-strategy only-if-needed
         fi
         # For Python 3.12:
         if [[ ${{ matrix.python-version }} == '3.12' ]]; then
-          poetry install -E "fasttext yake voikko spacy";
+          poetry install -E "nn fasttext yake stwfsa voikko spacy";
           # download the small English pretrained spaCy model needed by spacy analyzer
           poetry run python -m spacy download en_core_web_sm --upgrade-strategy only-if-needed
         fi
@@ -105,7 +99,7 @@ jobs:
     - name: Test with pytest
       run: |
         poetry run pytest --cov=./ --cov-report xml
-        if [[ ${{ matrix.python-version }} == '3.10' ]]; then
+        if [[ ${{ matrix.python-version }} == '3.11' ]]; then
           poetry run pytest --cov=./ --cov-report xml --cov-append -m slow
         fi
     - name: Upload coverage to Codecov
@@ -174,7 +168,7 @@ jobs:
     - name: "Prepare: restore caches, install Poetry, set up Python"
       uses: ./.github/actions/prepare
       with:
-        python-version: '3.10'
+        python-version: '3.11'
         poetry-version: ${{ env.POETRY_VERSION }}
     - name: Build and publish distribution to PyPI
       env:

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -4,7 +4,7 @@ checks:
     duplicate_code: true
 build:
   environment:
-    python: 3.9.17
+    python: 3.12
   dependencies:
     override:
      - pip install .[dev]

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This repository contains a rewritten production version of Annif based on the
 
 Annif is developed and tested on Linux. If you want to run Annif on Windows or Mac OS, the recommended way is to use Docker (see below) or a Linux virtual machine.
 
-You will need Python 3.9-3.12 to install Annif.
+You will need Python 3.10-3.12 to install Annif.
 
 The recommended way is to install Annif from
 [PyPI](https://pypi.org/project/annif/) into a virtual environment.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.9,<3.13"
+python = ">=3.10,<3.13"
 
 connexion = { version = "~3.1.0", extras = ["flask", "uvicorn", "swagger-ui"] }
 click = "8.1.*"


### PR DESCRIPTION
Drops Annif's support for Python 3.9, rotates Python versions in CI/CD pipeline and updates Python version for Scrutinizer to 3.12.