### PR TITLE
Flexible fusion part 2: core functionality

### DIFF
--- a/annif/backend/backend.py
+++ b/annif/backend/backend.py
@@ -14,7 +14,7 @@ from annif.suggestion import SuggestionBatch
 if TYPE_CHECKING:
     from configparser import SectionProxy
 
-    from annif.corpus.document import DocumentCorpus
+    from annif.corpus.document import Document, DocumentCorpus
     from annif.project import AnnifProject
 
 
@@ -113,34 +113,34 @@ class AnnifBackend(metaclass=abc.ABCMeta):
         parallel operation."""
         pass
 
-    def _suggest(self, text, params):
+    def _suggest(self, doc: Document, params: dict[str, Any]):
         """Either this method or _suggest_batch should be implemented by by
         backends.  It implements the suggest functionality for a single
         document, with pre-processed parameters."""
         pass  # pragma: no cover
 
     def _suggest_batch(
-        self, texts: list[str], params: dict[str, Any]
+        self, documents: list[Document], params: dict[str, Any]
     ) -> SuggestionBatch:
         """This method can be implemented by backends to use batching of documents in
         their operations. This default implementation uses the regular suggest
         functionality."""
         return SuggestionBatch.from_sequence(
-            [self._suggest(text, params) for text in texts],
+            [self._suggest(doc, params) for doc in documents],
             self.project.subjects,
             limit=int(params.get("limit")),
         )
 
     def suggest(
         self,
-        texts: list[str],
+        documents: list[Document],
         params: dict[str, Any] | None = None,
     ) -> SuggestionBatch:
         """Suggest subjects for the input documents and return a list of subject sets
         represented as a list of SubjectSuggestion objects."""
         beparams = self._get_backend_params(params)
         self.initialize()
-        return self._suggest_batch(texts, params=beparams)
+        return self._suggest_batch(documents, params=beparams)
 
     def debug(self, message: str) -> None:
         """Log a debug message from this backend"""

--- a/annif/backend/dummy.py
+++ b/annif/backend/dummy.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from annif.corpus import Document
 from annif.suggestion import SubjectSuggestion
 
 from . import backend
@@ -22,14 +23,17 @@ class DummyBackend(backend.AnnifLearningBackend):
     def initialize(self, parallel: bool = False) -> None:
         self.initialized = True
 
-    def _suggest(self, text: str, params: dict[str, Any]) -> list[SubjectSuggestion]:
+    def _suggest(
+        self, doc: Document, params: dict[str, Any]
+    ) -> list[SubjectSuggestion]:
         score = float(params.get("score", 1.0))
 
-        # Ensure tests fail if "text" with wrong type ends up here
-        assert isinstance(text, str)
+        # Ensure tests fail if "doc" with wrong type ends up here
+        assert isinstance(doc, Document)
+        assert isinstance(doc.text, str)
 
         # Give no hits for no text
-        if len(text) == 0:
+        if len(doc.text) == 0:
             return []
 
         # allow overriding returned subject via uri parameter

--- a/annif/backend/ensemble.py
+++ b/annif/backend/ensemble.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
     from optuna.trial import Trial
 
     from annif.backend.hyperopt import HPRecommendation
-    from annif.corpus.document import DocumentCorpus
+    from annif.corpus.document import Document, DocumentCorpus
 
 
 class BaseEnsembleBackend(backend.AnnifBackend):
@@ -41,10 +41,10 @@ class BaseEnsembleBackend(backend.AnnifBackend):
             project.initialize(parallel)
 
     def _suggest_with_sources(
-        self, texts: list[str], sources: list[tuple[str, float]]
+        self, documents: list[Document], sources: list[tuple[str, float]]
     ) -> dict[str, SuggestionBatch]:
         return {
-            project_id: self.project.registry.get_project(project_id).suggest(texts)
+            project_id: self.project.registry.get_project(project_id).suggest(documents)
             for project_id, _ in sources
         }
 
@@ -66,10 +66,10 @@ class BaseEnsembleBackend(backend.AnnifBackend):
         )
 
     def _suggest_batch(
-        self, texts: list[str], params: dict[str, Any]
+        self, documents: list[Document], params: dict[str, Any]
     ) -> SuggestionBatch:
         sources = annif.util.parse_sources(params["sources"])
-        batch_by_source = self._suggest_with_sources(texts, sources)
+        batch_by_source = self._suggest_with_sources(documents, sources)
         return self._merge_source_batches(batch_by_source, sources, params)
 
 

--- a/annif/backend/http.py
+++ b/annif/backend/http.py
@@ -18,6 +18,8 @@ from . import backend
 if TYPE_CHECKING:
     from datetime import datetime
 
+    from annif.corpus import Document
+
 
 class HTTPBackend(backend.AnnifBackend):
     name = "http"
@@ -64,8 +66,10 @@ class HTTPBackend(backend.AnnifBackend):
         else:
             return None
 
-    def _suggest(self, text: str, params: dict[str, Any]) -> list[SubjectSuggestion]:
-        data = {"text": text}
+    def _suggest(
+        self, doc: Document, params: dict[str, Any]
+    ) -> list[SubjectSuggestion]:
+        data = {"text": doc.text}
         if "project" in params:
             data["project"] = params["project"]
         if "limit" in params:

--- a/annif/backend/mixins.py
+++ b/annif/backend/mixins.py
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
 
     from scipy.sparse._csr import csr_matrix
 
+    from annif.corpus import Document
     from annif.suggestion import SubjectSuggestion
 
 
@@ -37,11 +38,15 @@ class ChunkingBackend(metaclass=abc.ABCMeta):
 
         pass  # pragma: no cover
 
-    def _suggest(self, text: str, params: dict[str, Any]) -> list[SubjectSuggestion]:
+    def _suggest(
+        self, doc: Document, params: dict[str, Any]
+    ) -> list[SubjectSuggestion]:
         self.debug(
-            'Suggesting subjects for text "{}..." (len={})'.format(text[:20], len(text))
+            'Suggesting subjects for text "{}..." (len={})'.format(
+                doc.text[:20], len(doc.text)
+            )
         )
-        sentences = self.project.analyzer.tokenize_sentences(text)
+        sentences = self.project.analyzer.tokenize_sentences(doc.text)
         self.debug("Found {} sentences".format(len(sentences)))
         chunksize = int(params["chunksize"])
         chunktexts = []

--- a/annif/backend/mllm.py
+++ b/annif/backend/mllm.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
     from optuna.trial import Trial
 
     from annif.backend.hyperopt import HPRecommendation
-    from annif.corpus.document import DocumentCorpus
+    from annif.corpus import Document, DocumentCorpus
     from annif.lexical.mllm import Candidate
 
 
@@ -163,7 +163,7 @@ class MLLMBackend(hyperopt.AnnifHyperoptBackend):
             vector[subject_id] = score
         return vector_to_suggestions(vector, int(params["limit"]))
 
-    def _suggest(self, text: str, params: dict[str, Any]) -> Iterator:
-        candidates = self._generate_candidates(text)
+    def _suggest(self, doc: Document, params: dict[str, Any]) -> Iterator:
+        candidates = self._generate_candidates(doc.text)
         prediction = self._model.predict(candidates)
         return self._prediction_to_result(prediction, params)

--- a/annif/backend/omikuji.py
+++ b/annif/backend/omikuji.py
@@ -21,7 +21,7 @@ from . import backend, mixins
 if TYPE_CHECKING:
     from scipy.sparse._csr import csr_matrix
 
-    from annif.corpus.document import DocumentCorpus
+    from annif.corpus import Document, DocumentCorpus
 
 
 class OmikujiBackend(mixins.TfidfVectorizerMixin, backend.AnnifBackend):
@@ -131,9 +131,9 @@ class OmikujiBackend(mixins.TfidfVectorizerMixin, backend.AnnifBackend):
         self._create_model(params, jobs)
 
     def _suggest_batch(
-        self, texts: list[str], params: dict[str, Any]
+        self, documents: list[Document], params: dict[str, Any]
     ) -> SuggestionBatch:
-        vector = self.vectorizer.transform(texts)
+        vector = self.vectorizer.transform([doc.text for doc in documents])
         limit = int(params["limit"])
 
         batch_results = []

--- a/annif/backend/pav.py
+++ b/annif/backend/pav.py
@@ -101,7 +101,7 @@ class PAVBackend(ensemble.BaseEnsembleBackend):
 
         ndocs = 0
         for docid, doc in enumerate(corpus.documents):
-            hits = source_project.suggest([doc.text])[0]
+            hits = source_project.suggest([doc])[0]
             vector = hits.as_vector()
             for cid in np.flatnonzero(vector):
                 data.append(vector[cid])

--- a/annif/backend/stwfsa.py
+++ b/annif/backend/stwfsa.py
@@ -12,7 +12,7 @@ from annif.util import atomic_save, boolean
 from . import backend
 
 if TYPE_CHECKING:
-    from annif.corpus.document import DocumentCorpus
+    from annif.corpus import Document, DocumentCorpus
 
 _KEY_CONCEPT_TYPE_URI = "concept_type_uri"
 _KEY_SUBTHESAURUS_TYPE_URI = "sub_thesaurus_type_uri"
@@ -125,9 +125,13 @@ class StwfsaBackend(backend.AnnifBackend):
             lambda model, store_path: model.store(store_path),
         )
 
-    def _suggest(self, text: str, params: dict[str, Any]) -> list[SubjectSuggestion]:
-        self.debug(f'Suggesting subjects for text "{text[:20]}..." (len={len(text)})')
-        result = self._model.suggest_proba([text])[0]
+    def _suggest(
+        self, doc: Document, params: dict[str, Any]
+    ) -> list[SubjectSuggestion]:
+        self.debug(
+            f'Suggesting subjects for text "{doc.text[:20]}..." (len={len(doc.text)})'
+        )
+        result = self._model.suggest_proba([doc.text])[0]
         suggestions = []
         for uri, score in result:
             subject_id = self.project.subjects.by_uri(uri)

--- a/annif/backend/svc.py
+++ b/annif/backend/svc.py
@@ -19,7 +19,7 @@ from . import backend, mixins
 if TYPE_CHECKING:
     from scipy.sparse._csr import csr_matrix
 
-    from annif.corpus.document import DocumentCorpus
+    from annif.corpus import Document, DocumentCorpus
 
 
 class SVCBackend(mixins.TfidfVectorizerMixin, backend.AnnifBackend):
@@ -106,9 +106,9 @@ class SVCBackend(mixins.TfidfVectorizerMixin, backend.AnnifBackend):
         return results
 
     def _suggest_batch(
-        self, texts: list[str], params: dict[str, Any]
+        self, documents: list[Document], params: dict[str, Any]
     ) -> SuggestionBatch:
-        vector = self.vectorizer.transform(texts)
+        vector = self.vectorizer.transform([doc.text for doc in documents])
         confidences = self._model.decision_function(vector)
         # convert to 0..1 score range using logistic function
         scores_list = scipy.special.expit(confidences)

--- a/annif/backend/tfidf.py
+++ b/annif/backend/tfidf.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 
     from scipy.sparse._csr import csr_matrix
 
-    from annif.corpus.document import DocumentCorpus
+    from annif.corpus import Document, DocumentCorpus
 
 
 class SubjectBuffer:
@@ -129,10 +129,12 @@ class TFIDFBackend(mixins.TfidfVectorizerMixin, backend.AnnifBackend):
         veccorpus = self.create_vectorizer(subjects)
         self._create_index(veccorpus)
 
-    def _suggest(self, text: str, params: dict[str, Any]) -> Iterator:
+    def _suggest(self, doc: Document, params: dict[str, Any]) -> Iterator:
         self.debug(
-            'Suggesting subjects for text "{}..." (len={})'.format(text[:20], len(text))
+            'Suggesting subjects for text "{}..." (len={})'.format(
+                doc.text[:20], len(doc.text)
+            )
         )
-        tokens = self.project.analyzer.tokenize_words(text)
+        tokens = self.project.analyzer.tokenize_words(doc.text)
         vectors = self.vectorizer.transform([" ".join(tokens)])
         return vector_to_suggestions(self._index[vectors[0]], int(params["limit"]))

--- a/annif/backend/yake.py
+++ b/annif/backend/yake.py
@@ -22,7 +22,7 @@ from . import backend
 if TYPE_CHECKING:
     from rdflib.term import URIRef
 
-    from annif.corpus.document import DocumentCorpus
+    from annif.corpus import Document, DocumentCorpus
 
 
 class YakeBackend(backend.AnnifBackend):
@@ -112,8 +112,12 @@ class YakeBackend(backend.AnnifBackend):
         words = phrase.split()
         return " ".join(sorted(words))
 
-    def _suggest(self, text: str, params: dict[str, Any]) -> list[SubjectSuggestion]:
-        self.debug(f'Suggesting subjects for text "{text[:20]}..." (len={len(text)})')
+    def _suggest(
+        self, doc: Document, params: dict[str, Any]
+    ) -> list[SubjectSuggestion]:
+        self.debug(
+            f'Suggesting subjects for text "{doc.text[:20]}..." (len={len(doc.text)})'
+        )
         limit = int(params["limit"])
 
         self._kw_extractor = yake.KeywordExtractor(
@@ -125,7 +129,7 @@ class YakeBackend(backend.AnnifBackend):
             top=int(params["num_keywords"]),
             features=self.params["features"],
         )
-        keyphrases = self._kw_extractor.extract_keywords(text)
+        keyphrases = self._kw_extractor.extract_keywords(doc.text)
         suggestions = self._keyphrases2suggestions(keyphrases)
 
         subject_suggestions = [

--- a/annif/cli.py
+++ b/annif/cli.py
@@ -13,11 +13,11 @@ import click_log
 from flask.cli import FlaskGroup
 
 import annif
-import annif.corpus
 import annif.parallel
 import annif.project
 import annif.registry
 from annif import cli_util, hfh_util
+from annif.corpus import Document, DocumentDirectory
 from annif.exception import (
     NotInitializedException,
     NotSupportedException,
@@ -282,9 +282,9 @@ def run_suggest(
             cli_util.show_hits(suggestions, project, lang)
     else:
         text = sys.stdin.read()
-        suggestions = project.suggest([text], backend_params).filter(limit, threshold)[
-            0
-        ]
+        suggestions = project.suggest([Document(text=text)], backend_params).filter(
+            limit, threshold
+        )[0]
         cli_util.show_hits(suggestions, project, lang)
 
 
@@ -319,7 +319,7 @@ def run_index(
         raise click.BadParameter(f'language "{lang}" not supported by vocabulary')
     backend_params = cli_util.parse_backend_params(backend_param, project)
 
-    documents = annif.corpus.DocumentDirectory(directory, require_subjects=False)
+    documents = DocumentDirectory(directory, require_subjects=False)
     results = project.suggest_corpus(documents, backend_params).filter(limit, threshold)
 
     for (docfilename, _), suggestions in zip(documents, results):

--- a/annif/corpus/document.py
+++ b/annif/corpus/document.py
@@ -171,9 +171,7 @@ class TransformingDocumentCorpus(DocumentCorpus):
     @property
     def documents(self):
         for doc in self._orig_corpus.documents:
-            yield Document(
-                text=self._transform_fn(doc.text), subject_set=doc.subject_set
-            )
+            yield self._transform_fn(doc)
 
 
 class LimitingDocumentCorpus(DocumentCorpus):

--- a/annif/corpus/document.py
+++ b/annif/corpus/document.py
@@ -133,7 +133,9 @@ class DocumentFileCSV(DocumentCorpus):
             key: val for key, val in row.items() if key not in ("text", "subject_uris")
         }
         yield Document(
-            text=(row["text"] or ""), subject_set=SubjectSet(subject_ids), metadata=metadata
+            text=(row["text"] or ""),
+            subject_set=SubjectSet(subject_ids),
+            metadata=metadata,
         )
 
     def _check_fields(self, reader: csv.DictReader) -> bool:

--- a/annif/corpus/document.py
+++ b/annif/corpus/document.py
@@ -129,7 +129,12 @@ class DocumentFileCSV(DocumentCorpus):
             self.subject_index.by_uri(annif.util.cleanup_uri(uri))
             for uri in row["subject_uris"].strip().split()
         }
-        yield Document(text=row["text"], subject_set=SubjectSet(subject_ids))
+        metadata = {
+            key: val for key, val in row.items() if key not in ("text", "subject_uris")
+        }
+        yield Document(
+            text=row["text"], subject_set=SubjectSet(subject_ids), metadata=metadata
+        )
 
     def _check_fields(self, reader: csv.DictReader) -> bool:
         fns = reader.fieldnames

--- a/annif/corpus/types.py
+++ b/annif/corpus/types.py
@@ -14,9 +14,9 @@ if TYPE_CHECKING:
 
 
 class Document:
-    def __init__(self, text, subject_set, metadata=None):
+    def __init__(self, text, subject_set=None, metadata=None):
         self.text = text
-        self.subject_set = subject_set
+        self.subject_set = subject_set if subject_set is not None else set()
         self.metadata = metadata if metadata is not None else {}
 
     def __repr__(self):

--- a/annif/corpus/types.py
+++ b/annif/corpus/types.py
@@ -12,7 +12,19 @@ if TYPE_CHECKING:
 
     from annif.vocab import SubjectIndex
 
-Document = collections.namedtuple("Document", "text subject_set")
+
+class Document:
+    def __init__(self, text, subject_set, metadata=None):
+        self.text = text
+        self.subject_set = subject_set
+        self.metadata = metadata if metadata is not None else {}
+
+    def __repr__(self):
+        return (
+            f"Document(text={self.text!r}, "
+            f"subject_set={self.subject_set!r}, "
+            f"metadata={self.metadata!r})"
+        )
 
 
 class DocumentCorpus(metaclass=abc.ABCMeta):

--- a/annif/parallel.py
+++ b/annif/parallel.py
@@ -61,7 +61,7 @@ class ProjectSuggestMap:
         filtered_hits = {}
         for project_id in self.project_ids:
             project = self.registry.get_project(project_id)
-            batch = project.suggest([doc.text], self.backend_params)
+            batch = project.suggest([doc], self.backend_params)
             filtered_hits[project_id] = batch.filter(self.limit, self.threshold)[0]
         return (filtered_hits, doc.subject_set)
 
@@ -69,12 +69,14 @@ class ProjectSuggestMap:
         self, batch
     ) -> tuple[dict[str, SuggestionBatch], Iterator[SubjectSet]]:
         filtered_hit_sets = {}
-        texts, subject_sets = zip(*[(doc.text, doc.subject_set) for doc in batch])
+        subject_sets = [doc.subject_set for doc in batch]
 
         for project_id in self.project_ids:
             project = self.registry.get_project(project_id)
-            batch = project.suggest(texts, self.backend_params)
-            filtered_hit_sets[project_id] = batch.filter(self.limit, self.threshold)
+            suggestion_batch = project.suggest(batch, self.backend_params)
+            filtered_hit_sets[project_id] = suggestion_batch.filter(
+                self.limit, self.threshold
+            )
         return (filtered_hit_sets, subject_sets)
 
 

--- a/annif/project.py
+++ b/annif/project.py
@@ -147,7 +147,7 @@ class AnnifProject(DatadirMixin):
         if backend_params is None:
             backend_params = {}
         beparams = backend_params.get(self.backend.backend_id, {})
-        return self.backend.suggest([doc.text for doc in docs], beparams)
+        return self.backend.suggest(docs, beparams)
 
     @property
     def analyzer(self) -> Analyzer:
@@ -250,8 +250,7 @@ class AnnifProject(DatadirMixin):
     ) -> annif.suggestion.SuggestionResults:
         """Suggest subjects for the given documents corpus in batches of documents."""
         suggestions = (
-            self.suggest([doc.text for doc in doc_batch], backend_params)
-            for doc_batch in corpus.doc_batches
+            self.suggest(doc_batch, backend_params) for doc_batch in corpus.doc_batches
         )
         import annif.suggestion
 
@@ -259,7 +258,7 @@ class AnnifProject(DatadirMixin):
 
     def suggest(
         self,
-        texts: list[str],
+        documents: list[Document],
         backend_params: defaultdict[str, dict] | None = None,
     ) -> annif.suggestion.SuggestionBatch:
         """Suggest subjects for the given documents batch."""
@@ -268,8 +267,8 @@ class AnnifProject(DatadirMixin):
                 logger.warning("Could not get train state information.")
             else:
                 raise NotInitializedException("Project is not trained.")
-        docs = [self.transform.transform_doc(Document(text=text)) for text in texts]
-        return self._suggest_with_backend(docs, backend_params)
+        transformed_docs = [self.transform.transform_doc(doc) for doc in documents]
+        return self._suggest_with_backend(transformed_docs, backend_params)
 
     def train(
         self,

--- a/annif/transform/__init__.py
+++ b/annif/transform/__init__.py
@@ -9,7 +9,7 @@ import annif
 from annif.exception import ConfigurationException
 from annif.util import parse_args
 
-from . import inputlimiter, transform
+from . import inputlimiter, select, transform
 
 if TYPE_CHECKING:
     from annif.project import AnnifProject
@@ -51,6 +51,7 @@ def get_transform(transform_specs: str, project: AnnifProject | None) -> Transfo
 _transforms = {
     transform.IdentityTransform.name: transform.IdentityTransform,
     inputlimiter.InputLimiter.name: inputlimiter.InputLimiter,
+    select.SelectTransform.name: select.SelectTransform,
 }
 
 # Optional transforms

--- a/annif/transform/inputlimiter.py
+++ b/annif/transform/inputlimiter.py
@@ -21,7 +21,7 @@ class InputLimiter(transform.BaseTransform):
         self.input_limit = int(input_limit)
         self._validate_value(self.input_limit)
 
-    def transform_fn(self, text: str) -> str:
+    def transform_text(self, text: str) -> str:
         return text[: self.input_limit]
 
     def _validate_value(self, input_limit: int) -> None:

--- a/annif/transform/langfilter.py
+++ b/annif/transform/langfilter.py
@@ -34,7 +34,7 @@ class LangFilter(transform.BaseTransform):
             self.project.language
         )
 
-    def transform_fn(self, text: str) -> str:
+    def transform_text(self, text: str) -> str:
         if len(text) < self.text_min_length:
             return text
 

--- a/annif/transform/select.py
+++ b/annif/transform/select.py
@@ -1,0 +1,34 @@
+"""A transformation that allows selecting Document metadata fields to be
+used instead of the main text."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from annif.corpus import Document
+
+from . import transform
+
+if TYPE_CHECKING:
+    from annif.project import AnnifProject
+
+
+class SelectTransform(transform.BaseTransform):
+    name = "select"
+
+    def __init__(self, project: AnnifProject | None, *fields: str) -> None:
+        super().__init__(project)
+        self.fields = fields
+
+    def _get_texts(self, doc):
+        for fld in self.fields:
+            if fld == "text":
+                yield doc.text
+            else:
+                yield doc.metadata[fld]
+
+    def transform_doc(self, doc: Document) -> Document:
+        new_text = "\n".join(self._get_texts(doc))
+        return Document(
+            text=new_text, subject_set=doc.subject_set, metadata=doc.metadata
+        )

