### PR TITLE
JSON corpus bugfix: avoid parsing subjects in annif index

### DIFF
--- a/annif/corpus/json.py
+++ b/annif/corpus/json.py
@@ -34,7 +34,7 @@ def _subjects_to_subject_set(subjects, subject_index, language):
 
 def json_file_to_document(
     filename: str,
-    subject_index: SubjectIndex,
+    subject_index: SubjectIndex | None,
     language: str,
     require_subjects: bool,
 ) -> Document | None:
@@ -55,11 +55,14 @@ def json_file_to_document(
         logger.warning(f"JSON validation failed for file {filename}: {err.message}")
         return None
 
-    subject_set = _subjects_to_subject_set(
-        data.get("subjects", []), subject_index, language
-    )
-    if require_subjects and not subject_set:
-        return None
+    if require_subjects:
+        subject_set = _subjects_to_subject_set(
+            data.get("subjects", []), subject_index, language
+        )
+        if not subject_set:
+            return None
+    else:
+        subject_set = None
 
     return Document(
         text=data.get("text", ""),

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -679,6 +679,9 @@ def test_index_txt(tmpdir):
 
 def test_index_json(tmpdir):
     tmpdir.join("doc1.json").write('{"text": "nothing special"}')
+    tmpdir.join("doc2.json").write(
+        '{"text": "nothing special", "subjects": [{"label": "dummy"}]}'
+    )
 
     result = runner.invoke(annif.cli.cli, ["index", "dummy-en", str(tmpdir)])
     assert not result.exception
@@ -687,6 +690,12 @@ def test_index_json(tmpdir):
     assert tmpdir.join("doc1.annif").exists()
     assert (
         tmpdir.join("doc1.annif").read_text("utf-8")
+        == "<http://example.org/dummy>\tdummy\t1.0000\n"
+    )
+
+    assert tmpdir.join("doc2.annif").exists()
+    assert (
+        tmpdir.join("doc2.annif").read_text("utf-8")
         == "<http://example.org/dummy>\tdummy\t1.0000\n"
     )
 


### PR DESCRIPTION
This is a follow-up fix to PR #872 . It addresses the first problem reported by @RietdorfC in https://github.com/NatLibFi/Annif/pull/872#issuecomment-3191205667 .

The `annif index` command was not working properly when used on a directory containing JSON files. It crashed with an error:

```
  File "/mnt/evalema0/annif_flexible_fusion_test/annif-venv/lib/python3.12/site-packages/annif/corpus/json.py", line 29, in _subjects_to_subject_set
    subject_ids.append(subject_index.by_uri(subj["uri"]))
                       ^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'by_uri'
```

The reason was that `annif index` doesn't pass DocumentDirectory a subject index, because it shouldn't be necessary. Yet the code tried to parse the existing subjects in the JSON file, causing the crash.

The PR fixes this by making the code lazier: it won't parse subjects from JSON files when they are not required (just like for txt/tsv files). I also modified a unit test to verify this.