### PR TITLE
Flexible fusion part 4: REST API document metadata support

### DIFF
--- a/annif/backend/http.py
+++ b/annif/backend/http.py
@@ -70,6 +70,8 @@ class HTTPBackend(backend.AnnifBackend):
         self, doc: Document, params: dict[str, Any]
     ) -> list[SubjectSuggestion]:
         data = {"text": doc.text}
+        for key, value in doc.metadata.items():
+            data[f"metadata_{key}"] = value
         if "project" in params:
             data["project"] = params["project"]
         if "limit" in params:

--- a/annif/openapi/annif.yaml
+++ b/annif/openapi/annif.yaml
@@ -392,13 +392,21 @@ components:
         document_id:
           type: string
           example: doc-1234
-      description: A document with an optional identifier
+        metadata:
+          type: object
+          additionalProperties:
+              type: string
+      description: A document with an optional identifier and/or metadata
     IndexedDocument:
       type: object
       properties:
         text:
           type: string
           example: A quick brown fox jumped over the lazy dog.
+        metadata:
+          type: object
+          additionalProperties:
+              type: string
         subjects:
           type: array
           items:

--- a/annif/openapi/annif.yaml
+++ b/annif/openapi/annif.yaml
@@ -66,6 +66,10 @@ paths:
       tags:
       - Automatic subject indexing
       summary: suggest subjects for a given text
+      description: >
+        This method suggests relevant subjects for a given input text (with
+        optional metadata). It supports optional parameters to control the
+        number of results, score threshold, and language of the subject labels.
       operationId: annif.rest.suggest
       parameters:
       - $ref: '#/components/parameters/project_id'
@@ -118,6 +122,10 @@ paths:
       tags:
       - Automatic subject indexing
       summary: suggest subjects for the given batch of up to 32 documents
+      description: >
+        This method suggests relevant subjects for a batch of up to 32 input texts
+        (with optional metadata). It supports optional parameters to control the
+        number of results, score threshold, and language of the subject labels.
       operationId: annif.rest.suggest_batch
       parameters:
       - $ref: '#/components/parameters/project_id'

--- a/annif/openapi/annif.yaml
+++ b/annif/openapi/annif.yaml
@@ -96,6 +96,9 @@ paths:
                 language:
                   type: string
                   description: language of subject labels
+              additionalProperties:
+                type: string
+                description: Additional metadata properties, starting with 'metadata_'
         required: true
       responses:
         "200":

--- a/annif/rest.py
+++ b/annif/rest.py
@@ -166,7 +166,12 @@ def suggest(
     parameters = dict(
         (key, body[key]) for key in ["language", "limit", "threshold"] if key in body
     )
-    documents = [{"text": body["text"]}]
+    metadata = {
+        key[len("metadata_") :]: value
+        for key, value in body.items()
+        if key.startswith("metadata_")
+    }
+    documents = [{"text": body["text"], "metadata": metadata}]
     result = _suggest(project_id, documents, parameters)
 
     if _is_error(result):
@@ -233,13 +238,16 @@ def _documents_to_corpus(
                 subject_set=SubjectSet(
                     [subject_index.by_uri(subj["uri"]) for subj in d["subjects"]]
                 ),
+                metadata=d.get("metadata", {}),
             )
             for d in documents
             if "text" in d and "subjects" in d
         ]
     else:
         corpus = [
-            Document(text=d["text"], subject_set=None) for d in documents if "text" in d
+            Document(text=d["text"], subject_set=None, metadata=d.get("metadata", {}))
+            for d in documents
+            if "text" in d
         ]
     return DocumentList(corpus)
 

--- a/tests/test_backend_http.py
+++ b/tests/test_backend_http.py
@@ -97,7 +97,7 @@ def test_http_suggest_post_args(app_project):
             },
             project=app_project,
         )
-        http.suggest([Document(text="this is some text")])
+        http.suggest([Document(text="this is some text", metadata={"field": "value"})])
 
         assert requests.post.call_args.args == ("http://api.example.org/analyze",)
         assert "text" in requests.post.call_args.kwargs["data"]
@@ -106,6 +106,8 @@ def test_http_suggest_post_args(app_project):
         assert requests.post.call_args.kwargs["data"]["project"] == "dummy"
         assert "limit" in requests.post.call_args.kwargs["data"]
         assert requests.post.call_args.kwargs["data"]["limit"] == "42"
+        assert "metadata_field" in requests.post.call_args.kwargs["data"]
+        assert requests.post.call_args.kwargs["data"]["metadata_field"] == "value"
 
 
 def test_http_suggest_zero_score(project):