--- a/annif/transform/select.py
+++ b/annif/transform/select.py
@@ -25,7 +25,7 @@ class SelectTransform(transform.BaseTransform):
             if fld == "text":
                 yield doc.text
             else:
-                yield doc.metadata[fld]
+                yield doc.metadata.get(fld, "")
 
     def transform_doc(self, doc: Document) -> Document:
         new_text = "\n".join(self._get_texts(doc))

--- a/annif/transform/transform.py
+++ b/annif/transform/transform.py
@@ -43,7 +43,7 @@ class BaseTransform(abc.ABC):
 
         raise NotImplementedError(
             "Subclasses must implement transform_text if they call it"
-        )
+        )  # pragma: no cover
 
 
 class IdentityTransform(BaseTransform):

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -6,7 +6,7 @@ import pytest
 
 import annif
 import annif.backend
-import annif.corpus
+from annif.corpus import Document, DocumentDirectory
 
 
 def test_get_backend_nonexistent():
@@ -17,7 +17,7 @@ def test_get_backend_nonexistent():
 def test_get_backend_dummy(project, dummy_subject_index):
     dummy_type = annif.backend.get_backend("dummy")
     dummy = dummy_type(backend_id="dummy", config_params={}, project=project)
-    result = dummy.suggest(["this is some text"])[0]
+    result = dummy.suggest([Document(text="this is some text")])[0]
     assert len(result) == 1
     hits = list(result)
     assert hits[0].subject_id == dummy_subject_index.by_uri("http://example.org/dummy")
