### PR TITLE
Use uv for managing dependencies

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,4 @@
 **/*.pyc
 data*
 venv
+.venv

--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -3,31 +3,18 @@ description:
 inputs:
   python-version:
     required: true
-  poetry-version:
+  uv-version:
     required: true
-outputs:
-  cache-matched-key:
-    value: ${{ steps.restore-cache.outputs.cache-matched-key }}
 runs:
   using: "composite"
   steps:
-    - name: Restore cached Poetry installation and its cache
-      id: restore-cache
-      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.3.0
-      with:
-        path: |
-          ~/.cache/pipx/venvs
-          ~/.local/bin
-          ~/.cache/pypoetry/
-        key: ignore-me
-        restore-keys: |
-          poetry-installation-and-cache-${{ inputs.python-version }}-${{ inputs.poetry-version }}-
     - name: Set up Python ${{ inputs.python-version }}
       uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548  # v6.1.0
       with:
         python-version: ${{ inputs.python-version }}
-    - name: Install Poetry
-      shell: bash
-      run: |
-        pipx install poetry==${{ inputs.poetry-version }}
-        poetry env use ${{ inputs.python-version }}
+    - name: Install uv
+      uses: astral-sh/setup-uv@681c641aba71e4a1c380be3ab5e12ad51f415867  # v7.1.6
+      with:
+        version: ${{ inputs.uv-version }}
+        python-version: ${{ inputs.python-version }}
+        enable-cache: true

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -96,23 +96,23 @@ jobs:
         # Selectively install the optional dependencies for some Python versions
         # For Python 3.10:
         if [[ ${{ matrix.python-version }} == '3.10' ]]; then
-          uv sync --extra "nn omikuji yake voikko stwfsa";
+          uv sync --extra nn --extra omikuji --extra yake --extra voikko --extra stwfsa;
         fi
         # For Python 3.11:
         if [[ ${{ matrix.python-version }} == '3.11' ]]; then
-          uv sync --extra "fasttext spacy estnltk";
+          uv sync --extra fasttext --extra spacy --extra estnltk;
           # download the small English pretrained spaCy model needed by spacy analyzer
           uv run python -m spacy download en_core_web_sm --upgrade-strategy only-if-needed
         fi
         # For Python 3.12:
         if [[ ${{ matrix.python-version }} == '3.12' ]]; then
-          uv sync --extra "nn fasttext yake stwfsa voikko spacy";
+          uv sync --extra nn --extra fasttext --extra yake --extra stwfsa --extra voikko --extra spacy;
           # download the small English pretrained spaCy model needed by spacy analyzer
           uv run python -m spacy download en_core_web_sm --upgrade-strategy only-if-needed
         fi
         # For Python 3.13:
         if [[ ${{ matrix.python-version }} == '3.13' ]]; then
-          uv sync --extra "fasttext yake voikko spacy";
+          uv sync --extra fasttext --extra yake --extra voikko --extra spacy;
           # download the small English pretrained spaCy model needed by spacy analyzer
           uv run python -m spacy download en_core_web_sm --upgrade-strategy only-if-needed
         fi

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -10,7 +10,7 @@ on:
 env:
   PIPX_HOME: "/home/runner/.cache/pipx"
   PIPX_BIN_DIR: "/home/runner/.local/bin"
-  POETRY_VERSION: "2.*"
+  UV_VERSION: "0.9.*"
 permissions:
   contents: read
 jobs:
@@ -25,23 +25,23 @@ jobs:
         egress-policy: audit
 
     - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-    - name: "Prepare: restore caches, install Poetry, set up Python"
+    - name: "Prepare: restore caches, install uv, set up Python"
       uses: ./.github/actions/prepare
       with:
         python-version: "3.12"
-        poetry-version: ${{ env.POETRY_VERSION }}
+        uv-version: ${{ env.UV_VERSION }}
     - name: Install Python dev dependencies
       run: |
-        poetry install --only dev
+        uv sync --only-dev
     - name: Lint with isort
       run: |
-        poetry run isort . --check-only --diff
+        uv run isort . --check-only --diff
     - name: Lint with Black
       run: |
-        poetry run black . --check --diff
+        uv run black . --check --diff
     - name: Lint with flake8
       run: |
-        poetry run flake8
+        uv run flake8
 
   time-startup:
     runs-on: ubuntu-22.04
@@ -53,18 +53,18 @@ jobs:
         egress-policy: audit
 
     - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-    - name: "Prepare: restore caches, install Poetry, set up Python"
+    - name: "Prepare: restore caches, install uv, set up Python"
       id: prepare
       uses: ./.github/actions/prepare
       with:
         python-version: "3.11"
-        poetry-version: ${{ env.POETRY_VERSION }}
+        uv-version: ${{ env.UV_VERSION }}
     - name: Install Python dependencies
       run: |
-        poetry install
+        uv sync
     - name: Check startup time
       run: |
-        poetry run tests/time-startup.sh
+        uv run tests/time-startup.sh
 
   test:
     runs-on: ubuntu-22.04
@@ -85,58 +85,48 @@ jobs:
         sudo apt-get install \
           libvoikko1 \
           voikko-fi
-    - name: "Prepare: restore caches, install Poetry, set up Python"
+    - name: "Prepare: restore caches, install uv, set up Python"
       id: prepare
       uses: ./.github/actions/prepare
       with:
         python-version: ${{ matrix.python-version }}
-        poetry-version: ${{ env.POETRY_VERSION }}
+        uv-version: ${{ env.UV_VERSION }}
     - name: Install Python dependencies
       run: |
         # Selectively install the optional dependencies for some Python versions
         # For Python 3.10:
         if [[ ${{ matrix.python-version }} == '3.10' ]]; then
-          poetry install -E "nn omikuji yake voikko stwfsa";
+          uv sync --extra "nn omikuji yake voikko stwfsa";
         fi
         # For Python 3.11:
         if [[ ${{ matrix.python-version }} == '3.11' ]]; then
-          poetry install -E "fasttext spacy estnltk";
+          uv sync --extra "fasttext spacy estnltk";
           # download the small English pretrained spaCy model needed by spacy analyzer
-          poetry run python -m spacy download en_core_web_sm --upgrade-strategy only-if-needed
+          uv run python -m spacy download en_core_web_sm --upgrade-strategy only-if-needed
         fi
         # For Python 3.12:
         if [[ ${{ matrix.python-version }} == '3.12' ]]; then
-          poetry install -E "nn fasttext yake stwfsa voikko spacy";
+          uv sync --extra "nn fasttext yake stwfsa voikko spacy";
           # download the small English pretrained spaCy model needed by spacy analyzer
-          poetry run python -m spacy download en_core_web_sm --upgrade-strategy only-if-needed
+          uv run python -m spacy download en_core_web_sm --upgrade-strategy only-if-needed
         fi
         # For Python 3.13:
         if [[ ${{ matrix.python-version }} == '3.13' ]]; then
-          poetry install -E "fasttext yake voikko spacy";
+          uv sync --extra "fasttext yake voikko spacy";
           # download the small English pretrained spaCy model needed by spacy analyzer
-          poetry run python -m spacy download en_core_web_sm --upgrade-strategy only-if-needed
+          uv run python -m spacy download en_core_web_sm --upgrade-strategy only-if-needed
         fi
-        poetry run python -m nltk.downloader punkt_tab
+        uv run python -m nltk.downloader punkt_tab
     - name: Test with pytest
       run: |
-        poetry run pytest --cov=./ --cov-report xml
+        uv run pytest --cov=./ --cov-report xml
         if [[ ${{ matrix.python-version }} == '3.11' ]]; then
-          poetry run pytest --cov=./ --cov-report xml --cov-append -m slow
+          uv run pytest --cov=./ --cov-report xml --cov-append -m slow
         fi
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7  # v5.5.1
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-    - name: Save cache
-      if: steps.prepare.outputs.cache-matched-key != format('poetry-installation-and-cache-{0}-{1}-{2}', matrix.python-version, env.POETRY_VERSION, hashFiles('**/poetry.lock'))
-      uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-      with:
-        path: |
-          ~/.cache/pipx/venvs
-          ~/.local/bin
-          ~/.cache/pypoetry/
-        # A new key is created to update the cache if some dependency has been updated
-        key:  poetry-installation-and-cache-${{ matrix.python-version }}-${{ env.POETRY_VERSION }}-${{ hashFiles('**/poetry.lock') }}
 
   test-docker-image:
     name: "test Docker image"
