### PR TITLE
Resolve `UserWarning: The parameter --verbosity...` for `annif list-*` CLI commands

### DIFF
--- a/annif/cli.py
+++ b/annif/cli.py
@@ -454,7 +454,6 @@ def run_eval(
 @cli.command("run")
 @click.option("--host", type=str, default="127.0.0.1")
 @click.option("--port", type=int, default=5000)
-@click.option("--log-level")
 @click_log.simple_verbosity_option(logger, default="ERROR")
 def run_app(**kwargs):
     """

--- a/annif/cli.py
+++ b/annif/cli.py
@@ -40,7 +40,6 @@ cli.params = [opt for opt in cli.params if opt.name not in ("env_file", "app")]
 
 @cli.command("list-projects")
 @cli_util.common_options
-@click_log.simple_verbosity_option(logger, default="ERROR")
 def run_list_projects():
     """
     List available projects.
@@ -112,7 +111,6 @@ def run_clear_project(project_id):
 
 @cli.command("list-vocabs")
 @cli_util.common_options
-@click_log.simple_verbosity_option(logger, default="ERROR")
 def run_list_vocabs():
     """
     List available vocabularies.

--- a/annif/cli.py
+++ b/annif/cli.py
@@ -454,7 +454,7 @@ def run_eval(
 @cli.command("run")
 @click.option("--host", type=str, default="127.0.0.1")
 @click.option("--port", type=int, default=5000)
-@click_log.simple_verbosity_option(logger, default="ERROR")
+@click_log.simple_verbosity_option(logger)
 def run_app(**kwargs):
     """
     Run Annif in server mode for development.


### PR DESCRIPTION
Click 8.2 introduced a warning for overriding parameter name: https://github.com/pallets/click/issues/2396. Now is shown e.g. this:
```
$ annif list-projects 
/home/myuser/.cache/pypoetry/virtualenvs/annif-ul-EXdhi-py3.11/lib/python3.11/site-packages/click/core.py:1193: UserWarning: The parameter --verbosity is used more than once. Remove its duplicate as parameters should be unique.
  parser = self.make_parser(ctx)
/home/myuser/.cache/pypoetry/virtualenvs/annif-ul-EXdhi-py3.11/lib/python3.11/site-packages/click/core.py:1193: UserWarning: The parameter -v is used more than once. Remove its duplicate as parameters should be unique.
  parser = self.make_parser(ctx)
/home/myuser/.cache/pypoetry/virtualenvs/annif-ul-EXdhi-py3.11/lib/python3.11/site-packages/click/core.py:1186: UserWarning: The parameter --verbosity is used more than once. Remove its duplicate as parameters should be unique.
  self.parse_args(ctx, args)
/home/myuser/.cache/pypoetry/virtualenvs/annif-ul-EXdhi-py3.11/lib/python3.11/site-packages/click/core.py:1186: UserWarning: The parameter -v is used more than once. Remove its duplicate as parameters should be unique.
  self.parse_args(ctx, args)
Project ID   Project Name      Vocabulary ID  Language  Trained  Modification time  
------------------------------------------------------------------------------------
tfidf-fi     TF-IDF Finnish    arch           fi        True     2025-08-06 14:51:20
tfidf-sv     TF-IDF Swedish    yso            sv        True     2024-08-30 11:01:37
tfidf-en     TF-IDF English    yso            en        True     2025-08-06 14:02:50  
fasttext-fi  fastText Finnish  yso            fi        None     -                  

```

In `annif list-projects` and `annif list-vocabs` the override was done delibaretely: [Hide warnings in list-projects command by raising default log-level](https://github.com/NatLibFi/Annif/commit/aa7360e2678956040131c28d1a2d98d78f621fdf). I think at that time the warnings about not installed dependencies were shown between the projects, which was messing up the list. Now the warnings are shown before the listing starts, so it seems ok to drop setting log-level to ERROR for the list-* commands:
```
$ annif list-projects 
warning: Could not create backend fasttext, make sure you've installed optional dependencies
Project ID   Project Name      Vocabulary ID  Language  Trained  Modification time  
------------------------------------------------------------------------------------
tfidf-fi     TF-IDF Finnish    arch           fi        True     2025-08-06 14:51:20
tfidf-sv     TF-IDF Swedish    yso            sv        True     2024-08-30 11:01:37
tfidf-en     TF-IDF English    yso            en        True     2025-08-06 14:02:50     
fasttext-fi  fastText Finnish  yso            fi        None     -                  
```

This PR also remove removes the inoperative `--log--level` option from `annif run` command and switches to use log-level INFO instead of ERROR. (Why was it set to ERROR?)