@@ -32,13 +32,13 @@ def test_learn_dummy(project, tmpdir):
     tmpdir.join("doc1.tsv").write("<http://www.yso.fi/onto/yso/p10849>\tarchaeologists")
     tmpdir.join("doc2.txt").write("doc2")
     tmpdir.join("doc2.tsv").write("<http://example.org/dummy>\tdummy")
-    docdir = annif.corpus.DocumentDirectory(
+    docdir = DocumentDirectory(
         str(tmpdir), project.subjects, "en", require_subjects=True
     )
 
     dummy.learn(docdir)
 
-    result = dummy.suggest(["this is some text"])[0]
+    result = dummy.suggest([Document(text="this is some text")])[0]
     assert len(result) == 1
     hits = list(result)
     assert hits[0].subject_id is not None

--- a/tests/test_backend_fasttext.py
+++ b/tests/test_backend_fasttext.py
@@ -5,7 +5,7 @@ import logging
 import pytest
 
 import annif.backend
-import annif.corpus
+from annif.corpus import Document, DocumentFileTSV
 from annif.exception import NotSupportedException
 
 fasttext = pytest.importorskip("annif.backend.fasttext")
@@ -71,7 +71,7 @@ def test_fasttext_train_unknown_subject(tmpdir, datadir, project):
         "nonexistent\thttp://example.com/nonexistent\n"
         + "arkeologia\thttp://www.yso.fi/onto/yso/p1265"
     )
