### PR TITLE
[StepSecurity] ci: Harden GitHub Actions

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -19,6 +19,11 @@ jobs:
     runs-on: ubuntu-22.04
     name: lint with isort, Black & flake8
     steps:
+    - name: Harden the runner (Audit all outbound calls)
+      uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+      with:
+        egress-policy: audit
+
     - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
     - name: "Prepare: restore caches, install Poetry, set up Python"
       uses: ./.github/actions/prepare
@@ -42,6 +47,11 @@ jobs:
     runs-on: ubuntu-22.04
     name: check CLI startup time
     steps:
+    - name: Harden the runner (Audit all outbound calls)
+      uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+      with:
+        egress-policy: audit
+
     - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
     - name: "Prepare: restore caches, install Poetry, set up Python"
       id: prepare
@@ -64,6 +74,11 @@ jobs:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
     name: test on Python ${{ matrix.python-version }}
     steps:
+    - name: Harden the runner (Audit all outbound calls)
+      uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+      with:
+        egress-policy: audit
+
     - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
     - name: Install system packages
       run: |
@@ -128,6 +143,11 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 15
     steps:
+    - name: Harden the runner (Audit all outbound calls)
+      uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+      with:
+        egress-policy: audit
+
     - name: "Build image for testing"
       uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83  # v6.18.0
       with:
@@ -144,6 +164,11 @@ jobs:
     timeout-minutes: 15
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
+    - name: Harden the runner (Audit all outbound calls)
+      uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+      with:
+        egress-policy: audit
+
     - name: Login to Quay.io
       uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1  # v3.5.0
       with:
@@ -170,6 +195,11 @@ jobs:
     runs-on: ubuntu-22.04
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
     steps:
+    - name: Harden the runner (Audit all outbound calls)
+      uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+      with:
+        egress-policy: audit
+
     - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
     - name: "Prepare: restore caches, install Poetry, set up Python"
       uses: ./.github/actions/prepare

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,6 +26,11 @@ jobs:
         language: [ python ]
 
     steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+        with:
+          egress-policy: audit
+
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 

--- a/.github/workflows/docker-rebuild.yml
+++ b/.github/workflows/docker-rebuild.yml
@@ -9,6 +9,11 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 15
     steps:
+    - name: Harden the runner (Audit all outbound calls)
+      uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+      with:
+        egress-policy: audit
+
     - name: "Build for testing"
       uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83  # v6.18.0
       with:


### PR DESCRIPTION
This PR is a copy of the PR I automatically made to target my fork: https://github.com/juhoinkinen/Annif/pull/43. For some reason I could not use the automated [Secure Workflow](https://docs.stepsecurity.io/getting-started/quickstart-community-tier/getting-started-with-secure-workflow) process to directly target NatLibFi/Annif (I got an error message stating that a fork could not be created and an advice to try again after 5 minutes, but waiting did not help).

Below is the original, autogenerated description.

---

## Summary

This pull request is created by [StepSecurity](https://app.stepsecurity.io/securerepo) at the request of @juhoinkinen. Please merge the Pull Request to incorporate the requested changes. Please tag @juhoinkinen on your message if you have any questions related to the PR.
## Security Fixes

### Harden Runner

[Harden-Runner](https://github.com/step-security/harden-runner) is an open-source security agent for the GitHub-hosted runner to prevent software supply chain attacks. It prevents exfiltration of credentials, detects tampering of source code during build, and enables running jobs without `sudo` access. See how popular open-source projects use Harden-Runner [here](https://docs.stepsecurity.io/whos-using-harden-runner).

<details>
<summary>Harden runner usage</summary>

You can find link to view insights and policy recommendation in the build log

<img src="https://github.com/step-security/harden-runner/blob/main/images/buildlog1.png?raw=true" width="60%" height="60%">

Please refer to [documentation](https://docs.stepsecurity.io/harden-runner) to find more details.
</details>



## Feedback
For bug reports, feature requests, and general feedback; please email support@stepsecurity.io. To create such PRs, please visit https://app.stepsecurity.io/securerepo.


Signed-off-by: StepSecurity Bot <bot@stepsecurity.io>