### PR TITLE
Add JSON fulltext corpus format

### DIFF
--- a/annif/cli.py
+++ b/annif/cli.py
@@ -332,7 +332,7 @@ def run_index(
     results = project.suggest_corpus(documents, backend_params).filter(limit, threshold)
 
     for docfilename, suggestions in zip(documents, results):
-        subjectfilename = re.sub(r"\.txt$", suffix, docfilename)
+        subjectfilename = re.sub(r"\.(txt|json)$", suffix, docfilename)
         if os.path.exists(subjectfilename) and not force:
             click.echo(
                 "Not overwriting {} (use --force to override)".format(subjectfilename)

--- a/annif/cli.py
+++ b/annif/cli.py
@@ -328,11 +328,11 @@ def run_index(
         raise click.BadParameter(f'language "{lang}" not supported by vocabulary')
     backend_params = cli_util.parse_backend_params(backend_param, project)
 
-    documents = DocumentDirectory(directory, require_subjects=False)
-    results = project.suggest_corpus(documents, backend_params).filter(limit, threshold)
+    corpus = DocumentDirectory(directory, require_subjects=False)
+    results = project.suggest_corpus(corpus, backend_params).filter(limit, threshold)
 
-    for docfilename, suggestions in zip(documents, results):
-        subjectfilename = re.sub(r"\.(txt|json)$", suffix, docfilename)
+    for doc, suggestions in zip(corpus.documents, results):
+        subjectfilename = re.sub(r"\.(txt|json)$", suffix, doc.file_path)
         if os.path.exists(subjectfilename) and not force:
             click.echo(
                 "Not overwriting {} (use --force to override)".format(subjectfilename)

--- a/annif/cli.py
+++ b/annif/cli.py
@@ -331,7 +331,7 @@ def run_index(
     documents = DocumentDirectory(directory, require_subjects=False)
     results = project.suggest_corpus(documents, backend_params).filter(limit, threshold)
 
-    for (docfilename, _), suggestions in zip(documents, results):
+    for docfilename, suggestions in zip(documents, results):
         subjectfilename = re.sub(r"\.txt$", suffix, docfilename)
         if os.path.exists(subjectfilename) and not force:
             click.echo(

--- a/annif/corpus/document.py
+++ b/annif/corpus/document.py
@@ -66,7 +66,7 @@ class DocumentDirectory(DocumentCorpus):
         with open(filename, errors="replace", encoding="utf-8-sig") as docfile:
             text = docfile.read()
         if not self.require_subjects:
-            return Document(text=text, subject_set=None)
+            return Document(text=text, subject_set=None, file_path=filename)
 
         subjfilename = self._get_subject_filename(filename)
         if subjfilename is None:
@@ -77,7 +77,7 @@ class DocumentDirectory(DocumentCorpus):
             subjects = SubjectSet.from_string(
                 subjfile.read(), self.subject_index, self.language
             )
-        return Document(text=text, subject_set=subjects)
+        return Document(text=text, subject_set=subjects, file_path=filename)
 
     @property
     def documents(self) -> Iterator[Document]:

--- a/annif/corpus/document.py
+++ b/annif/corpus/document.py
@@ -80,8 +80,16 @@ class DocumentDirectory(DocumentCorpus):
         return Document(text=text, subject_set=subjects)
 
     def _read_json_file(self, filename: str) -> Document | None:
+        if os.path.getsize(filename) == 0:
+            logger.warning(f"Skipping empty file {filename}")
+            return None
+
         with open(filename) as jsonfile:
-            data = json.load(jsonfile)
+            try:
+                data = json.load(jsonfile)
+            except json.JSONDecodeError as err:
+                logger.warning(f"JSON parsing failed for file {filename}: {err}")
+                return None
 
         subjects = SubjectSet(
             [

--- a/annif/corpus/json.py
+++ b/annif/corpus/json.py
@@ -1,0 +1,51 @@
+"""Support for document corpora in JSON format"""
+
+import json
+import os.path
+
+import annif
+from annif.vocab import SubjectIndex
+
+from .types import Document, SubjectSet
+
+logger = annif.logger
+
+
+def _subjects_to_subject_set(subjects, subject_index, language):
+    subject_ids = []
+    for subj in subjects:
+        if "uri" in subj:
+            subject_ids.append(subject_index.by_uri(subj["uri"]))
+        else:
+            subject_ids.append(subject_index.by_label(subj["label"], language))
+    return SubjectSet(subject_ids)
+
+
+def json_file_to_document(
+    filename: str,
+    subject_index: SubjectIndex,
+    language: str,
+    require_subjects: bool,
+) -> Document | None:
+    if os.path.getsize(filename) == 0:
+        logger.warning(f"Skipping empty file {filename}")
+        return None
+
+    with open(filename) as jsonfile:
+        try:
+            data = json.load(jsonfile)
+        except json.JSONDecodeError as err:
+            logger.warning(f"JSON parsing failed for file {filename}: {err}")
+            return None
+
+    subject_set = _subjects_to_subject_set(
+        data.get("subjects", []), subject_index, language
+    )
+    if require_subjects and not subject_set:
+        return None
+
+    return Document(
+        text=data.get("text", ""),
+        metadata=data.get("metadata", {}),
+        subject_set=subject_set,
+    )

--- a/annif/corpus/json.py
+++ b/annif/corpus/json.py
@@ -65,4 +65,5 @@ def json_file_to_document(
         text=data.get("text", ""),
         metadata=data.get("metadata", {}),
         subject_set=subject_set,
+        file_path=filename,
     )

--- a/annif/corpus/json.py
+++ b/annif/corpus/json.py
@@ -52,7 +52,7 @@ def json_file_to_document(
     try:
         jsonschema.validate(instance=data, schema=_get_json_schema("document.json"))
     except jsonschema.ValidationError as err:
-        logger.warning(f"JSON validation failed for file {filename}: {err}")
+        logger.warning(f"JSON validation failed for file {filename}: {err.message}")
         return None
 
     subject_set = _subjects_to_subject_set(

--- a/annif/corpus/json.py
+++ b/annif/corpus/json.py
@@ -42,7 +42,7 @@ def json_file_to_document(
         logger.warning(f"Skipping empty file {filename}")
         return None
 
-    with open(filename) as jsonfile:
+    with open(filename, "r", encoding="utf-8") as jsonfile:
         try:
             data = json.load(jsonfile)
         except json.JSONDecodeError as err:

--- a/annif/corpus/types.py
+++ b/annif/corpus/types.py
@@ -14,16 +14,18 @@ if TYPE_CHECKING:
 
 
 class Document:
-    def __init__(self, text, subject_set=None, metadata=None):
+    def __init__(self, text, subject_set=None, metadata=None, file_path=None):
         self.text = text
         self.subject_set = subject_set if subject_set is not None else set()
         self.metadata = metadata if metadata is not None else {}
+        self.file_path = file_path
 
     def __repr__(self):
         return (
             f"Document(text={self.text!r}, "
             f"subject_set={self.subject_set!r}, "
-            f"metadata={self.metadata!r})"
+            f"metadata={self.metadata!r}, "
+            f"file_path={self.file_path!r})"
         )
 
 

--- a/annif/schemas/document.json
+++ b/annif/schemas/document.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Document",
+  "type": "object",
+  "properties": {
+    "text": {
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "subjects": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "uri": {
+            "type": "string",
+            "format": "uri"
+          },
+          "label": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false,
+        "anyOf": [
+          { "required": ["uri"] },
+          { "required": ["label"] }
+        ]
+      }
+    }
+  },
+  "anyOf": [
+    { "required": ["text"] },
+    { "required": ["metadata"] }
+  ],
+  "additionalProperties": false
+}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,6 +10,7 @@ import shutil
 from datetime import datetime, timedelta
 from unittest import mock
 
+import pytest
 from click.shell_completion import ShellComplete
 from click.testing import CliRunner
 from huggingface_hub.utils import HFValidationError
@@ -728,17 +729,17 @@ def test_eval_label(tmpdir):
     assert result.exit_code == 0
 
     precision = re.search(r"Precision .*doc.*:\s+(\d.\d+)", result.output)
-    assert float(precision.group(1)) == 0.5
+    assert float(precision.group(1)) == pytest.approx(0.5)
     recall = re.search(r"Recall .*doc.*:\s+(\d.\d+)", result.output)
-    assert float(recall.group(1)) == 0.5
+    assert float(recall.group(1)) == pytest.approx(0.5)
     f_measure = re.search(r"F1 score .*doc.*:\s+(\d.\d+)", result.output)
-    assert float(f_measure.group(1)) == 0.5
+    assert float(f_measure.group(1)) == pytest.approx(0.5)
     precision1 = re.search(r"Precision@1:\s+(\d.\d+)", result.output)
-    assert float(precision1.group(1)) == 0.5
+    assert float(precision1.group(1)) == pytest.approx(0.5)
     precision3 = re.search(r"Precision@3:\s+(\d.\d+)", result.output)
-    assert float(precision3.group(1)) == 0.5
+    assert float(precision3.group(1)) == pytest.approx(0.5)
     precision5 = re.search(r"Precision@5:\s+(\d.\d+)", result.output)
-    assert float(precision5.group(1)) == 0.5
+    assert float(precision5.group(1)) == pytest.approx(0.5)
     true_positives = re.search(r"True positives:\s+(\d+)", result.output)
     assert int(true_positives.group(1)) == 1
     false_positives = re.search(r"False positives:\s+(\d+)", result.output)
@@ -761,17 +762,17 @@ def test_eval_uri(tmpdir):
     assert result.exit_code == 0
 
     precision = re.search(r"Precision .*doc.*:\s+(\d.\d+)", result.output)
-    assert float(precision.group(1)) == 0.5
+    assert float(precision.group(1)) == pytest.approx(0.5)
     recall = re.search(r"Recall .*doc.*:\s+(\d.\d+)", result.output)
-    assert float(recall.group(1)) == 0.5
+    assert float(recall.group(1)) == pytest.approx(0.5)
     f_measure = re.search(r"F1 score .*doc.*:\s+(\d.\d+)", result.output)
-    assert float(f_measure.group(1)) == 0.5
+    assert float(f_measure.group(1)) == pytest.approx(0.5)
     precision1 = re.search(r"Precision@1:\s+(\d.\d+)", result.output)
-    assert float(precision1.group(1)) == 0.5
+    assert float(precision1.group(1)) == pytest.approx(0.5)
     precision3 = re.search(r"Precision@3:\s+(\d.\d+)", result.output)
-    assert float(precision3.group(1)) == 0.5
+    assert float(precision3.group(1)) == pytest.approx(0.5)
     precision5 = re.search(r"Precision@5:\s+(\d.\d+)", result.output)
-    assert float(precision5.group(1)) == 0.5
+    assert float(precision5.group(1)) == pytest.approx(0.5)
     true_positives = re.search(r"True positives:\s+(\d+)", result.output)
     assert int(true_positives.group(1)) == 1
     false_positives = re.search(r"False positives:\s+(\d+)", result.output)
@@ -795,17 +796,17 @@ def test_eval_json(tmpdir):
     assert result.exit_code == 0
 
     precision = re.search(r"Precision .*doc.*:\s+(\d.\d+)", result.output)
-    assert float(precision.group(1)) == 0.5
+    assert float(precision.group(1)) == pytest.approx(0.5)
     recall = re.search(r"Recall .*doc.*:\s+(\d.\d+)", result.output)
-    assert float(recall.group(1)) == 0.5
+    assert float(recall.group(1)) == pytest.approx(0.5)
     f_measure = re.search(r"F1 score .*doc.*:\s+(\d.\d+)", result.output)
-    assert float(f_measure.group(1)) == 0.5
+    assert float(f_measure.group(1)) == pytest.approx(0.5)
     precision1 = re.search(r"Precision@1:\s+(\d.\d+)", result.output)
-    assert float(precision1.group(1)) == 0.5
+    assert float(precision1.group(1)) == pytest.approx(0.5)
     precision3 = re.search(r"Precision@3:\s+(\d.\d+)", result.output)
-    assert float(precision3.group(1)) == 0.5
+    assert float(precision3.group(1)) == pytest.approx(0.5)
     precision5 = re.search(r"Precision@5:\s+(\d.\d+)", result.output)
-    assert float(precision5.group(1)) == 0.5
+    assert float(precision5.group(1)) == pytest.approx(0.5)
     true_positives = re.search(r"True positives:\s+(\d+)", result.output)
     assert int(true_positives.group(1)) == 1
     false_positives = re.search(r"False positives:\s+(\d+)", result.output)
@@ -833,7 +834,7 @@ def test_eval_param(tmpdir):
     # since zero scores were set with the parameter, there should be no hits
     # at all
     recall = re.search(r"Recall .*doc.*:\s+(\d.\d+)", result.output)
-    assert float(recall.group(1)) == 0.0
+    assert float(recall.group(1)) == pytest.approx(0.0)
 
 
 def test_eval_metric(tmpdir):
@@ -1043,11 +1044,11 @@ def test_optimize_dir(tmpdir):
     assert result.exit_code == 0
 
     precision = re.search(r"Best\s+Precision .*?doc.*?:\s+(\d.\d+)", result.output)
-    assert float(precision.group(1)) == 0.5
+    assert float(precision.group(1)) == pytest.approx(0.5)
     recall = re.search(r"Best\s+Recall .*?doc.*?:\s+(\d.\d+)", result.output)
-    assert float(recall.group(1)) == 0.5
+    assert float(recall.group(1)) == pytest.approx(0.5)
     f_measure = re.search(r"Best\s+F1 score .*?doc.*?:\s+(\d.\d+)", result.output)
-    assert float(f_measure.group(1)) == 0.5
+    assert float(f_measure.group(1)) == pytest.approx(0.5)
     ndocs = re.search(r"Documents evaluated:\s+(\d)", result.output)
     assert int(ndocs.group(1)) == 2
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -782,6 +782,40 @@ def test_eval_uri(tmpdir):
     assert int(ndocs.group(1)) == 2
 
 
+def test_eval_json(tmpdir):
+    data1 = {"text": "doc1", "subjects": [{"uri": "http://example.org/dummy"}]}
+    tmpdir.join("doc1.json").write(json.dumps(data1))
+    data2 = {"text": "doc2", "subjects": [{"uri": "http://example.org/none"}]}
+    tmpdir.join("doc2.json").write(json.dumps(data2))
+    data3 = {"text": "doc3"}
+    tmpdir.join("doc3.json").write(json.dumps(data3))
+
+    result = runner.invoke(annif.cli.cli, ["eval", "dummy-en", str(tmpdir)])
+    assert not result.exception
+    assert result.exit_code == 0
+
+    precision = re.search(r"Precision .*doc.*:\s+(\d.\d+)", result.output)
+    assert float(precision.group(1)) == 0.5
+    recall = re.search(r"Recall .*doc.*:\s+(\d.\d+)", result.output)
+    assert float(recall.group(1)) == 0.5
+    f_measure = re.search(r"F1 score .*doc.*:\s+(\d.\d+)", result.output)
+    assert float(f_measure.group(1)) == 0.5
+    precision1 = re.search(r"Precision@1:\s+(\d.\d+)", result.output)
+    assert float(precision1.group(1)) == 0.5
+    precision3 = re.search(r"Precision@3:\s+(\d.\d+)", result.output)
+    assert float(precision3.group(1)) == 0.5
+    precision5 = re.search(r"Precision@5:\s+(\d.\d+)", result.output)
+    assert float(precision5.group(1)) == 0.5
+    true_positives = re.search(r"True positives:\s+(\d+)", result.output)
+    assert int(true_positives.group(1)) == 1
+    false_positives = re.search(r"False positives:\s+(\d+)", result.output)
+    assert int(false_positives.group(1)) == 1
+    false_negatives = re.search(r"False negatives:\s+(\d+)", result.output)
+    assert int(false_negatives.group(1)) == 1
+    ndocs = re.search(r"Documents evaluated:\s+(\d+)", result.output)
+    assert int(ndocs.group(1)) == 2
+
+
 def test_eval_param(tmpdir):
     tmpdir.join("doc1.txt").write("doc1")
     tmpdir.join("doc1.key").write("dummy")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -576,8 +576,8 @@ def test_suggest_file(tmpdir):
 def test_suggest_two_files(tmpdir):
     docfile1 = tmpdir.join("doc-1.txt")
     docfile1.write("nothing special")
-    docfile2 = tmpdir.join("doc-2.txt")
-    docfile2.write("again nothing special")
+    docfile2 = tmpdir.join("doc-2.json")
+    docfile2.write(json.dumps({"text": "again nothing special"}))
 
     result = runner.invoke(
         annif.cli.cli, ["suggest", "dummy-fi", str(docfile1), str(docfile2)]

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -17,7 +17,11 @@ def test_document():
     assert doc.text == "Hello world"
     assert doc.subject_set == set()
     assert doc.metadata == {}
-    assert repr(doc) == "Document(text='Hello world', subject_set=set(), metadata={})"
+    assert doc.file_path is None
+    assert repr(doc) == (
+        "Document(text='Hello world', subject_set=set(), "
+        "metadata={}, file_path=None)"
+    )
 
 
 def test_subjectset_uris(subject_index):

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -8,7 +8,7 @@ import numpy as np
 import pytest
 
 import annif.corpus
-from annif.corpus import Document, TransformingDocumentCorpus
+from annif.corpus import Document, SubjectSet, TransformingDocumentCorpus
 from annif.exception import OperationFailedException
 
 
@@ -242,7 +242,7 @@ def test_docdir_tsv_require_subjects(tmpdir, subject_index):
 def test_docdir_json_require_subjects(tmpdir, subject_index):
     data1 = {"text": "doc1", "subjects": [{"uri": "http://www.yso.fi/onto/yso/p2558"}]}
     tmpdir.join("doc1.json").write(json.dumps(data1))
-    data2 = {"text": "doc2", "subjects": [{"uri": "http://www.yso.fi/onto/yso/p4622"}]}
+    data2 = {"text": "doc2", "subjects": [{"label": "prehistory"}]}
     tmpdir.join("doc2.json").write(json.dumps(data2))
     data3 = {"text": "doc3"}
     tmpdir.join("doc3.json").write(json.dumps(data3))
@@ -261,6 +261,12 @@ def test_docdir_json_require_subjects(tmpdir, subject_index):
     # only 2 of the files include subjects
     docs = list(docdir.documents)
     assert len(docs) == 2
+    assert docs[0].subject_set == SubjectSet(
+        [subject_index.by_uri("http://www.yso.fi/onto/yso/p2558")]
+    )
+    assert docs[1].subject_set == SubjectSet(
+        [subject_index.by_uri("http://www.yso.fi/onto/yso/p4622")]
+    )
 
 
 def test_docdir_tsv_as_doccorpus(tmpdir, subject_index):

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -99,12 +99,9 @@ def test_docdir_key(tmpdir):
     docdir = annif.corpus.DocumentDirectory(str(tmpdir), require_subjects=False)
     files = sorted(list(docdir))
     assert len(files) == 3
-    assert files[0][0] == str(tmpdir.join("doc1.txt"))
-    assert files[0][1] is None
-    assert files[1][0] == str(tmpdir.join("doc2.txt"))
-    assert files[1][1] is None
-    assert files[2][0] == str(tmpdir.join("doc3.txt"))
-    assert files[2][1] is None
+    assert files[0] == str(tmpdir.join("doc1.txt"))
+    assert files[1] == str(tmpdir.join("doc2.txt"))
+    assert files[2] == str(tmpdir.join("doc3.txt"))
 
 
 def test_docdir_tsv(tmpdir):
@@ -117,12 +114,9 @@ def test_docdir_tsv(tmpdir):
     docdir = annif.corpus.DocumentDirectory(str(tmpdir), require_subjects=False)
     files = sorted(list(docdir))
     assert len(files) == 3
-    assert files[0][0] == str(tmpdir.join("doc1.txt"))
-    assert files[0][1] is None
-    assert files[1][0] == str(tmpdir.join("doc2.txt"))
-    assert files[1][1] is None
-    assert files[2][0] == str(tmpdir.join("doc3.txt"))
-    assert files[2][1] is None
+    assert files[0] == str(tmpdir.join("doc1.txt"))
+    assert files[1] == str(tmpdir.join("doc2.txt"))
+    assert files[2] == str(tmpdir.join("doc3.txt"))
 
 
 def test_docdir_tsv_bom(tmpdir, subject_index):
@@ -161,12 +155,17 @@ def test_docdir_key_require_subjects(tmpdir, subject_index):
     docdir = annif.corpus.DocumentDirectory(
         str(tmpdir), subject_index, "en", require_subjects=True
     )
+
+    # the docdir contains 3 files
     files = sorted(list(docdir))
-    assert len(files) == 2
-    assert files[0][0] == str(tmpdir.join("doc1.txt"))
-    assert files[0][1] == str(tmpdir.join("doc1.key"))
-    assert files[1][0] == str(tmpdir.join("doc2.txt"))
-    assert files[1][1] == str(tmpdir.join("doc2.key"))
+    assert len(files) == 3
+    assert files[0] == str(tmpdir.join("doc1.txt"))
+    assert files[1] == str(tmpdir.join("doc2.txt"))
+    assert files[2] == str(tmpdir.join("doc3.txt"))
+
+    # only 2 of the files include subjects
+    docs = list(docdir.documents)
+    assert len(docs) == 2
 
 
 def test_docdir_tsv_require_subjects(tmpdir, subject_index):
@@ -179,12 +178,17 @@ def test_docdir_tsv_require_subjects(tmpdir, subject_index):
     docdir = annif.corpus.DocumentDirectory(
         str(tmpdir), subject_index, "en", require_subjects=True
     )
+
+    # the docdir contains 3 files
     files = sorted(list(docdir))
-    assert len(files) == 2
-    assert files[0][0] == str(tmpdir.join("doc1.txt"))
-    assert files[0][1] == str(tmpdir.join("doc1.tsv"))
-    assert files[1][0] == str(tmpdir.join("doc2.txt"))
-    assert files[1][1] == str(tmpdir.join("doc2.tsv"))
+    assert len(files) == 3
+    assert files[0] == str(tmpdir.join("doc1.txt"))
+    assert files[1] == str(tmpdir.join("doc2.txt"))
+    assert files[2] == str(tmpdir.join("doc3.txt"))
+
+    # only 2 of the files include subjects
+    docs = list(docdir.documents)
+    assert len(docs) == 2
 
 
 def test_docdir_tsv_as_doccorpus(tmpdir, subject_index):

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -193,6 +193,21 @@ def test_docdir_json_broken(tmpdir, caplog):
     assert "JSON parsing failed" in caplog.text
 
 
+def test_docdir_json_invalid(tmpdir, caplog):
+    tmpdir.join("doc1.json").write(json.dumps({"follows_schema": False}))
+
+    docdir = annif.corpus.DocumentDirectory(str(tmpdir), require_subjects=False)
+    files = sorted(docdir)
+    assert len(files) == 1
+    assert files[0] == str(tmpdir.join("doc1.json"))
+
+    with caplog.at_level(logging.WARNING):
+        docs = list(docdir.documents)
+
+    assert len(docs) == 0
+    assert "JSON validation failed" in caplog.text
+
+
 def test_docdir_key_require_subjects(tmpdir, subject_index):
     tmpdir.join("doc1.txt").write("doc1")
     tmpdir.join("doc1.key").write("<http://example.org/key1>\tkey1")

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -98,7 +98,7 @@ def test_docdir_key(tmpdir):
     tmpdir.join("doc3.txt").write("doc3")
 
     docdir = annif.corpus.DocumentDirectory(str(tmpdir), require_subjects=False)
-    files = sorted(list(docdir))
+    files = sorted(docdir)
     assert len(files) == 3
     assert files[0] == str(tmpdir.join("doc1.txt"))
     assert files[1] == str(tmpdir.join("doc2.txt"))
@@ -113,7 +113,7 @@ def test_docdir_tsv(tmpdir):
     tmpdir.join("doc3.txt").write("doc3")
 
     docdir = annif.corpus.DocumentDirectory(str(tmpdir), require_subjects=False)
-    files = sorted(list(docdir))
+    files = sorted(docdir)
     assert len(files) == 3
     assert files[0] == str(tmpdir.join("doc1.txt"))
     assert files[1] == str(tmpdir.join("doc2.txt"))
@@ -155,7 +155,7 @@ def test_docdir_json(tmpdir):
     tmpdir.join("doc3.json").write(json.dumps(data3))
 
     docdir = annif.corpus.DocumentDirectory(str(tmpdir), require_subjects=False)
-    files = sorted(list(docdir))
+    files = sorted(docdir)
     assert len(files) == 3
     assert files[0] == str(tmpdir.join("doc1.json"))
     assert files[1] == str(tmpdir.join("doc2.json"))
@@ -174,7 +174,7 @@ def test_docdir_key_require_subjects(tmpdir, subject_index):
     )
 
     # the docdir contains 3 files
-    files = sorted(list(docdir))
+    files = sorted(docdir)
     assert len(files) == 3
     assert files[0] == str(tmpdir.join("doc1.txt"))
     assert files[1] == str(tmpdir.join("doc2.txt"))
@@ -197,7 +197,7 @@ def test_docdir_tsv_require_subjects(tmpdir, subject_index):
     )
 
     # the docdir contains 3 files
-    files = sorted(list(docdir))
+    files = sorted(docdir)
     assert len(files) == 3
     assert files[0] == str(tmpdir.join("doc1.txt"))
     assert files[1] == str(tmpdir.join("doc2.txt"))
@@ -221,7 +221,7 @@ def test_docdir_json_require_subjects(tmpdir, subject_index):
     )
 
     # the docdir contains 3 files
-    files = sorted(list(docdir))
+    files = sorted(docdir)
     assert len(files) == 3
     assert files[0] == str(tmpdir.join("doc1.json"))
     assert files[1] == str(tmpdir.join("doc2.json"))


### PR DESCRIPTION
This PR adds a new JSON-based fulltext corpus format, based on the discussion in issue #868 (ping @RietdorfC @c-poley).

It extends the existing support for document directories. Previously, the directory had to contain `.txt` files, with gold standard subjects stored in `.tsv` (or `.key`) files with the same basename. This PR adds another option: the directory may instead (or also) contain `.json` files with JSON data of the following form:

```json
{
  "text": "A quick brown fox jumped over the lazy dog.",
  "metadata": {
    "title": "As We May Think",
    "author": "Bush, Vannevar"
  },
  "subjects": [
    { "uri": "http://www.yso.fi/onto/yso/p817", "label": "future" },
    { "uri": "http://www.yso.fi/onto/yso/p3295", "label": "visions (prospects)" },
    { "uri": "http://www.yso.fi/onto/yso/p15527", "label": "science fiction" }
  ]
}
```

All top level fields (`text`, `metadata` and `subjects`) are optional. Subject labels are also optional and included only for illustration; they do not affect the parsing. The JSON format is the same as the one used by the REST API method `learn`, specified by the [IndexedDocument schema](https://github.com/NatLibFi/Annif/blob/140a1b63748639426f9e9d2d793116acf99bdfce/annif/openapi/annif.yaml#L408-L431) in the OpenAPI specification, except ~~there are no required fields~~ the set of required fields is a bit different (either `text` or `metadata` is required on the top level, and if subjects are included, they must specify either `uri` or `label`).

Closes #868.