-    document_corpus = annif.corpus.DocumentFileTSV(str(tmpfile), project.subjects)
+    document_corpus = DocumentFileTSV(str(tmpfile), project.subjects)
 
     fasttext.train(document_corpus)
     assert fasttext._model is not None
@@ -183,12 +183,14 @@ def test_fasttext_suggest(project):
 
     results = fasttext.suggest(
         [
-            """Arkeologiaa sanotaan joskus myös
+            Document(
+                text="""Arkeologiaa sanotaan joskus myös
         muinaistutkimukseksi tai muinaistieteeksi. Se on humanistinen tiede
         tai oikeammin joukko tieteitä, jotka tutkivat ihmisen menneisyyttä.
         Tutkimusta tehdään analysoimalla muinaisjäännöksiä eli niitä jälkiä,
         joita ihmisten toiminta on jättänyt maaperään tai vesistöjen
         pohjaan."""
+            )
         ]
     )[0]
 
@@ -212,6 +214,6 @@ def test_fasttext_suggest_empty_chunks(project):
         project=project,
     )
 
-    results = fasttext.suggest([""])[0]
+    results = fasttext.suggest([Document(text="")])[0]
 
     assert len(results) == 0

--- a/tests/test_backend_http.py
+++ b/tests/test_backend_http.py
@@ -8,6 +8,7 @@ import pytest
 import requests.exceptions
 
 import annif.backend.http
+from annif.corpus import Document
 from annif.exception import OperationFailedException
 from annif.vocab import Subject
 
@@ -31,7 +32,7 @@ def test_http_suggest(app_project):
             },
             project=app_project,
         )
-        result = http.suggest(["this is some text"])[0]
+        result = http.suggest([Document(text="this is some text")])[0]
         assert len(result) == 1
         hits = list(result)
         assert hits[0].subject_id is not None
@@ -74,7 +75,7 @@ def test_http_suggest_with_results(app_project):
             )
         )
 
-        result = http.suggest(["this is some text"])[0]
+        result = http.suggest([Document(text="this is some text")])[0]
         assert len(result) == 1
         hits = list(result)
         assert hits[0].subject_id is not None
@@ -96,7 +97,7 @@ def test_http_suggest_post_args(app_project):
             },
             project=app_project,
         )
-        http.suggest(["this is some text"])
+        http.suggest([Document(text="this is some text")])
 
         assert requests.post.call_args.args == ("http://api.example.org/analyze",)
         assert "text" in requests.post.call_args.kwargs["data"]
@@ -126,7 +127,7 @@ def test_http_suggest_zero_score(project):
             },
             project=project,
         )
-        result = http.suggest(["this is some text"])[0]
+        result = http.suggest([Document(text="this is some text")])[0]
         assert len(result) == 0
 
 
@@ -143,7 +144,7 @@ def test_http_suggest_error(project):
             },
             project=project,
         )
-        result = http.suggest(["this is some text"])[0]
+        result = http.suggest([Document(text="this is some text")])[0]
         assert len(result) == 0
 
 
@@ -164,7 +165,7 @@ def test_http_suggest_json_fails(project):
             },
             project=project,
         )
-        result = http.suggest(["this is some text"])[0]
+        result = http.suggest([Document(text="this is some text")])[0]
         assert len(result) == 0
 
 
@@ -185,7 +186,7 @@ def test_http_suggest_unexpected_json(project):
             },
             project=project,
         )
-        result = http.suggest(["this is some text"])[0]
+        result = http.suggest([Document(text="this is some text")])[0]
         assert len(result) == 0
 
 
@@ -300,7 +301,7 @@ def test_headers(project):
             },
             project=project,
         )
-        http.suggest("this is some text")
+        http.suggest([Document("this is some text")])
 
         version = importlib.metadata.version("annif")
         assert requests.post.call_args.kwargs["headers"] == {

--- a/tests/test_backend_mllm.py
+++ b/tests/test_backend_mllm.py
@@ -4,6 +4,7 @@ import pytest
 
 import annif
 import annif.backend
+from annif.corpus import Document
 from annif.exception import NotInitializedException, NotSupportedException
 
 
@@ -80,12 +81,14 @@ def test_mllm_suggest(project):
 
     results = mllm.suggest(
         [
-            """Arkeologia on tieteenala, jota sanotaan joskus
+            Document(
+                text="""Arkeologia on tieteenala, jota sanotaan joskus
         muinaistutkimukseksi tai muinaistieteeksi. Se on humanistinen tiede
         tai oikeammin joukko tieteitä, jotka tutkivat ihmisen menneisyyttä.
         Tutkimusta tehdään analysoimalla muinaisjäännöksiä eli niitä jälkiä,
         joita ihmisten toiminta on jättänyt maaperään tai vesistöjen
         pohjaan."""
+            )
         ]
     )[0]
 