--- a/tests/test_rest.py
+++ b/tests/test_rest.py
@@ -224,6 +224,22 @@ def test_rest_suggest_batch_two_docs(app):
         assert result[1]["results"][0]["label"] == "dummy-fi"
 
 
+def test_rest_suggest_batch_two_docs_with_metadata(app):
+    with app.app_context():
+        result = annif.rest.suggest_batch(
+            "dummy-fi",
+            {
+                "documents": [
+                    {"text": "example text", "metadata": {"score": 0.5}},
+                    {"text": "another example text", "metadata": {"score": 0.7}},
+                ]
+            },
+        )[0]
+        assert len(result) == 2
+        assert result[0]["results"][0]["score"] == pytest.approx(0.5)
+        assert result[1]["results"][0]["score"] == pytest.approx(0.7)
+
+
 def test_rest_suggest_batch_with_language_override(app):
     with app.app_context():
         result = annif.rest.suggest_batch(

--- a/tests/test_rest.py
+++ b/tests/test_rest.py
@@ -2,6 +2,8 @@
 
 import importlib
 
+import pytest
+
 import annif.rest
 
 
@@ -170,6 +172,20 @@ def test_rest_suggest_with_notations(app):
             "dummy-fi", {"text": "example text", "limit": 10, "threshold": 0.0}
         )[0]
         assert result["results"][0]["notation"] is None
+
+
+def test_rest_suggest_with_metadata(app):
+    with app.app_context():
+        result = annif.rest.suggest(
+            "dummy-fi",
+            {
+                "text": "example text",
+                "limit": 10,
+                "threshold": 0.0,
+                "metadata_score": 0.6,
+            },
+        )[0]
+        assert result["results"][0]["score"] == pytest.approx(0.6)
 
 
 def test_rest_suggest_batch_one_doc(app):


### PR DESCRIPTION
4th part of #813, after #866.

This PR adds support for document metadata into the REST API methods `suggest`, `suggest_batch` and `learn`. It also adds metadata support to the `http` backend so that it will pass along any document metadata to the REST API call.

# `suggest` method

The `suggest` method accepts a request body of the type `application/x-www-form-urlencoded`. This is a bit old-fashioned and means that the basic data structure is a flat list of `field=value` pairs. Before this PR, there were only a few valid field names in use, including `text`, `limit` and `threshold`. I considered several alternatives on how to add support for metadata fields, which could have arbitrary names:

1. Use the metadata field directly as the field name, e.g. `title=As We May Think`
2. Use the metadata field with a prefix, e.g. `metadata_title=As We May Think`
3. Use an indexed field name that looks a bit like a dict lookup, e.g. `metadata[title]=As We May Think`
4. Use a structured JSON value that includes all metadata fields and their values, e.g. `metadata={"title": "As We May Think"}`

Option 1 has the problem that the metadata field names could clash with existing (or future) field names. Option 3 is a bit difficult to implement both in the client and in the server code, though could be done (this pattern is sometimes used in PHP web applications). Option 4 seemed a bit weird to me. So I went for Option 2, using the prefix `metadata_`.

## How to test

Sadly, it appears that the Swagger UI for testing the REST API does not understand `additionalProperties` in this context so it's not possible to include metadata properties in a test request. Here is a way of doing it using `curl` on the command line (note the last part with `metadata_title`):

```
curl  'http://127.0.0.1:5000/v1/projects/myproject/suggest' \
  -H 'accept: application/json' \
  -H 'Content-Type: application/x-www-form-urlencoded' \
  -d 'text=my_test&metadata_title=As We May Think'
```

# `suggest_batch` and `learn` methods

These methods already accept a structured JSON request body, so it was fairly simple to add a new, optional `metadata` field with an object as the value, storing metadata fields and their values.

## How to test

This can be tested by sending a request body like this to `suggest_batch`:

```json
{
  "documents": [
    {
      "text": "A quick brown fox jumped over the lazy dog.",
      "document_id": "doc-1234",
      "metadata": {
        "title": "As We May Think"
      }
    }
  ]
}
```

for example using curl:

```
curl -X 'POST' \
  'http://127.0.0.1:5000/v1/projects/myproject/suggest-batch?limit=10&threshold=0' \
  -H 'accept: application/json' \
  -H 'Content-Type: application/json' \
  -d '{
  "documents": [
    {
      "text": "A quick brown fox jumped over the lazy dog.",
      "document_id": "doc-1234",
      "metadata": {
        "title": "As We May Think"
      }
    }
  ]
}'
```

The Swagger UI also supports this. You simply have to edit the JSON request body. It already contains placeholder keys and values for metadata.

# `http` backend

The `http` backend currently only supports the plain `suggest` method (one document at a time), not `suggest_batch`. I simply amended the code to pass along any metadata values using the `metadata_` prefix for field names.