### PR TITLE
Add annif index-file CLI command

### DIFF
--- a/annif/cli.py
+++ b/annif/cli.py
@@ -354,13 +354,27 @@ def run_index(
     default=False,
     help="Force overwriting of existing result files",
 )
+@click.option(
+    "--include-doc/--no-include-doc",
+    "-i/-I",
+    default=True,
+    help="Include input documents in output",
+)
 @click.option("--limit", "-l", default=10, help="Maximum number of subjects")
 @click.option("--threshold", "-t", default=0.0, help="Minimum score threshold")
 @click.option("--language", "-L", help="Language of subject labels")
 @cli_util.backend_param_option
 @cli_util.common_options
 def run_index_text(
-    project_id, paths, suffix, force, limit, threshold, language, backend_param
+    project_id,
+    paths,
+    suffix,
+    force,
+    include_doc,
+    limit,
+    threshold,
+    language,
+    backend_param,
 ):
     """
     Index a file with documents, suggesting subjects for each document.
@@ -390,11 +404,11 @@ def run_index_text(
 
         with open(outfilename, "w", encoding="utf-8") as outfile:
             for doc, suggestions in zip(corpus.documents, results):
-                out_suggestions = [
+                output = doc.as_dict(project.subjects, lang) if include_doc else {}
+                output["results"] = [
                     suggestion_to_dict(suggestion, project.subjects, lang)
                     for suggestion in suggestions
                 ]
-                output = {"results": out_suggestions}
                 outfile.write(json.dumps(output) + "\n")
 
 

--- a/annif/cli.py
+++ b/annif/cli.py
@@ -381,7 +381,7 @@ def run_index_text(
             limit, threshold
         )
 
-        outfilename = re.sub(r"\.(csv|tsv|jsonl)$", suffix, path)
+        outfilename = re.sub(r"(\.[^.]+)?(\.gz)?$", "", path) + suffix
         if os.path.exists(outfilename) and not force:
             click.echo(
                 "Not overwriting {} (use --force to override)".format(outfilename)

--- a/annif/cli.py
+++ b/annif/cli.py
@@ -377,7 +377,7 @@ def run_index_file(
     backend_param,
 ):
     """
-    Index a file with documents, suggesting subjects for each document.
+    Index file(s) containing documents, suggesting subjects for each document.
     Write the results in JSONL files with the given suffix (``.annif.jsonl`` by
     default).
     """

--- a/annif/cli.py
+++ b/annif/cli.py
@@ -25,7 +25,7 @@ from annif.exception import (
 )
 from annif.project import Access
 from annif.simplemma_util import detect_language
-from annif.util import metric_code
+from annif.util import metric_code, suggestion_to_dict
 
 logger = annif.logger
 click_log.basic_config(logger)
@@ -390,19 +390,11 @@ def run_index_text(
 
         with open(outfilename, "w", encoding="utf-8") as outfile:
             for doc, suggestions in zip(corpus.documents, results):
-                out_suggestions = []
-                for suggestion in suggestions:
-                    subj = project.subjects[suggestion.subject_id]
-                    out_suggestions.append(
-                        {
-                            "uri": subj.uri,
-                            "label": subj.labels[lang],
-                            "notation": subj.notation,
-                            "score": suggestion.score,
-                        }
-                    )
-
-                output = {"suggestions": [out_suggestions]}
+                out_suggestions = [
+                    suggestion_to_dict(suggestion, project.subjects, lang)
+                    for suggestion in suggestions
+                ]
+                output = {"results": out_suggestions}
                 outfile.write(json.dumps(output) + "\n")
 
 

--- a/annif/cli.py
+++ b/annif/cli.py
@@ -342,7 +342,7 @@ def run_index(
             cli_util.show_hits(suggestions, project, lang, file=subjfile)
 
 
-@cli.command("index-text")
+@cli.command("index-file")
 @cli_util.project_id
 @click.argument("paths", type=click.Path(exists=True, dir_okay=False), nargs=-1)
 @click.option(
@@ -365,7 +365,7 @@ def run_index(
 @click.option("--language", "-L", help="Language of subject labels")
 @cli_util.backend_param_option
 @cli_util.common_options
-def run_index_text(
+def run_index_file(
     project_id,
     paths,
     suffix,

--- a/annif/cli_util.py
+++ b/annif/cli_util.py
@@ -128,6 +128,22 @@ def format_datetime(dt: datetime | None) -> str:
     return dt.astimezone().strftime("%Y-%m-%d %H:%M:%S")
 
 
+def open_doc_path(path, subject_index, vocab_lang, require_subjects=True):
+    """open a single path and return it as a DocumentCorpus"""
+    if os.path.isdir(path):
+        return annif.corpus.DocumentDirectory(
+            path, subject_index, vocab_lang, require_subjects
+        )
+    if annif.corpus.DocumentFileCSV.is_csv_file(path):
+        return annif.corpus.DocumentFileCSV(path, subject_index, require_subjects)
+    elif annif.corpus.DocumentFileJSONL.is_jsonl_file(path):
+        return annif.corpus.DocumentFileJSONL(
+            path, subject_index, vocab_lang, require_subjects
+        )
+    else:
+        return annif.corpus.DocumentFileTSV(path, subject_index, require_subjects)
+
+
 def open_documents(
     paths: tuple[str, ...],
     subject_index: SubjectIndex,
@@ -141,26 +157,13 @@ def open_documents(
     The corpus will be returned as an instance of DocumentCorpus or
     LimitingDocumentCorpus."""
 
