### PR TITLE
Fix zip destination path in Hugging Face repo when using custom data directory location

### DIFF
--- a/annif/hfh_util.py
+++ b/annif/hfh_util.py
@@ -94,7 +94,7 @@ def prepare_commits(
 def _prepare_datadir_commit(data_dir: str) -> tuple[io.BufferedRandom, Any]:
     from huggingface_hub import CommitOperationAdd
 
-    zip_repo_path = data_dir.split(os.path.sep, 1)[1] + ".zip"
+    zip_repo_path = os.path.join(*data_dir.rsplit(os.path.sep, 2)[1:3]) + ".zip"
     fobj = _archive_dir(data_dir)
     operation = CommitOperationAdd(path_in_repo=zip_repo_path, path_or_fileobj=fobj)
     return fobj, operation

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1559,14 +1559,14 @@ def test_upload(
     assert (
         mock.call(
             path_or_fileobj=mock.ANY,  # io.BufferedRandom object
-            path_in_repo="data/vocabs/dummy.zip",
+            path_in_repo="vocabs/dummy.zip",
         )
         in CommitOperationAdd.call_args_list
     )
     assert (
         mock.call(
             path_or_fileobj=mock.ANY,  # io.BufferedRandom object
-            path_in_repo="data/projects/dummy-fi.zip",
+            path_in_repo="projects/dummy-fi.zip",
         )
         in CommitOperationAdd.call_args_list
     )


### PR DESCRIPTION
When using a nondefault data directory location (with `ANNIF_DATADIR` environment variable) and running `annif upload`, the zipped projects and vocabs data files end up in a wrong path in the destination repository; the full local data directory gets created to the repo. For example, when using a temp directory, a project datafile with a path like this appears in the repo: `tmp/tmp3ttl0hbh/data/projects/tfidf-fi.zip`

This is fixed by getting the path to be used in the repo by reading the local datadir path from the right and using two parts of it (the project-id directory and the directory containing it, either `projects` or `vocabs`).

There was a unit test for this, but it was asserting a wrong path to be created in the repo.

I noticed this when working with #907. 