### PR TITLE
Revert "Resolve `UserWarning: The structure of inputs doesn't match` by Keras"

### DIFF
--- a/annif/backend/nn_ensemble.py
+++ b/annif/backend/nn_ensemble.py
@@ -161,20 +161,18 @@ class NNEnsembleBackend(backend.AnnifLearningBackend, ensemble.BaseEnsembleBacke
         params: dict[str, Any],
     ) -> SuggestionBatch:
         src_weight = dict(sources)
-        score_vectors = [
-            np.array(
+        score_vectors = np.array(
+            [
                 [
-                    [
-                        np.sqrt(suggestions.as_vector())
-                        * src_weight[project_id]
-                        * len(batch_by_source)
-                        for suggestions in batch
-                    ]
-                    for project_id, batch in batch_by_source.items()
-                ],
-                dtype=np.float32,
-            ).transpose(1, 2, 0)
-        ]
+                    np.sqrt(suggestions.as_vector())
+                    * src_weight[project_id]
+                    * len(batch_by_source)
+                    for suggestions in batch
+                ]
+                for project_id, batch in batch_by_source.items()
+            ],
+            dtype=np.float32,
+        ).transpose(1, 2, 0)
         prediction = self._model(score_vectors).numpy()
         return SuggestionBatch.from_sequence(
             [


### PR DESCRIPTION
Reverts NatLibFi/Annif#883. 

This was a mistake: before the PR to-be-reverted, the UserWarning was shown _only_ when using models trained on some previous TensorFlow version, but after it, the UserWarning was show on all the models trained with the current TF version.

The warning has been showing on Finto AI logs all the time, I suppose for every request to NN ensemble projects. However, with this code, when running locally, the warning is only shown once after startup, which is maybe a result of the dependency updates?

Anyway, we are going to retrain NN ensemble projects for Finto AI in near future, which removes the looping log messages, if it still remains.