@@ -206,14 +196,14 @@ jobs:
         egress-policy: audit
 
     - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-    - name: "Prepare: restore caches, install Poetry, set up Python"
+    - name: "Prepare: restore caches, install uv, set up Python"
       uses: ./.github/actions/prepare
       with:
         python-version: '3.11'
-        poetry-version: ${{ env.POETRY_VERSION }}
+        uv-version: ${{ env.UV_VERSION }}
     - name: Build distributions
       run: |
-        poetry build
+        uv build
     - name: Publish package distributions to PyPI
       uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e  # v1.13.0
 

--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@ __pycache__
 *.pyc
 data
 docs/_build/
-poetry.lock
+uv.lock
 projects.cfg
 venv/
 .hypothesis/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,47 +1,53 @@
-FROM python:3.12-slim-bookworm
+# Use a Python 3.12 + uv image (Debian bookworm-slim)
+FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
 LABEL org.opencontainers.image.authors="grp-natlibfi-annif@helsinki.fi"
 SHELL ["/bin/bash", "-c"]
 
 ARG optional_dependencies="voikko fasttext nn omikuji yake spacy stwfsa"
-ARG POETRY_VIRTUALENVS_CREATE=false
 
 # Install system dependencies needed at runtime:
 RUN apt-get update && apt-get upgrade -y && \