@@ -101,7 +104,7 @@ def test_mllm_suggest_no_matches(project):
         backend_id="mllm", config_params={"limit": 8, "language": "fi"}, project=project
     )
 
-    results = mllm.suggest(["Nothing matches this."])[0]
+    results = mllm.suggest([Document(text="Nothing matches this.")])[0]
 
     assert len(results) == 0
 
@@ -143,4 +146,4 @@ def test_mllm_suggest_no_model(datadir, project):
 
     datadir.join("mllm-model.gz").remove()
     with pytest.raises(NotInitializedException):
-        mllm.suggest("example text")
+        mllm.suggest([Document(text="example text")])

--- a/tests/test_backend_omikuji.py
+++ b/tests/test_backend_omikuji.py
@@ -3,7 +3,7 @@
 import pytest
 
 import annif.backend
-import annif.corpus
+from annif.corpus import Document, DocumentFileTSV
 from annif.exception import NotInitializedException, NotSupportedException
 
 pytest.importorskip("annif.backend.omikuji")
@@ -27,7 +27,7 @@ def test_omikuji_suggest_no_vectorizer(project):
     omikuji = omikuji_type(backend_id="omikuji", config_params={}, project=project)
 
     with pytest.raises(NotInitializedException):
-        omikuji.suggest("example text")
+        omikuji.suggest([Document("example text")])
 
 
 def test_omikuji_create_train_file(tmpdir, project, datadir):
@@ -37,7 +37,7 @@ def test_omikuji_create_train_file(tmpdir, project, datadir):
         + "arkeologia\thttp://www.yso.fi/onto/yso/p1265\n"
         + "...\thttp://example.com/none"
     )
-    corpus = annif.corpus.DocumentFileTSV(str(tmpfile), project.subjects)
+    corpus = DocumentFileTSV(str(tmpfile), project.subjects)
     omikuji_type = annif.backend.get_backend("omikuji")
     omikuji = omikuji_type(backend_id="omikuji", config_params={}, project=project)
     input = (doc.text for doc in corpus.documents)
@@ -123,12 +123,14 @@ def test_omikuji_suggest(project):
 
     results = omikuji.suggest(
         [
-            """Arkeologiaa sanotaan joskus myös
+            Document(
+                text="""Arkeologiaa sanotaan joskus myös
         muinaistutkimukseksi tai muinaistieteeksi. Se on humanistinen tiede
         tai oikeammin joukko tieteitä, jotka tutkivat ihmisen menneisyyttä.
         Tutkimusta tehdään analysoimalla muinaisjäännöksiä eli niitä jälkiä,
         joita ihmisten toiminta on jättänyt maaperään tai vesistöjen
         pohjaan."""
+            )
         ]
     )[0]
 
@@ -144,7 +146,7 @@ def test_omikuji_suggest_no_input(project):
         backend_id="omikuji", config_params={"limit": 8}, project=project
     )
 
-    results = omikuji.suggest(["j"])[0]
+    results = omikuji.suggest([Document(text="j")])[0]
     assert len(results) == 0
 
 
@@ -154,4 +156,4 @@ def test_omikuji_suggest_no_model(datadir, project):
 
     datadir.join("omikuji-model").remove()
     with pytest.raises(NotInitializedException):
-        omikuji.suggest(["example text"])[0]
+        omikuji.suggest([Document(text="example text")])[0]

--- a/tests/test_backend_pav.py
+++ b/tests/test_backend_pav.py
@@ -7,7 +7,7 @@ import py.path
 import pytest
 
 import annif.backend
-import annif.corpus
+from annif.corpus import Document, DocumentFileTSV
 from annif.exception import NotSupportedException
 
 
@@ -48,7 +48,7 @@ def test_pav_train(tmpdir, app_project):
         + "another\thttp://example.org/dummy\n"
         + "none\thttp://example.org/none"
     )
-    document_corpus = annif.corpus.DocumentFileTSV(str(tmpfile), app_project.subjects)
+    document_corpus = DocumentFileTSV(str(tmpfile), app_project.subjects)
 
     pav.train(document_corpus)
     datadir = py.path.local(app_project.datadir)
@@ -106,12 +106,14 @@ def test_pav_suggest(app_project):
 
     results = pav.suggest(
         [
-            """Arkeologiaa sanotaan joskus myös
+            Document(
+                text="""Arkeologiaa sanotaan joskus myös
         muinaistutkimukseksi tai muinaistieteeksi. Se on humanistinen tiede
         tai oikeammin joukko tieteitä, jotka tutkivat ihmisen menneisyyttä.
         Tutkimusta tehdään analysoimalla muinaisjäännöksiä eli niitä jälkiä,
         joita ihmisten toiminta on jättänyt maaperään tai vesistöjen
         pohjaan."""
+            )
         ]
     )[0]
 
@@ -137,7 +139,7 @@ def test_pav_train_params(tmpdir, app_project, caplog):
         + "another\thttp://example.org/dummy\n"
         + "none\thttp://example.org/none"
     )
-    document_corpus = annif.corpus.DocumentFileTSV(str(tmpfile), app_project.subjects)
+    document_corpus = DocumentFileTSV(str(tmpfile), app_project.subjects)
     params = {"min-docs": 5}
 
     with caplog.at_level(logging.DEBUG):