-    def open_doc_path(path, subject_index):
-        """open a single path and return it as a DocumentCorpus"""
-        if os.path.isdir(path):
-            return annif.corpus.DocumentDirectory(
-                path, subject_index, vocab_lang, require_subjects=True
-            )
-        if annif.corpus.DocumentFileCSV.is_csv_file(path):
-            return annif.corpus.DocumentFileCSV(path, subject_index)
-        elif annif.corpus.DocumentFileJSONL.is_jsonl_file(path):
-            return annif.corpus.DocumentFileJSONL(path, subject_index, vocab_lang)
-        else:
-            return annif.corpus.DocumentFileTSV(path, subject_index)
-
     if len(paths) == 0:
         logger.warning("Reading empty file")
-        docs = open_doc_path(os.path.devnull, subject_index)
+        docs = open_doc_path(os.path.devnull, subject_index, vocab_lang)
     elif len(paths) == 1:
-        docs = open_doc_path(paths[0], subject_index)
+        docs = open_doc_path(paths[0], subject_index, vocab_lang)
     else:
-        corpora = [open_doc_path(path, subject_index) for path in paths]
+        corpora = [open_doc_path(path, subject_index, vocab_lang) for path in paths]
         docs = annif.corpus.CombinedCorpus(corpora)
     if docs_limit is not None:
         docs = annif.corpus.LimitingDocumentCorpus(docs, docs_limit)

--- a/annif/corpus/document.py
+++ b/annif/corpus/document.py
@@ -168,7 +168,9 @@ class DocumentFileCSV(DocumentCorpus):
                 yield from self._parse_row(row)
 
     def _parse_row(self, row: dict[str, str]) -> Iterator[Document]:
