### PR TITLE
Support document_id in JSON(L) and CSV corpus formats & JSONL output

### DIFF
--- a/annif/cli.py
+++ b/annif/cli.py
@@ -418,7 +418,12 @@ def run_index_file(
 
         with stream_cm as stream:
             for doc, suggestions in zip(corpus.documents, results):
-                output_data = doc.as_dict(project.subjects, lang) if include_doc else {}
+                if include_doc:
+                    output_data = doc.as_dict(project.subjects, lang)
+                else:
+                    output_data = {}
+                    if doc.document_id:
+                        output_data["document_id"] = doc.document_id
                 output_data["results"] = [
                     suggestion_to_dict(suggestion, project.subjects, lang)
                     for suggestion in suggestions

--- a/annif/corpus/document.py
+++ b/annif/corpus/document.py
@@ -178,12 +178,15 @@ class DocumentFileCSV(DocumentCorpus):
         else:
             subject_ids = set()
         metadata = {
-            key: val for key, val in row.items() if key not in ("text", "subject_uris")
+            key: val
+            for key, val in row.items()
+            if key not in ("document_id", "text", "subject_uris")
         }
         yield Document(
             text=(row["text"] or ""),
             subject_set=SubjectSet(subject_ids),
             metadata=metadata,
+            document_id=row.get("document_id", None),
         )
 
     def _check_fields(self, reader: csv.DictReader) -> bool:

--- a/annif/corpus/json.py
+++ b/annif/corpus/json.py
@@ -66,6 +66,7 @@ def json_to_document(
         metadata=data.get("metadata", {}),
         subject_set=subject_set,
         file_path=filename,
+        document_id=data.get("document_id", None),
     )
 
 

--- a/annif/corpus/types.py
+++ b/annif/corpus/types.py
@@ -19,15 +19,18 @@ class Document:
         text: str,
         subject_set: SubjectSet | None = None,
         metadata: dict[str, Any] | None = None,
+        document_id: str | None = None,
         file_path: str | None = None,
     ):
         self.text = text
         self.subject_set = subject_set if subject_set is not None else SubjectSet()
         self.metadata = metadata if metadata is not None else {}
+        self.document_id = document_id
         self.file_path = file_path
 
     def as_dict(self, subject_index: SubjectIndex, language: str) -> dict[str, Any]:
         return {
+            "document_id": self.document_id,
             "text": self.text,
             "metadata": self.metadata,
             "subjects": self.subject_set.as_list(subject_index, language),
@@ -35,7 +38,8 @@ class Document:
 
     def __repr__(self):
         return (
-            f"Document(text={self.text!r}, "
+            f"Document(document_id={self.document_id!r}, "
+            f"text={self.text!r}, "
             f"subject_set={self.subject_set!r}, "
             f"metadata={self.metadata!r}, "
             f"file_path={self.file_path!r})"

--- a/annif/corpus/types.py
+++ b/annif/corpus/types.py
@@ -29,12 +29,16 @@ class Document:
         self.file_path = file_path
 
     def as_dict(self, subject_index: SubjectIndex, language: str) -> dict[str, Any]:
-        return {
-            "document_id": self.document_id,
-            "text": self.text,
-            "metadata": self.metadata,
-            "subjects": self.subject_set.as_list(subject_index, language),
-        }
+        doc = {"text": self.text}
+
+        if self.document_id:
+            doc["document_id"] = self.document_id
+        if self.metadata:
+            doc["metadata"] = self.metadata
+        if self.subject_set:
+            doc["subjects"] = self.subject_set.as_list(subject_index, language)
+
+        return doc
 
     def __repr__(self):
         return (

--- a/annif/schemas/document.json
+++ b/annif/schemas/document.json
@@ -3,6 +3,9 @@
   "title": "Document",
   "type": "object",
   "properties": {
+    "document_id": {
+      "type": "string"
+    },
     "text": {
       "type": "string"
     },

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -848,10 +848,10 @@ def test_index_file_tsv_gzipped_output(tmpdir):
 def test_index_file_csv(tmpdir):
     docfile = tmpdir.join("documents.csv")
     lines = (
-        "text,subject_uris",
-        "Läntinen,<http://example.org/none>",
-        "Oulunlinnan,<http://example.org/dummy>",
-        '"Harald Hirmuinen",<http://example.org/none>',
+        "document_id,text,subject_uris",
+        "L,Läntinen,<http://example.org/none>",
+        "O,Oulunlinnan,<http://example.org/dummy>",
+        'HH,"Harald Hirmuinen",<http://example.org/none>',
     )
     docfile.write("\n".join(lines))
 
@@ -866,6 +866,7 @@ def test_index_file_csv(tmpdir):
     assert len(lines) == 3
     data0 = json.loads(lines[0])
     assert data0["text"] == "Läntinen"
+    assert data0["document_id"] == "L"
     assert data0["subjects"][0]["uri"] == "http://example.org/none"
     assert data0["results"][0]["uri"] == "http://example.org/dummy"
     assert data0["results"][0]["label"] == "dummy"
@@ -873,6 +874,7 @@ def test_index_file_csv(tmpdir):
 
     data1 = json.loads(lines[1])
     assert data1["text"] == "Oulunlinnan"
+    assert data1["document_id"] == "O"
     assert data1["subjects"][0]["uri"] == "http://example.org/dummy"
     assert len(data1["results"]) == 1
 
@@ -883,7 +885,7 @@ def test_index_file_jsonl(tmpdir):
         '{"text": "Läntinen", ' + '"subjects": [{"uri": "http://example.org/none"}]}',
         '{"text": "Oulunlinnan", '
         + '"subjects": [{"uri": "http://example.org/dummy"}]}',
-        '{"text": "Harald Hirmuinen", '
+        '{"text": "Harald Hirmuinen", "document_id": "HH", '
         + '"subjects": [{"uri": "http://example.org/none"}]}',
     )
     docfile.write("\n".join(lines))
@@ -908,6 +910,10 @@ def test_index_file_jsonl(tmpdir):
     assert data1["text"] == "Oulunlinnan"
     assert data1["subjects"][0]["uri"] == "http://example.org/dummy"
     assert len(data1["results"]) == 1
+
+    data2 = json.loads(lines[2])
+    assert data2["text"] == "Harald Hirmuinen"
+    assert data2["document_id"] == "HH"
 
 
 def test_index_file_with_language_override(tmpdir):

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -39,8 +39,9 @@ def test_document_with_all_fields(subject_index):
     assert doc.metadata == {"title": "Hello"}
     assert doc.file_path == "hello.txt"
     assert repr(doc) == (
-        "Document(document_id='test', text='Hello world', subject_set=SubjectSet([42, 55]), "
-        "metadata={'title': 'Hello'}, file_path='hello.txt')"
+        "Document(document_id='test', text='Hello world', "
+        "subject_set=SubjectSet([42, 55]), metadata={'title': 'Hello'}, "
+        "file_path='hello.txt')"
     )
     assert doc.as_dict(subject_index, "en") == {
         "document_id": "test",

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -12,7 +12,7 @@ from annif.corpus import Document, SubjectSet, TransformingDocumentCorpus
 from annif.exception import OperationFailedException
 
 
-def test_document():
+def test_document(subject_index):
     doc = Document(text="Hello world")
     assert doc.text == "Hello world"
     assert doc.subject_set == SubjectSet()
@@ -22,6 +22,43 @@ def test_document():
         "Document(document_id=None, text='Hello world', subject_set=SubjectSet([]), "
         "metadata={}, file_path=None)"
     )
+    assert doc.as_dict(subject_index, "en") == {"text": "Hello world"}
+
+
+def test_document_with_all_fields(subject_index):
+    doc = Document(
+        text="Hello world",
+        document_id="test",
+        subject_set=SubjectSet([42, 55]),
+        metadata={"title": "Hello"},
+        file_path="hello.txt",
+    )
+    assert doc.text == "Hello world"
+    assert doc.document_id == "test"
+    assert doc.subject_set == SubjectSet([42, 55])
+    assert doc.metadata == {"title": "Hello"}
+    assert doc.file_path == "hello.txt"
+    assert repr(doc) == (
+        "Document(document_id='test', text='Hello world', subject_set=SubjectSet([42, 55]), "
+        "metadata={'title': 'Hello'}, file_path='hello.txt')"
+    )
+    assert doc.as_dict(subject_index, "en") == {
+        "document_id": "test",
+        "metadata": {
+            "title": "Hello",
+        },
+        "subjects": [
+            {
+                "label": "ancient DNA",
+                "uri": "http://www.yso.fi/onto/yso/p29546",
+            },
+            {
+                "label": "Megalithic culture",
+                "uri": "http://www.yso.fi/onto/yso/p14800",
+            },
+        ],
+        "text": "Hello world",
+    }
 
 
 def test_subjectset_uris(subject_index):

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -19,7 +19,7 @@ def test_document():
     assert doc.metadata == {}
     assert doc.file_path is None
     assert repr(doc) == (
-        "Document(text='Hello world', subject_set=SubjectSet([]), "
+        "Document(document_id=None, text='Hello world', subject_set=SubjectSet([]), "
         "metadata={}, file_path=None)"
     )
 
@@ -387,6 +387,22 @@ def test_docfile_csv_plain(tmpdir, subject_index):
     assert len(list(docs.documents)) == 3
 
 
+def test_docfile_csv_document_id(tmpdir, subject_index):
+    docfile = tmpdir.join("documents.csv")
+    lines = (
+        "document_id,text,subject_uris",
+        "L,Läntinen,<http://www.yso.fi/onto/yso/p2557>",
+        "O,Oulunlinnan,<http://www.yso.fi/onto/yso/p7346>",
+        'HH,"Harald Hirmuinen",<http://www.yso.fi/onto/yso/p6479>',
+    )
+    docfile.write("\n".join(lines))
+
+    docs = annif.corpus.DocumentFileCSV(str(docfile), subject_index)
+    assert len(list(docs.documents)) == 3
+    firstdoc = next(docs.documents)
+    assert firstdoc.document_id == "L"
+
+
 def test_docfile_csv_metadata(tmpdir, subject_index):
     docfile = tmpdir.join("documents-metadata.csv")
     lines = (
@@ -410,7 +426,7 @@ def test_docfile_csv_metadata(tmpdir, subject_index):
 def test_docfile_jsonl_plain(tmpdir, subject_index):
     docfile = tmpdir.join("documents.jsonl")
     lines = (
-        '{"text": "Läntinen", '
+        '{"text": "Läntinen", "document_id": "L", '
         + '"subjects": [{"uri": "http://www.yso.fi/onto/yso/p2557"}]}',
         '{"text": "Oulunlinnan", '
         + '"subjects": [{"uri": "http://www.yso.fi/onto/yso/p7346"}]}',
@@ -421,6 +437,8 @@ def test_docfile_jsonl_plain(tmpdir, subject_index):
 
     docs = annif.corpus.DocumentFileJSONL(str(docfile), subject_index, "fi")
     assert len(list(docs.documents)) == 3
+    firstdoc = next(docs.documents)
+    assert firstdoc.document_id == "L"
 
 
 def test_docfile_jsonl_broken(tmpdir, subject_index, caplog):


### PR DESCRIPTION
This PR adds support for an optional `document_id` field in JSON & JSONL corpus formats. It can also be used as a special field in CSV corpus files. The document_id will be stored within the Document object and retained in JSONL output produced by the new `annif index-file` command.

TODO:

- [x] `annif index-file` should preserve `document_id` even when the `--no-include-doc` option is used (but only include it if not None)
- [x] check the implementation of the REST API method `suggest-batch` - can it make use of this mechanism?

Closes #885