### PR TITLE
Add missing links to website

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -246,7 +246,7 @@
       href="https://spacy.io/">spaCy</a>. It is <strong>multilingual</strong> and can support <strong>any
       subject vocabulary</strong> (in SKOS or a simple TSV format). It
       provides a <a href="https://annif.readthedocs.io/en/stable/source/commands.html">command-line interface</a>, a simple Web UI and a microservice-style
-      <a href="https://ai.finto.fi/v1/ui/">REST API</a>.</p>
+      <a href="https://api.annif.org/v1/ui/">REST API</a>.</p>
     </div>
   </div>
 


### PR DESCRIPTION
I noticed that the website (annif.org) was missing some direct links so I added them.