-        if self.require_subjects:
+        if self.require_subjects or (
+            self.subject_index is not None and "subject_uris" in row
+        ):
             subject_ids = {
                 self.subject_index.by_uri(annif.util.cleanup_uri(uri))
                 for uri in (row["subject_uris"] or "").strip().split()

--- a/annif/corpus/json.py
+++ b/annif/corpus/json.py
@@ -52,7 +52,7 @@ def json_to_document(
         logger.warning(f"JSON validation failed for file {filename}: {err.message}")
         return None
 
-    if require_subjects:
+    if require_subjects or (subject_index is not None and "subjects" in data):
         subject_set = _subjects_to_subject_set(
             data.get("subjects", []), subject_index, language
         )

--- a/annif/corpus/types.py
+++ b/annif/corpus/types.py
@@ -14,11 +14,24 @@ if TYPE_CHECKING:
 
 
 class Document:
-    def __init__(self, text, subject_set=None, metadata=None, file_path=None):
+    def __init__(
+        self,
+        text: str,
+        subject_set: SubjectSet | None = None,
+        metadata: dict[str, Any] | None = None,
+        file_path: str | None = None,
+    ):
         self.text = text
-        self.subject_set = subject_set if subject_set is not None else set()
+        self.subject_set = subject_set if subject_set is not None else SubjectSet()
         self.metadata = metadata if metadata is not None else {}
         self.file_path = file_path
+
+    def as_dict(self, subject_index: SubjectIndex, language: str) -> dict[str, Any]:
+        return {
+            "text": self.text,
+            "metadata": self.metadata,
+            "subjects": self.subject_set.as_list(subject_index, language),
+        }
 
     def __repr__(self):
         return (
@@ -136,3 +149,14 @@ class SubjectSet:
         destination[list(self._subject_ids)] = True
 
         return destination
+
+    def as_list(
+        self, subject_index: SubjectIndex, language: str
+    ) -> list[dict[str:str]]:
+        ret = []
+        for subject_id in self._subject_ids:
+            subject = subject_index[subject_id]
+            ret.append({"uri": subject.uri, "label": subject.labels[language]})
+
+    def __repr__(self):
+        return f"SubjectSet({self._subject_ids!r})"

--- a/annif/corpus/types.py
+++ b/annif/corpus/types.py
@@ -153,10 +153,11 @@ class SubjectSet:
     def as_list(
         self, subject_index: SubjectIndex, language: str
     ) -> list[dict[str:str]]:
-        ret = []
+        subjects = []
         for subject_id in self._subject_ids:
             subject = subject_index[subject_id]
-            ret.append({"uri": subject.uri, "label": subject.labels[language]})
+            subjects.append({"uri": subject.uri, "label": subject.labels[language]})
+        return subjects
 
     def __repr__(self):
         return f"SubjectSet({self._subject_ids!r})"

--- a/annif/util.py
+++ b/annif/util.py
@@ -7,7 +7,11 @@ import logging
 import os
 import os.path
 import tempfile
-from typing import Any, Callable
+from typing import TYPE_CHECKING, Any, Callable
+
+if TYPE_CHECKING:
+    from annif.corpus.subject import SubjectIndex
+    from annif.suggestion import SubjectSuggestion, SuggestionResults
 
 from annif import logger
 
@@ -112,3 +116,29 @@ def identity(x: Any) -> Any:
 def metric_code(metric):
     """Convert a human-readable metric name into an alphanumeric string"""
     return metric.translate(metric.maketrans(" ", "_", "()"))
+
+
+def suggestion_to_dict(
+    suggestion: SubjectSuggestion, subject_index: SubjectIndex, language: str
+) -> dict[str, str | float | None]:
+    subject = subject_index[suggestion.subject_id]
+    return {
+        "uri": subject.uri,
+        "label": subject.labels[language],
+        "notation": subject.notation,
+        "score": suggestion.score,
+    }
+
+
+def suggestion_results_to_list(
+    suggestion_results: SuggestionResults, subjects: SubjectIndex, lang: str
+) -> list[dict[str, list]]:
+    return [
+        {
+            "results": [
+                suggestion_to_dict(suggestion, subjects, lang)
+                for suggestion in suggestions
+            ]
+        }
+        for suggestions in suggestion_results
+    ]

--- a/docs/source/commands.rst
+++ b/docs/source/commands.rst
@@ -129,6 +129,13 @@ Subject index administration
 
    N/A
 
+.. click:: annif.cli:run_index_file
+   :prog: annif index-file
+
+**REST equivalent**
+
+   N/A
+
 .. click:: annif.cli:run_hyperopt
    :prog: annif hyperopt
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -792,7 +792,7 @@ def test_index_file_tsv(tmpdir):
     assert data0["subjects"][0]["uri"] == "http://example.org/none"
     assert data0["results"][0]["uri"] == "http://example.org/dummy"
     assert data0["results"][0]["label"] == "dummy"
-    assert data0["results"][0]["score"] == 1.0
+    assert data0["results"][0]["score"] == pytest.approx(1.0)
 
     data1 = json.loads(lines[1])
     assert data1["text"] == "Oulunlinnan"
@@ -819,7 +819,7 @@ def test_index_file_tsv(tmpdir):
     assert data0["subjects"][0]["uri"] == "http://example.org/none"
     assert data0["results"][0]["uri"] == "http://example.org/dummy"
     assert data0["results"][0]["label"] == "dummy-fi"
-    assert data0["results"][0]["score"] == 1.0
+    assert data0["results"][0]["score"] == pytest.approx(1.0)
 
 
 def test_index_file_tsv_gzipped_output(tmpdir):
@@ -869,7 +869,7 @@ def test_index_file_csv(tmpdir):
     assert data0["subjects"][0]["uri"] == "http://example.org/none"
     assert data0["results"][0]["uri"] == "http://example.org/dummy"
     assert data0["results"][0]["label"] == "dummy"
-    assert data0["results"][0]["score"] == 1.0
+    assert data0["results"][0]["score"] == pytest.approx(1.0)
 
     data1 = json.loads(lines[1])
     assert data1["text"] == "Oulunlinnan"
@@ -902,7 +902,7 @@ def test_index_file_jsonl(tmpdir):
     assert data0["subjects"][0]["uri"] == "http://example.org/none"
     assert data0["results"][0]["uri"] == "http://example.org/dummy"
     assert data0["results"][0]["label"] == "dummy"
-    assert data0["results"][0]["score"] == 1.0
+    assert data0["results"][0]["score"] == pytest.approx(1.0)
 
     data1 = json.loads(lines[1])
     assert data1["text"] == "Oulunlinnan"
@@ -935,7 +935,7 @@ def test_index_file_with_language_override(tmpdir):
     assert data0["subjects"][0]["uri"] == "http://example.org/none"
     assert data0["results"][0]["uri"] == "http://example.org/dummy"
     assert data0["results"][0]["label"] == "dummy-fi"
-    assert data0["results"][0]["score"] == 1.0
+    assert data0["results"][0]["score"] == pytest.approx(1.0)
 
 
 def test_index_file_with_language_override_bad_value(tmpdir):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,7 @@
 """Unit test module for Annif CLI commands"""
 
 import contextlib
+import gzip
 import importlib
 import json
 import os.path
@@ -819,6 +820,29 @@ def test_index_file_tsv(tmpdir):
     assert data0["results"][0]["uri"] == "http://example.org/dummy"
     assert data0["results"][0]["label"] == "dummy-fi"
     assert data0["results"][0]["score"] == 1.0
+
+
+def test_index_file_tsv_gzipped_output(tmpdir):
+    docfile = tmpdir.join("documents.tsv")
+    lines = (
+        "Läntinen\t<http://example.org/none>",
+        "Oulunlinnan\t<http://example.org/dummy>",
+        "Harald Hirmuinen\t<http://example.org/none>",
+    )
+    docfile.write("\n".join(lines))
+
+    result = runner.invoke(
+        annif.cli.cli, ["index-file", "--gzip", "dummy-en", str(docfile)]
+    )
+    assert not result.exception
+    assert result.exit_code == 0
+
+    outfile = tmpdir.join("documents.annif.jsonl.gz")
+    assert outfile.exists()
+
+    with gzip.open(str(outfile), "rt") as gzf:
+        lines = gzf.readlines()
+        assert len(lines) == 3
 
 
 def test_index_file_csv(tmpdir):

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -15,11 +15,11 @@ from annif.exception import OperationFailedException
 def test_document():
     doc = Document(text="Hello world")
     assert doc.text == "Hello world"
-    assert doc.subject_set == set()
+    assert doc.subject_set == SubjectSet()
     assert doc.metadata == {}
     assert doc.file_path is None
     assert repr(doc) == (
-        "Document(text='Hello world', subject_set=set(), "
+        "Document(text='Hello world', subject_set=SubjectSet([]), "
         "metadata={}, file_path=None)"
     )
 

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -570,6 +570,22 @@ def test_docfile_csv_plain_invalid_columns_no_require_subjects(tmpdir, subject_i
     assert str(excinfo.value).startswith("Cannot parse CSV file")
 
 
+def test_docfile_csv_plain_no_require_subjects(tmpdir, subject_index):
+    docfile = tmpdir.join("documents_invalid.csv")
+    lines = (
+        "text",
+        "Läntinen",
+        "Oulunlinnan",
+        '"Harald Hirmuinen"',
+    )
+    docfile.write("\n".join(lines).encode("utf-8-sig"))
+
+    docs = annif.corpus.DocumentFileCSV(
+        str(docfile), subject_index, require_subjects=False
+    )
+    assert len(list(docs.documents)) == 3
+
+
 def test_docfile_tsv_gzipped(tmpdir, subject_index):
     docfile = tmpdir.join("documents.tsv.gz")
     with gzip.open(str(docfile), "wt") as gzf:


### PR DESCRIPTION
This PR adds a new `annif index-file` CLI command. It works similarly than `annif index`, but for short text corpora (in TSV, CSV or JSONL format): it processes the input corpus files one document at a time, produces subjects suggestions, and writes results in JSONL format. 

Usage examples:

- `annif index-file yso-tfidf-fi input.tsv` -> produces file `input1.annif.jsonl` with as many lines as the input file has docs
- `annif index-file yso-tfidf-fi input.csv` -> ditto
- `annif index-file yso-tfidf-fi input.jsonl` -> ditto
- `annif index-file yso-tfidf-fi input1.tsv input2.csv input3.jsonl` -> all the above in a single command, writing to three separate files
- `annif index-file --gzip yso-tfidf-fi input.tsv` -> produces gzipped file `input.annif.jsonl.gz` with as many lines as the input file has docs
- `annif index-file --output out.jsonl input.tsv` -> writes into `out.jsonl`
- `annif index-file --gzip --output out.jsonl input.tsv` -> writes into `out.jsonl.gz`
- `annif index-file --output - input.tsv` -> writes into stdout

There are also options to select whether to include the original input text, metadata and subjects (`--include-doc`) or not (`--no-include-doc`), defaulting to the former.

Usage message:

```
Usage: annif index-file [OPTIONS] PROJECT_ID [PATHS]...

  Index file(s) containing documents, suggesting subjects for each document.
  Write the results in JSONL files with the given suffix (``.annif.jsonl`` by
  default).

Options:
  -s, --suffix TEXT               File name suffix for result files
  -z, --gzip / -Z, --no-gzip      Gzip compress result files
  -O, --output FILE               Redirect all output to the given file (or
                                  '-' for stdout)
  -f, --force / -F, --no-force    Force overwriting of existing result files
  -i, --include-doc / -I, --no-include-doc
                                  Include input documents in output
  -l, --limit INTEGER             Maximum number of subjects
  -t, --threshold FLOAT           Minimum score threshold
  -L, --language TEXT             Language of subject labels
  -b, --backend-param TEXT        Override backend parameter of the config
                                  file. Syntax: `-b
                                  <backend>.<parameter>=<value>`.
  -v, --verbosity LVL             Either CRITICAL, ERROR, WARNING, INFO or
                                  DEBUG
  -p, --projects PATH             Set path to project configuration file or
                                  directory
  --help                          Show this message and exit.
```

Implementation notes:

- Originally I intended to extend the `annif index` command, but it turned out that the options and other features needed for short text corpora are substantially different than what full text corpora require, so I chose to make it a new command `index-file` instead.
- This PR relaxes the requirements of short text corpus files: subjects are no longer mandatory for either TSV, CSV or JSONL corpus files in order to make it possible to use `annif index-file` without preexisting subjects. TSV without subjects is essentially a raw text file with one line per record with the restriction that tab characters are not allowed.
- The output JSON structure is essentially the same as what the REST API commands `suggest` and `suggest-batch` produce. I moved the code that generates this format from `rest.py` to `util.py` and renamed the functions to make them a bit more descriptive.

Closes #639