@@ -156,12 +158,14 @@ def test_pav_suggest_after_min_docs(app_project):
 
     results = pav.suggest(
         [
-            """Arkeologiaa sanotaan joskus myös
+            Document(
+                text="""Arkeologiaa sanotaan joskus myös
         muinaistutkimukseksi tai muinaistieteeksi. Se on humanistinen tiede
         tai oikeammin joukko tieteitä, jotka tutkivat ihmisen menneisyyttä.
         Tutkimusta tehdään analysoimalla muinaisjäännöksiä eli niitä jälkiä,
         joita ihmisten toiminta on jättänyt maaperään tai vesistöjen
         pohjaan."""
+            )
         ]
     )[0]
 

--- a/tests/test_backend_stwfsa.py
+++ b/tests/test_backend_stwfsa.py
@@ -1,7 +1,7 @@
 import pytest
 
-import annif.corpus
 from annif.backend import get_backend
+from annif.corpus import Document, DocumentList
 from annif.exception import NotInitializedException, NotSupportedException
 
 stwfsa = pytest.importorskip("annif.backend.stwfsa")
@@ -46,7 +46,7 @@ def test_stwfsa_not_initialized(project):
     stwfsa_type = get_backend(stwfsa_backend_name)
     stwfsa = stwfsa_type(backend_id="stwfsa", config_params={}, project=project)
     with pytest.raises(NotInitializedException):
-        stwfsa.suggest(["example text"])[0]
+        stwfsa.suggest([Document(text="example text")])[0]
 
 
 def test_stwfsa_train(document_corpus, project, datadir):
@@ -62,7 +62,7 @@ def test_stwfsa_train(document_corpus, project, datadir):
 
 
 def test_empty_corpus(project):
-    corpus = annif.corpus.DocumentList([])
+    corpus = DocumentList([])
     stwfsa_type = get_backend(stwfsa_backend_name)
     stwfsa = stwfsa_type(
         backend_id=stwfsa_backend_name, config_params={"limit": 10}, project=project
@@ -86,7 +86,7 @@ def test_stwfsa_suggest_unknown(project):
     stwfsa = stwfsa_type(
         backend_id=stwfsa_backend_name, config_params={"limit": 10}, project=project
     )
-    results = stwfsa.suggest(["1234"])[0]
+    results = stwfsa.suggest([Document(text="1234")])[0]
     assert len(results) == 0
 
 
@@ -99,7 +99,8 @@ def test_stwfsa_suggest(project, datadir):
     # And "random" words between them
     results = stwfsa.suggest(
         [
-            """random
+            Document(
+                text="""random
     muinais-DNA random random
     labyrintit random random random
     Eurooppalainen yleissopimus arkeologisen perinnön suojelusta random
@@ -110,6 +111,7 @@ def test_stwfsa_suggest(project, datadir):
     muinaismuistoalueet  random random random
     zikkuratit random random
     termoluminesenssi random random random"""
+            )
         ]
     )[0]
     assert len(results) == 10

--- a/tests/test_backend_svc.py
+++ b/tests/test_backend_svc.py
@@ -3,7 +3,7 @@
 import pytest
 
 import annif.backend
-import annif.corpus
+from annif.corpus import Document
 from annif.exception import NotInitializedException, NotSupportedException
 
 
@@ -25,7 +25,7 @@ def test_svc_suggest_no_vectorizer(project):
     svc = svc_type(backend_id="svc", config_params={}, project=project)
 
     with pytest.raises(NotInitializedException):
-        svc.suggest(["example text"])[0]
+        svc.suggest([Document(text="example text")])[0]
 
 
 def test_svc_train(datadir, document_corpus, project, caplog):
@@ -71,7 +71,7 @@ def test_svc_suggest(project):
     svc_type = annif.backend.get_backend("svc")
     svc = svc_type(backend_id="svc", config_params={"limit": 20}, project=project)
 
-    results = svc.suggest(["""Arkeologiaa sanotaan joskus myös..."""])[0]
+    results = svc.suggest([Document(text="Arkeologiaa sanotaan joskus myös...")])[0]
 
     assert len(results) > 0
     assert len(results) <= 20
@@ -83,7 +83,7 @@ def test_svc_suggest_no_input(project):
     svc_type = annif.backend.get_backend("svc")
     svc = svc_type(backend_id="svc", config_params={"limit": 8}, project=project)
 
-    results = svc.suggest(["j"])[0]
+    results = svc.suggest([Document(text="j")])[0]
     assert len(results) == 0
 
 
@@ -93,4 +93,4 @@ def test_svc_suggest_no_model(datadir, project):
 
     datadir.join("svc-model.gz").remove()
     with pytest.raises(NotInitializedException):
-        svc.suggest(["example text"])[0]
+        svc.suggest([Document(text="example text")])[0]

--- a/tests/test_backend_tfidf.py
+++ b/tests/test_backend_tfidf.py
@@ -2,7 +2,7 @@
 
 import annif
 import annif.backend
-import annif.corpus
+from annif.corpus import Document
 
 
 def test_tfidf_default_params(project):
@@ -31,12 +31,14 @@ def test_tfidf_suggest(project):
 
     results = tfidf.suggest(
         [
-            """Arkeologiaa sanotaan joskus myös
+            Document(
+                text="""Arkeologiaa sanotaan joskus myös
         muinaistutkimukseksi tai muinaistieteeksi. Se on humanistinen tiede
         tai oikeammin joukko tieteitä, jotka tutkivat ihmisen menneisyyttä.
         Tutkimusta tehdään analysoimalla muinaisjäännöksiä eli niitä jälkiä,
         joita ihmisten toiminta on jättänyt maaperään tai vesistöjen
         pohjaan."""
+            )
         ]
     )[0]
 
@@ -52,12 +54,14 @@ def test_suggest_params(project):
 
     results = tfidf.suggest(
         [
-            """Arkeologiaa sanotaan joskus myös
+            Document(
+                text="""Arkeologiaa sanotaan joskus myös
         muinaistutkimukseksi tai muinaistieteeksi. Se on humanistinen tiede
         tai oikeammin joukko tieteitä, jotka tutkivat ihmisen menneisyyttä.
         Tutkimusta tehdään analysoimalla muinaisjäännöksiä eli niitä jälkiä,
         joita ihmisten toiminta on jättänyt maaperään tai vesistöjen
         pohjaan."""
+            )
         ],
         params,
     )[0]
@@ -68,6 +72,6 @@ def test_tfidf_suggest_unknown(project):
     tfidf_type = annif.backend.get_backend("tfidf")
     tfidf = tfidf_type(backend_id="tfidf", config_params={"limit": 10}, project=project)
 
-    results = tfidf.suggest(["abcdefghijk"])[0]  # unknown word
+    results = tfidf.suggest([Document(text="abcdefghijk")])[0]  # unknown word
 
     assert len(results) == 0

--- a/tests/test_backend_yake.py
+++ b/tests/test_backend_yake.py
@@ -4,6 +4,7 @@ import pytest
 
 import annif
 import annif.backend
+from annif.corpus import Document
 from annif.exception import ConfigurationException, NotSupportedException
 
 pytest.importorskip("annif.backend.yake")
