### PR TITLE
add vocab size and loaded status to project information returned by REST API

### DIFF
--- a/annif/project.py
+++ b/annif/project.py
@@ -330,10 +330,7 @@ class AnnifProject(DatadirMixin):
         """return this project as a dict"""
 
         try:
-            vocab = {
-                "vocab_id": self.vocab.vocab_id,
-                "languages": sorted(self.vocab.languages),
-            }
+            vocab = self.vocab.dump()
             vocab_lang = self.vocab_lang
         except ConfigurationException:
             vocab = None

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -79,6 +79,8 @@ def test_get_project_fi_dump(registry):
         "vocab": {
             "vocab_id": "dummy",
             "languages": ["en", "fi"],
+            "size": 2,
+            "loaded": True,
         },
         "vocab_language": "fi",
         "is_trained": True,


### PR DESCRIPTION
This little PR changes the data structure returned by the REST API `projects` method so it also includes vocabulary size and loaded status. It actually reduces code size a little because we can reuse the `Project.dump()` method.

The original idea of the data returned by `project` was to keep the vocabulary information minimal. But since the OpenAPI spec "promises" that the size and loaded fields should be there there (even though they are not mandatory fields in the schema), we might as well include them.

Fixes #912