### PR TITLE
Fix member paths in zip archive in Hugging Face uploads when using custom data directory

### DIFF
--- a/annif/hfh_util.py
+++ b/annif/hfh_util.py
@@ -127,8 +127,9 @@ def _archive_dir(data_dir: str) -> io.BufferedRandom:
             encoding="utf-8",
         )
         for fpath in fpaths:
-            logger.debug(f"Adding {fpath}")
-            arcname = os.path.join(*fpath.parts[1:])
+            # Get file path retaining projects/<projectid> or vocabs/<vocabid> parents
+            arcname = fpath.relative_to(path.parent.parent)
+            logger.debug(f"Adding {fpath} to zip archive as member {arcname}")
             zfile.write(fpath, arcname=arcname)
     fp.seek(0)
     return fp

--- a/annif/hfh_util.py
+++ b/annif/hfh_util.py
@@ -119,16 +119,18 @@ def _is_train_file(fname: str) -> bool:
 
 def _archive_dir(data_dir: str) -> io.BufferedRandom:
     fp = tempfile.TemporaryFile()
-    path = pathlib.Path(data_dir)
-    fpaths = [fpath for fpath in path.glob("**/*") if not _is_train_file(fpath.name)]
+    data_dir_path = pathlib.Path(data_dir)  # <projectid> or <vocabid> directory
+    fpaths = [p for p in data_dir_path.glob("**/*") if not _is_train_file(p.name)]
+    # Strip projects/<projectid> or vocabs/<vocabid>:
+    root_datadir = data_dir_path.parent.parent
+
     with zipfile.ZipFile(fp, mode="w") as zfile:
         zfile.comment = bytes(
             f"Archived by Annif {importlib.metadata.version('annif')}",
             encoding="utf-8",
         )
         for fpath in fpaths:
-            # Get file path retaining projects/<projectid> or vocabs/<vocabid> parents
-            arcname = fpath.relative_to(path.parent.parent)
+            arcname = fpath.relative_to(root_datadir)
             logger.debug(f"Adding {fpath} to zip archive as member {arcname}")
             zfile.write(fpath, arcname=arcname)
     fp.seek(0)

--- a/tests/test_hfh_util.py
+++ b/tests/test_hfh_util.py
@@ -67,9 +67,9 @@ def test_archive_dir(testdatadir):
     assert isinstance(fobj, io.BufferedRandom)
 
     with zipfile.ZipFile(fobj, mode="r") as zfile:
-        archived_files = zfile.namelist()
-    assert len(archived_files) == 1
-    assert os.path.split(archived_files[0])[1] == "foo.txt"
+        archived_file_paths = zfile.namelist()
+    assert len(archived_file_paths) == 1
+    assert archived_file_paths[0] == os.path.join("projects", "dummy-fi", "foo.txt")
 
 
 def test_get_project_config(app_project):


### PR DESCRIPTION
The fix in #908 was only partial: the member paths inside the uploaded zip archives still included the full datadir part, when `ANNIF_DATADIR` environment variable was used:

```
unzip -l ~/Downloads/tfidf-fi.zip 
Archive:  /home/jmminkin/Downloads/tfidf-fi.zip
Archived by Annif 1.5.0.dev0
  Length      Date    Time    Name
---------  ---------- -----   ----
   406760  2025-11-11 13:45   tmp/data/projects/tfidf-fi/vectorizer
   159508  2025-11-11 13:45   tmp/data/projects/tfidf-fi/tfidf-matrix.npz
```

After this everything should be ok. 