### PR TITLE
Fix slow annif train JSONL test & avoid slow jsonschema import

### DIFF
--- a/annif/corpus/json.py
+++ b/annif/corpus/json.py
@@ -5,8 +5,6 @@ import json
 import os.path
 from importlib.resources import files
 
-import jsonschema
-
 import annif
 from annif.vocab import SubjectIndex
 
@@ -39,6 +37,8 @@ def json_to_document(
     language: str,
     require_subjects: bool,
 ) -> Document | None:
+
+    import jsonschema
 
     try:
         data = json.loads(json_data)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -342,7 +342,9 @@ def test_train_jsonl(testdatadir):
     docfile = os.path.join(
         os.path.dirname(__file__), "corpora", "archaeology", "documents.jsonl"
     )
-    result = runner.invoke(annif.cli.cli, ["train", "tfidf-fi", docfile])
+    result = runner.invoke(
+        annif.cli.cli, ["train", "--docs-limit", "100", "tfidf-fi", docfile]
+    )
     assert not result.exception
     assert result.exit_code == 0
     assert testdatadir.join("projects/tfidf-fi/vectorizer").exists()


### PR DESCRIPTION
This PR fixes two recently introduced slowdowns related to JSON corpus support:

# Slow unit test

Training on JSONL documents is currently quite slow due to the JSON validation. This may be due to a recent performance issue in jsonschema: https://github.com/python-jsonschema/referencing/issues/178

Because of the slow validation, the `test_train_jsonl` unit test in `test_cli.py`, which trains a TF-IDF model on 6400 documents, is quite slow - it takes around 30 seconds on my laptop, slowing down the test suite.

This PR fixes the slow unit test by adding a `--docs-limit 100` parameter to the `annif train` command, restricting the train run and thus the slow validation to 100 documents. On my laptop, the time for running `pytest tests/test_cli.py` goes from ~45 seconds to ~15 seconds.

# Slow import

`import jsonschema` at the top level in `annif/corpus/json.py` takes around 0.1-0.2 seconds every time Annif is started up, even though it is usually not needed. This PR moves it inside the `json_to_document` function so that it is imported only when actually needed.