@@ -17,7 +18,7 @@ def test_invalid_label_type(project):
         project=project,
     )
     with pytest.raises(ConfigurationException):
-        yake.suggest("example text")
+        yake.suggest([Document(text="example text")])
 
 
 def test_yake_suggest(project):
@@ -28,12 +29,14 @@ def test_yake_suggest(project):
 
     results = yake.suggest(
         [
-            """Arkeologia on tieteenala, jota sanotaan joskus
+            Document(
+                text="""Arkeologia on tieteenala, jota sanotaan joskus
         muinaistutkimukseksi tai muinaistieteeksi. Se on humanistinen tiede
         tai oikeammin joukko tieteitä, jotka tutkivat ihmisen menneisyyttä.
         Tutkimusta tehdään analysoimalla muinaisjäännöksiä eli niitä jälkiä,
         joita ihmisten toiminta on jättänyt maaperään tai vesistöjen
         pohjaan."""
+            )
         ]
     )[0]
 
@@ -49,7 +52,7 @@ def test_yake_suggest_no_input(project):
         backend_id="yake", config_params={"limit": 8, "language": "fi"}, project=project
     )
 
-    results = yake.suggest(["ja tai .,!"])[0]
+    results = yake.suggest([Document(text="ja tai .,!")])[0]
     assert len(results) == 0
 
 

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -253,6 +253,26 @@ def test_docfile_csv_plain(tmpdir, subject_index):
     assert len(list(docs.documents)) == 3
 
 
+def test_docfile_csv_metadata(tmpdir, subject_index):
+    docfile = tmpdir.join("documents-metadata.csv")
+    lines = (
+        "text,title,subject_uris,author",
+        (
+            "Consider a future device...,"
+            "As We May Think,"
+            "http://www.yso.fi/onto/yso/p817,"
+            '"Bush, Vannevar"'
+        ),
+    )
+    docfile.write("\n".join(lines))
+
+    docs = annif.corpus.DocumentFileCSV(str(docfile), subject_index)
+    firstdoc = next(docs.documents)
+    assert firstdoc.text == "Consider a future device..."
+    assert firstdoc.metadata["title"] == "As We May Think"
+    assert firstdoc.metadata["author"] == "Bush, Vannevar"
+
+
 def test_docfile_tsv_bom(tmpdir, subject_index):
     docfile = tmpdir.join("documents_bom.tsv")
     data = """Läntinen\t<http://www.yso.fi/onto/yso/p2557>
@@ -263,6 +283,7 @@ def test_docfile_tsv_bom(tmpdir, subject_index):
     docs = annif.corpus.DocumentFileTSV(str(docfile), subject_index)
     firstdoc = next(docs.documents)
     assert firstdoc.text.startswith("Läntinen")
+    assert firstdoc.metadata == {}
 
 
 def test_docfile_csv_bom(tmpdir, subject_index):
@@ -278,6 +299,7 @@ def test_docfile_csv_bom(tmpdir, subject_index):
     docs = annif.corpus.DocumentFileCSV(str(docfile), subject_index)
     firstdoc = next(docs.documents)
     assert firstdoc.text.startswith("Läntinen")
+    assert firstdoc.metadata == {}
 
 
 def test_docfile_tsv_plain_invalid_lines(tmpdir, caplog, subject_index):

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -10,6 +10,14 @@ from annif.corpus import Document, TransformingDocumentCorpus
 from annif.exception import OperationFailedException
 
 
+def test_document():
+    doc = Document(text="Hello world")
+    assert doc.text == "Hello world"
+    assert doc.subject_set == set()
+    assert doc.metadata == {}
+    assert repr(doc) == "Document(text='Hello world', subject_set=set(), metadata={})"
+
+
 def test_subjectset_uris(subject_index):
     data = """<http://www.yso.fi/onto/yso/p2558>\trautakausi
     <http://www.yso.fi/onto/yso/p12738>\tviikinkiaika

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -6,7 +6,7 @@ import numpy as np
 import pytest
 
 import annif.corpus
-from annif.corpus import TransformingDocumentCorpus
+from annif.corpus import Document, TransformingDocumentCorpus
 from annif.exception import OperationFailedException
 
 
@@ -420,8 +420,8 @@ def test_combinedcorpus(tmpdir, subject_index):
 
 
 def test_transformingcorpus(document_corpus):
-    def double(x):
-        return x + x
+    def double(doc):
+        return Document(doc.text + doc.text, subject_set=doc.subject_set)
 
     transformed_corpus = TransformingDocumentCorpus(document_corpus, double)
     for transf_doc, doc in zip(transformed_corpus.documents, document_corpus.documents):

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -7,6 +7,7 @@ import pytest
 
 import annif.backend.dummy
 import annif.project
+from annif.corpus import Document
 from annif.exception import ConfigurationException, NotSupportedException
 from annif.project import Access
 
@@ -290,7 +291,8 @@ def test_project_train_state_not_available(registry, caplog):
 
 def test_project_transform_text_pass_through(registry):
     project = registry.get_project("dummy-transform")
-    assert project.transform.transform_text("this is some text") == "this is some text"
+    doc = Document(text="this is some text")
+    assert project.transform.transform_doc(doc).text == "this is some text"
 
 
 def test_project_not_initialized(registry):

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -207,7 +207,7 @@ def test_project_learn(registry, tmpdir):
         str(tmpdir), project.subjects, "en", require_subjects=True
     )
     project.learn(docdir)
-    result = project.suggest(["this is some text"])[0]
+    result = project.suggest([Document(text="this is some text")])[0]
     assert len(result) == 1
     hits = list(result)
     assert hits[0].subject_id == project.subjects.by_uri("http://example.org/none")
@@ -244,7 +244,7 @@ def test_project_train_fasttext(registry, document_corpus, testdatadir):
 
 def test_project_suggest(registry):
     project = registry.get_project("dummy-en")
-    result = project.suggest(["this is some text"])[0]
+    result = project.suggest([Document(text="this is some text")])[0]
     assert len(result) == 1
     hits = list(result)
     assert hits[0].subject_id == project.subjects.by_uri("http://example.org/dummy")
@@ -253,7 +253,7 @@ def test_project_suggest(registry):
 
 def test_project_suggest_transform_limit(registry):
     project = registry.get_project("limit-transform")
-    result = project.suggest(["this is some text"])[0]
+    result = project.suggest([Document(text="this is some text")])[0]
     assert len(result) == 0
 
 
@@ -280,7 +280,7 @@ def test_project_train_state_not_available(registry, caplog):
     project = registry.get_project("dummy-vocablang")
     project.backend.is_trained = None
     with caplog.at_level(logging.WARNING):
-        result = project.suggest(["this is some text"])[0]
+        result = project.suggest([Document(text="this is some text")])[0]
     assert project.is_trained is None
     assert len(result) == 1
     hits = list(result)

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -67,4 +67,4 @@ def test_transform_not_implemented():
         pass
 
     with pytest.raises(NotImplementedError):
-        transform = NotImplementedTransform(None)
+        NotImplementedTransform(None)

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -43,6 +43,14 @@ def test_select_transform():
     assert new_doc.metadata == doc.metadata
 
 
+def test_select_transform_nonexistent():
+    transf = annif.transform.get_transform("select(nonexistent)", project=None)
+    doc = Document(text="mytext", metadata={"title": "My Title"})
+    new_doc = transf.transform_doc(doc)
+    assert new_doc.text == ""
+    assert new_doc.metadata == doc.metadata
+
+
 def test_chained_transforms_doc():
     transf = annif.transform.get_transform("limit(5),pass,limit(3),", project=None)
     assert transf.transform_doc(Document(text="abcdefghij")).text == "abc"

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -3,6 +3,7 @@
 import pytest
 
 import annif.transform
+from annif.corpus import Document
 from annif.exception import ConfigurationException
 from annif.transform import parse_specs
 
@@ -24,7 +25,8 @@ def test_get_transform_badspec(project):
 
 def test_input_limiter():
     transf = annif.transform.get_transform("limit(3)", project=None)
-    assert transf.transform_text("running") == "run"
+    doc = Document(text="running")
+    assert transf.transform_doc(doc).text == "run"
 
 
 def test_input_limiter_with_negative_value(project):
@@ -32,15 +34,15 @@ def test_input_limiter_with_negative_value(project):
         annif.transform.get_transform("limit(-2)", project)
 
 
-def test_chained_transforms_text():
+def test_chained_transforms_doc():
     transf = annif.transform.get_transform("limit(5),pass,limit(3),", project=None)
-    assert transf.transform_text("abcdefghij") == "abc"
+    assert transf.transform_doc(Document(text="abcdefghij")).text == "abc"
 
     # Check with a more arbitrary transform function
     reverser = annif.transform.transform.IdentityTransform(None)
-    reverser.transform_fn = lambda x: x[::-1]
+    reverser.transform_text = lambda x: x[::-1]
     transf.transforms.append(reverser)
-    assert transf.transform_text("abcdefghij") == "cba"
+    assert transf.transform_doc(Document(text="abcdefghij")).text == "cba"
 
 
 def test_chained_transforms_corpus(document_corpus):
@@ -52,7 +54,7 @@ def test_chained_transforms_corpus(document_corpus):
 
     # Check with a more arbitrary transform function
     reverser = annif.transform.transform.IdentityTransform(None)
-    reverser.transform_fn = lambda x: x[::-1]
+    reverser.transform_text = lambda x: x[::-1]
     transf.transforms.append(reverser)
     for transf_doc, doc in zip(transformed_corpus.documents, document_corpus.documents):
         assert transf_doc.text == doc.text[:3][::-1]

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -6,6 +6,7 @@ import annif.transform
 from annif.corpus import Document
 from annif.exception import ConfigurationException
 from annif.transform import parse_specs
+from annif.transform.transform import BaseTransform
 
 
 def test_parse_specs():
@@ -59,3 +60,11 @@ def test_chained_transforms_corpus(document_corpus):
     for transf_doc, doc in zip(transformed_corpus.documents, document_corpus.documents):
         assert transf_doc.text == doc.text[:3][::-1]
         assert transf_doc.subject_set == doc.subject_set
+
+
+def test_transform_not_implemented():
+    class NotImplementedTransform(BaseTransform):
+        pass
+
+    with pytest.raises(NotImplementedError):
+        transform = NotImplementedTransform(None)

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -35,6 +35,14 @@ def test_input_limiter_with_negative_value(project):
         annif.transform.get_transform("limit(-2)", project)
 
 
+def test_select_transform():
+    transf = annif.transform.get_transform("select(title,text)", project=None)
+    doc = Document(text="mytext", metadata={"title": "My Title"})
+    new_doc = transf.transform_doc(doc)
+    assert new_doc.text == "My Title\nmytext"
+    assert new_doc.metadata == doc.metadata
+
+
 def test_chained_transforms_doc():
     transf = annif.transform.get_transform("limit(5),pass,limit(3),", project=None)
     assert transf.transform_doc(Document(text="abcdefghij")).text == "abc"

--- a/tests/test_transform_langfilter.py
+++ b/tests/test_transform_langfilter.py
@@ -3,6 +3,7 @@
 import pytest
 
 import annif.transform
+from annif.corpus import Document
 
 pytest.importorskip("annif.transform.langfilter")
 
@@ -40,24 +41,24 @@ def test_lang_filter(project):
         arkistojen, museoiden ja muiden toimijoiden kanssa.
     """
     text_filtered = " ".join(text_filtered.split())
-    assert transf.transform_text(text) == text_filtered
+    assert transf.transform_doc(Document(text=text)).text == text_filtered
 
 
 def test_lang_filter_text_min_length(project):
     text = "This is just some non-Finnish text of 52 characters."
     transf = annif.transform.get_transform("filter_lang", project)
-    assert transf.transform_text(text) == text
+    assert transf.transform_doc(Document(text=text)).text == text
     # Set a short text_min_length to apply language filtering:
     transf = annif.transform.get_transform("filter_lang(text_min_length=50)", project)
-    assert transf.transform_text(text) == ""
+    assert transf.transform_doc(Document(text=text)).text == ""
 
 
 def test_lang_filter_sentence_min_length(project):
     text = "This is a non-Finnish sentence of 42 chars. And this of 20 chars."
     transf = annif.transform.get_transform("filter_lang(text_min_length=50)", project)
-    assert transf.transform_text(text) == text
+    assert transf.transform_doc(Document(text=text)).text == text
     # Set a short sentence_min_length to apply language filtering:
     transf = annif.transform.get_transform(
         "filter_lang(text_min_length=50,sentence_min_length=30)", project
     )
-    assert transf.transform_text(text) == "And this of 20 chars."
+    assert transf.transform_doc(Document(text=text)).text == "And this of 20 chars."


### PR DESCRIPTION
2nd part of #813, after PR #863

This PR implements the core functionality needed for experimenting with "flexible fusion", i.e. making it possible to apply Annif backends not just on document text, but metadata fields. It enables the following:

* The CSV short text format can now contain extra columns/fields for metadata. Internally, they are stored in the new `metadata` field within Document objects.
* A new transform `select` can be used to select which parts of a document (main text and/or metadata fields) are given as input to the backend. For example `select(title)` or `select(title,description,text)`

# Implementation notes

* I had to change the namedtuple Document into a real class in order to better support optional fields. Now only `text` is a mandatory field, while `subject_set` and `metadata` are optional (defaulting to empty set and empty dict, respectively)
* I extended the transform functionality. Previously transforms could only operate on text. Now transforms can implement either `transform_text` (to transform text only, similar as before) or `transform_doc` (transform whole Document objects). The latter was needed to implement the `select` transform.
* I had to change all the various suggest methods on both projects and backends to accept a Document (or batch of Document objects) instead of text. This lead to a lot of churn, but it's all in a single commit b0bb1632936f674d5400e9f94a33de6a048451e1.
* ~~Currently, this PR is targeting the PR branch of #863 because this is built on top of that.~~ It needs to be merged after #863.

# What is still missing

This PR implements only the minimum needed for experimentation with custom metadata and select transforms: it should now be possible to train and evaluate models with custom document metadata, as long as the CSV short text corpus format is used.

These parts are still missing, to be implemented in future PRs:

* support for metadata in the full text corpus format (for example via YAML front matter, or a separate file for metadata)
* CLI suggest command should allow specifying extra metadata fields, probably as command line arguments
* REST API suggest method should allow specifying extra metadata fields in the request + the `http` backend should support it
* Web UI should allow entering metadata fields
