### PR TITLE
Resolve `UserWarning: The structure of inputs doesn't match` by Keras

### DIFF
--- a/annif/backend/nn_ensemble.py
+++ b/annif/backend/nn_ensemble.py
@@ -161,18 +161,20 @@ class NNEnsembleBackend(backend.AnnifLearningBackend, ensemble.BaseEnsembleBacke
         params: dict[str, Any],
     ) -> SuggestionBatch:
         src_weight = dict(sources)
-        score_vectors = np.array(
-            [
+        score_vectors = [
+            np.array(
                 [
-                    np.sqrt(suggestions.as_vector())
-                    * src_weight[project_id]
-                    * len(batch_by_source)
-                    for suggestions in batch
-                ]
-                for project_id, batch in batch_by_source.items()
-            ],
-            dtype=np.float32,
-        ).transpose(1, 2, 0)
+                    [
+                        np.sqrt(suggestions.as_vector())
+                        * src_weight[project_id]
+                        * len(batch_by_source)
+                        for suggestions in batch
+                    ]
+                    for project_id, batch in batch_by_source.items()
+                ],
+                dtype=np.float32,
+            ).transpose(1, 2, 0)
+        ]
         prediction = self._model(score_vectors).numpy()
         return SuggestionBatch.from_sequence(
             [


### PR DESCRIPTION
This resolves the warning that is shown when NN ensemble is used to give suggestions:
```
/home/myuser/.cache/pypoetry/virtualenvs/annif-ul-EXdhi-py3.11/lib/python3.11/site-packages/keras/src/models/functional.py:241: UserWarning: The structure of `inputs` doesn't match the expected structure.
Expected: ['input_layer']
Received: inputs=Tensor(shape=(1, 130, 2))
  warnings.warn(msg)
```
This has actually been logged already by Annif 1.3.

The example in [Keras documentation](https://keras.io/api/models/model/) and the note below it seem contradictory; there is an issue about this warning: https://github.com/tensorflow/tensorflow/issues/82372

Anyway, I checked that resolving this warning by wrapping the `score_vector` in a list does not change the results.


