### PR TITLE
Configure cooldown of 5 days for Dependabot updates of GH Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
       - "/.github/actions/prepare"
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 5
     groups:
       github-actions:
         patterns:


### PR DESCRIPTION
It is probably a good idea to have a cooldown period for Dependabot updates, see [this blog](https://blog.yossarian.net/2025/11/21/We-should-all-be-using-dependency-cooldowns). 

Note that currently Dependabot only handles the GitHub Actions updates.