-	if [[ $optional_dependencies =~ "voikko" ]]; then \
-		apt-get install -y --no-install-recommends \
-			libvoikko1 \
-			voikko-fi; \
-	fi && \
-	# Install rsync for model transfers:
-	apt-get install -y --no-install-recommends rsync && \
-	rm -rf /var/lib/apt/lists/* /usr/include/*
+    if [[ $optional_dependencies =~ "voikko" ]]; then \
+        apt-get install -y --no-install-recommends \
+            libvoikko1 \
+            voikko-fi; \
+    fi && \
+    # Install rsync for model transfers:
+    apt-get install -y --no-install-recommends rsync && \
+    rm -rf /var/lib/apt/lists/* /usr/include/*
 
 WORKDIR /Annif
-RUN pip install --upgrade pip "poetry~=2.0" --no-cache-dir
 
+# Copy only project metadata first to maximize Docker layer caching
 COPY pyproject.toml setup.cfg README.md LICENSE.txt CITATION.cff projects.cfg.dist /Annif/
 
-# First round of installation for Docker layer caching:
-RUN echo "Installing dependencies for optional features: $optional_dependencies" \
-	&& poetry install -E "$optional_dependencies" --no-root \
-	&& rm -rf /root/.cache/pypoetry  # No need for cache because of poetry.lock
+# First round: install dependencies only (no project), with selected extras.
+RUN extras=(); \
+    for e in ${optional_dependencies}; do extras+=(--extra "$e"); done; \
+    uv sync --no-install-project --no-dev "${extras[@]}"
 
 # Download nltk data
-RUN python -m nltk.downloader punkt_tab -d /usr/share/nltk_data
+RUN uv run --no-sync python -m nltk.downloader punkt_tab -d /usr/share/nltk_data
 
-# Download spaCy models, if the optional feature was selected
+# Download spaCy models only if 'spacy' extra is selected
 ARG spacy_models=en_core_web_sm
 RUN if [[ $optional_dependencies =~ "spacy" ]]; then \
-		for model in $(echo $spacy_models | tr "," "\n"); do \
-			python -m spacy download $model; \
-		done; \
-	fi
+        for model in $(echo "$spacy_models" | tr "," "\n"); do \
+            uv run --no-sync python -m spacy download "$model"; \
+        done; \
+    fi
 
-# Second round of installation with the actual code:
+# Second round: add source and install the actual project (editable by default)
 COPY annif /Annif/annif
 COPY tests /Annif/tests
-RUN poetry install -E "$optional_dependencies"
+RUN extras=(); \
+    for e in ${optional_dependencies}; do extras+=(--extra "$e"); done; \
+    uv sync --no-dev "${extras[@]}"
 
+# Make virtualenv executables available to shell and entrypoint
+ENV PATH="/Annif/.venv/bin:${PATH}"
+
+# Enable Annif bash completion (now available on PATH)
 WORKDIR /annif-projects
 RUN annif completion --bash >> /etc/bash.bashrc  # Enable tab completion
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,13 @@ RUN apt-get update && apt-get upgrade -y && \
 
 WORKDIR /Annif
 
+RUN groupadd -g 998 annif_user && \
+    useradd -m -u 998 -g annif_user annif_user && \
+    chown -R annif_user:annif_user /Annif
+USER annif_user
+
 # Copy only project metadata first to maximize Docker layer caching
-COPY pyproject.toml setup.cfg README.md LICENSE.txt CITATION.cff projects.cfg.dist /Annif/
+COPY --chown=annif_user:annif_user pyproject.toml setup.cfg README.md LICENSE.txt CITATION.cff projects.cfg.dist /Annif/
 
 # First round: install dependencies only (no project), with selected extras.
 RUN extras=(); \
@@ -27,11 +32,11 @@ RUN extras=(); \
     uv sync --no-install-project "${extras[@]}"
 
 # Download nltk data
-RUN uv run --no-sync python -m nltk.downloader punkt_tab -d /usr/share/nltk_data
+RUN uv run --no-sync python -m nltk.downloader punkt_tab
 
 # Second round: add source and install the actual project (editable by default)
-COPY annif /Annif/annif
-COPY tests /Annif/tests
+COPY --chown=annif_user:annif_user annif /Annif/annif
+COPY --chown=annif_user:annif_user tests /Annif/tests
 RUN extras=(); \
     for e in ${optional_dependencies}; do extras+=(--extra "$e"); done; \
     uv sync "${extras[@]}"
@@ -49,16 +54,7 @@ ENV PATH="/Annif/.venv/bin:${PATH}"
 
 # Enable Annif bash completion (now available on PATH)
 WORKDIR /annif-projects
-RUN annif completion --bash >> /etc/bash.bashrc  # Enable tab completion
-
-# Switch user to non-root:
-RUN groupadd -g 998 annif_user && \
-    useradd -r -u 998 -g annif_user annif_user && \
-    chmod -R a+rX /Annif && \
-    mkdir -p /Annif/tests/data /Annif/projects.d && \
-    chown -R annif_user:annif_user /annif-projects /Annif/tests/data
-USER annif_user
-ENV HF_HOME="/tmp"
+RUN annif completion --bash >> ~/.bashrc
 
 ENV GUNICORN_CMD_ARGS="--worker-class uvicorn.workers.UvicornWorker"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,6 +54,7 @@ RUN annif completion --bash >> /etc/bash.bashrc  # Enable tab completion
 WORKDIR /annif-projects
 RUN groupadd -g 998 annif_user && \
     useradd -r -u 998 -g annif_user annif_user && \
+    chmod -R a+rX /Annif/* && \
     mkdir -p /Annif/tests/data /Annif/projects.d && \
     chown -R annif_user:annif_user /annif-projects /Annif/tests/data
 USER annif_user

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,9 +51,10 @@ ENV PATH="/Annif/.venv/bin:${PATH}"
 WORKDIR /annif-projects
 RUN groupadd -g 998 annif_user && \
     useradd -m -u 998 -g annif_user annif_user && \
-    mkdir -p /Annif/tests/data && \
+    mkdir -p /Annif/tests/data /Annif/projects.d && \
     chown -R annif_user:annif_user /annif-projects /Annif/tests/data
 USER annif_user
+ENV HF_HOME="/tmp"
 
 # Enable Annif bash completion (now available on PATH)
 RUN annif completion --bash >> ~/.bashrc

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ COPY pyproject.toml setup.cfg README.md LICENSE.txt CITATION.cff projects.cfg.di
 # First round: install dependencies only (no project), with selected extras.
 RUN extras=(); \
     for e in ${optional_dependencies}; do extras+=(--extra "$e"); done; \
-    uv sync --no-install-project --no-dev "${extras[@]}"
+    uv sync --no-install-project "${extras[@]}"
 
 # Download nltk data
 RUN uv run --no-sync python -m nltk.downloader punkt_tab -d /usr/share/nltk_data
@@ -42,7 +42,7 @@ COPY annif /Annif/annif
 COPY tests /Annif/tests
 RUN extras=(); \
     for e in ${optional_dependencies}; do extras+=(--extra "$e"); done; \
-    uv sync --no-dev "${extras[@]}"
+    uv sync "${extras[@]}"
 
 # Make virtualenv executables available to shell and entrypoint
 ENV PATH="/Annif/.venv/bin:${PATH}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,13 +47,15 @@ RUN if [[ $optional_dependencies =~ "spacy" ]]; then \
 # Make virtualenv executables available to shell and entrypoint
 ENV PATH="/Annif/.venv/bin:${PATH}"
 
-# Create non-root user for running annif commands
+# Set up working dir & non-root user for running annif commands
+WORKDIR /annif-projects
 RUN groupadd -g 998 annif_user && \
-    useradd -m -u 998 -g annif_user annif_user
+    useradd -m -u 998 -g annif_user annif_user && \
+    mkdir -p /Annif/tests/data && \
+    chown -R annif_user:annif_user /annif-projects /Annif/tests/data
 USER annif_user
 
 # Enable Annif bash completion (now available on PATH)
-WORKDIR /annif-projects
 RUN annif completion --bash >> ~/.bashrc
 
 ENV GUNICORN_CMD_ARGS="--worker-class uvicorn.workers.UvicornWorker"

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,13 +18,8 @@ RUN apt-get update && apt-get upgrade -y && \
 
 WORKDIR /Annif
 
-RUN groupadd -g 998 annif_user && \
-    useradd -m -u 998 -g annif_user annif_user && \
-    chown -R annif_user:annif_user /Annif
-USER annif_user
-
 # Copy only project metadata first to maximize Docker layer caching
-COPY --chown=annif_user:annif_user pyproject.toml setup.cfg README.md LICENSE.txt CITATION.cff projects.cfg.dist /Annif/
+COPY pyproject.toml setup.cfg README.md LICENSE.txt CITATION.cff projects.cfg.dist /Annif/
 
 # First round: install dependencies only (no project), with selected extras.
 RUN extras=(); \
@@ -32,11 +27,11 @@ RUN extras=(); \
     uv sync --no-install-project "${extras[@]}"
 
 # Download nltk data
-RUN uv run --no-sync python -m nltk.downloader punkt_tab
+RUN uv run --no-sync python -m nltk.downloader punkt_tab -d /usr/share/nltk_data
 
 # Second round: add source and install the actual project (editable by default)
-COPY --chown=annif_user:annif_user annif /Annif/annif
-COPY --chown=annif_user:annif_user tests /Annif/tests
+COPY annif /Annif/annif
+COPY tests /Annif/tests
 RUN extras=(); \
     for e in ${optional_dependencies}; do extras+=(--extra "$e"); done; \
     uv sync "${extras[@]}"
@@ -51,6 +46,11 @@ RUN if [[ $optional_dependencies =~ "spacy" ]]; then \
 
 # Make virtualenv executables available to shell and entrypoint
 ENV PATH="/Annif/.venv/bin:${PATH}"
+
+# Create non-root user for running annif commands
+RUN groupadd -g 998 annif_user && \
+    useradd -m -u 998 -g annif_user annif_user
+USER annif_user
 
 # Enable Annif bash completion (now available on PATH)
 WORKDIR /annif-projects

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,17 +47,17 @@ RUN if [[ $optional_dependencies =~ "spacy" ]]; then \
 # Make virtualenv executables available to shell and entrypoint
 ENV PATH="/Annif/.venv/bin:${PATH}"
 
+# Enable Annif bash completion (now available on PATH)
+RUN annif completion --bash >> /etc/bash.bashrc  # Enable tab completion
+
 # Set up working dir & non-root user for running annif commands
 WORKDIR /annif-projects
 RUN groupadd -g 998 annif_user && \
-    useradd -m -u 998 -g annif_user annif_user && \
+    useradd -r -u 998 -g annif_user annif_user && \
     mkdir -p /Annif/tests/data /Annif/projects.d && \
     chown -R annif_user:annif_user /annif-projects /Annif/tests/data
 USER annif_user
 ENV HF_HOME="/tmp"
-
-# Enable Annif bash completion (now available on PATH)
-RUN annif completion --bash >> ~/.bashrc
 
 ENV GUNICORN_CMD_ARGS="--worker-class uvicorn.workers.UvicornWorker"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,13 @@ RUN extras=(); \
 # Download nltk data
 RUN uv run --no-sync python -m nltk.downloader punkt_tab -d /usr/share/nltk_data
 
+# Second round: add source and install the actual project (editable by default)
+COPY annif /Annif/annif
+COPY tests /Annif/tests
+RUN extras=(); \
+    for e in ${optional_dependencies}; do extras+=(--extra "$e"); done; \
+    uv sync "${extras[@]}"
+
 # Download spaCy models only if 'spacy' extra is selected
 ARG spacy_models=en_core_web_sm
 RUN if [[ $optional_dependencies =~ "spacy" ]]; then \
@@ -36,13 +43,6 @@ RUN if [[ $optional_dependencies =~ "spacy" ]]; then \
             uv run --no-sync python -m spacy download "$model"; \
         done; \
     fi
-
-# Second round: add source and install the actual project (editable by default)
-COPY annif /Annif/annif
-COPY tests /Annif/tests
-RUN extras=(); \
-    for e in ${optional_dependencies}; do extras+=(--extra "$e"); done; \
-    uv sync "${extras[@]}"
 
 # Make virtualenv executables available to shell and entrypoint
 ENV PATH="/Annif/.venv/bin:${PATH}"

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Annif can be tried out in the [GitHub Codespaces](https://docs.github.com/en/cod
 
 A development version of Annif can be installed by cloning the [GitHub
 repository](https://github.com/NatLibFi/Annif).
-[Poetry](https://python-poetry.org/) is used for managing dependencies and virtual environment for the development version; Poetry 2.0+ is required.
+[uv](https://docs.astral.sh/uv/) is used for managing dependencies and virtual environment for the development version.
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for information on [unit tests](CONTRIBUTING.md#unit-tests), [code style](CONTRIBUTING.md#code-style), [development flow](CONTRIBUTING.md#development-flow) etc. details that are useful when participating in Annif development.
 
@@ -81,26 +81,34 @@ Clone the repository.
 
 Switch into the repository directory.
 
-Install [pipx](https://pypa.github.io/pipx/) and Poetry if you don't have them. First pipx:
+Install [pipx](https://pypa.github.io/pipx/) and uv if you don't have them. First pipx:
 
     python3 -m pip install --user pipx
     python3 -m pipx ensurepath
 
-Open a new shell, and then install Poetry:
+Open a new shell, and then install uv:
 
-    pipx install poetry==2.*
+    pipx install uv
 
-Poetry can be installed also without pipx: check the [Poetry documentation](https://python-poetry.org/docs/master/#installation).
+uv can be installed also without pipx: check the [uv documentation](https://docs.astral.sh/uv/getting-started/installation/).
 
 Create a virtual environment and install dependencies:
 
-    poetry install
+    uv sync
 
-By default development dependencies are included. Use option `-E` to install dependencies for selected optional features (`-E "extra1 extra2"` for multiple extras), or install all of them with `--all-extras`. By default the virtual environment directory is not under the project directory, but there is a [setting for selecting this](https://python-poetry.org/docs/configuration/#virtualenvsin-project).
+By default development dependencies are included. Use option `--extra` to install dependencies for selected optional features (`--extra "extra1 extra2"` for multiple extras), or install all of them with `--all-extras`. By default the virtual environment directory is `.venv` under the project directory.
+
+You can run Annif in one of two ways:
+
+### 1. One-off using `uv run`
+
+    uv run annif
+
+### 2. Activating the virtual environment
 
 Enter the virtual environment:
 
-    eval $(poetry env activate)
+    source .venv/bin/activate
 
 Start up the application:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,6 @@ dependencies = [
     "requests~=2.32.3",
     "rdflib~=7.1.3",
     "tomli~=2.2.1; python_version<'3.11'",
-    "pip>=25.3",
 ]
 
 [project.optional-dependencies]
@@ -54,7 +53,10 @@ nn = [
     "lmdb~=1.7.3",
 ]
 omikuji = ["omikuji==0.5.*"]
-spacy = ["spacy~=3.8.4"]
+spacy = [
+    "spacy~=3.8.4",
+    "pip>=25.3",
+]
 stwfsa = ["stwfsapy~=0.6.1"]
 voikko = ["voikko==0.5.*"]
 yake = ["yake~=0.6.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ dependencies = [
     "requests~=2.32.3",
     "rdflib~=7.1.3",
     "tomli~=2.2.1; python_version<'3.11'",
+    "pip>=25.3",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,17 +2,14 @@
 name = "annif"
 version = "1.5.0-dev"
 description = "Automated subject indexing and classification tool"
-license = "Apache-2.0"
-readme = "README.md"
+authors = [{ name = "National Library of Finland", email = "finto-posti@helsinki.fi" }]
 requires-python = ">=3.10,<3.14"
-
-authors = [
-    {name = "National Library of Finland", email = "finto-posti@helsinki.fi"},
-]
+readme = "README.md"
+license = "Apache-2.0"
 maintainers = [
-    {name = "Osma Suominen", email = "osma.suominen@helsinki.fi"},
-    {name = "Juho Inkinen", email = "juho.inkinen@helsinki.fi"},
-    {name = "Mona Lehtinen", email = "mona.lehtinen@helsinki.fi"},
+    { name = "Osma Suominen", email = "osma.suominen@helsinki.fi" },
+    { name = "Juho Inkinen", email = "juho.inkinen@helsinki.fi" },
+    { name = "Mona Lehtinen", email = "mona.lehtinen@helsinki.fi" },
 ]
 keywords = [
     "machine-learning",
@@ -28,7 +25,6 @@ classifiers = [
     "Operating System :: OS Independent",
     "Development Status :: 5 - Production/Stable",
 ]
-
 dependencies = [
     "click~=8.2.1",
     "click-log==0.4.*",
@@ -52,24 +48,15 @@ dependencies = [
 [project.optional-dependencies]
 fasttext = ["fasttext-numpy2==0.10.4"]
 estnltk = ["estnltk==1.7.4"]
-nn = ["tensorflow-cpu~=2.20.0", "lmdb~=1.7.3"]
+nn = [
+    "tensorflow-cpu~=2.20.0",
+    "lmdb~=1.7.3",
+]
 omikuji = ["omikuji==0.5.*"]
 spacy = ["spacy~=3.8.4"]
 stwfsa = ["stwfsapy~=0.6.1"]
 voikko = ["voikko==0.5.*"]
 yake = ["yake~=0.6.0"]
-
-[tool.poetry.group.dev.dependencies]
-py = "*"
-pytest = "8.*"
-pytest-cov = "*"
-pytest-watch = "*"
-pytest-flask = "*"
-flake8 = "*"
-bumpversion = "*"
-black = "25.*"
-isort = "*"
-schemathesis = "3.*.*"
 
 [project.urls]
 homepage = "https://annif.org"
@@ -79,9 +66,19 @@ documentation = "https://github.com/NatLibFi/Annif/wiki"
 [project.scripts]
 annif = "annif.cli:cli"
 
-[build-system]
-requires = ["poetry-core>=2.0.0,<3.0.0"]
-build-backend = "poetry.core.masonry.api"
+[dependency-groups]
+dev = [
+    "py",
+    "pytest==8.*",
+    "pytest-cov",
+    "pytest-watch",
+    "pytest-flask",
+    "flake8",
+    "bumpversion",
+    "black==25.*",
+    "isort",
+    "schemathesis==3.*",
+]
 
 [tool.isort]
 profile = "black"
@@ -91,3 +88,7 @@ skip_gitignore = true
 [tool.pytest.ini_options]
 markers = ["slow: marks tests as slow (deselect with '-m \"not slow\"')"]
 addopts = "-m 'not slow'"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,10 @@ test = pytest
 [flake8]
 max-line-length = 88
 ignore = E203 W503
+exclude =
+	.git
+	__pycache__
+	.venv
 
 [coverage:report]
 exclude_also = 


### PR DESCRIPTION
This PR switches to uv for dependency management instead of Poetry.

Included changes:
- migrate `pyproject.toml` to work with `uv`; for example, declare the dev dependencies using standard `[dependency-groups]` section
- update README.md to explain how to use `uv` commands for development installs
- migrate GitHub Actions to use `uv` instead of Poetry
- migrate Dockerfile to use `uv` instead of Poetry
- configure `flake8` to skip e.g. `.venv` directory (`uv` will create the virtual environment there by default)

Some notes:

1. `uv` doesn't have a command for permanently activating the venv like the old `poetry shell` or the newer equivalent `eval $(poetry env activate)`. It is recommended to use `uv run` every time, but I think that's cumbersome. However, the venv can simply be activated using `source .venv/bin/activate` so I recommended that in the README. (There is an [open issue](https://github.com/astral-sh/uv/issues/1910) about this, but it seems that implementing this properly to handle all edge cases is a bit difficult, so the developers hesitate to do it.)
2. I changed the Docker base image to one provided by Astral / uv: `ghcr.io/astral-sh/uv:python3.12-bookworm-slim`. An alternative would have been to keep the vanilla base image `python:3.12-slim-bookworm` and just install `uv` within that.
3. I _think_ that the GitHub Actions action `astral-sh/setup-uv` is handling all caching of dependencies, but I haven't verified that it works in a sane way...

Overall, `uv` seems a bit faster than Poetry. For example, the GitHub Actions run completes in less than 3 minutes, when it used to take a bit more than 3 minutes (though with a lot of variation).

In the future, using `uv` should enable better management of PyTorch variants when we add it as a dependency (for example for the EBM backend - see #914 ).

Closes #919 
