### PR TITLE
Reimplement NN ensemble using PyTorch

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -96,7 +96,7 @@ jobs:
         # Selectively install the optional dependencies for some Python versions
         # For Python 3.10:
         if [[ ${{ matrix.python-version }} == '3.10' ]]; then
-          uv sync --extra nn --extra omikuji --extra yake --extra voikko --extra stwfsa;
+          uv sync --extra nn --extra torch-cpu --extra omikuji --extra yake --extra voikko --extra stwfsa;
         fi
         # For Python 3.11:
         if [[ ${{ matrix.python-version }} == '3.11' ]]; then
@@ -106,7 +106,7 @@ jobs:
         fi
         # For Python 3.12:
         if [[ ${{ matrix.python-version }} == '3.12' ]]; then
-          uv sync --extra nn --extra fasttext --extra yake --extra stwfsa --extra voikko --extra spacy;
+          uv sync --extra nn --extra torch-cpu --extra fasttext --extra yake --extra stwfsa --extra voikko --extra spacy;
           # download the small English pretrained spaCy model needed by spacy analyzer
           uv run python -m spacy download en_core_web_sm --upgrade-strategy only-if-needed
         fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
 LABEL org.opencontainers.image.authors="grp-natlibfi-annif@helsinki.fi"
 SHELL ["/bin/bash", "-c"]
 
-ARG optional_dependencies="voikko fasttext nn omikuji yake spacy stwfsa"
+ARG optional_dependencies="voikko fasttext nn omikuji yake spacy stwfsa torch-cpu"
 
 # Install system dependencies needed at runtime:
 RUN apt-get update && apt-get upgrade -y && \

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Create a virtual environment and install dependencies:
 
     uv sync
 
-By default development dependencies are included. Use the option `--extra` to install dependencies for selected optional features (`--extra foo --extra bar` for multiple extras). There are also special extras for selecting the PyTorch backend for those optional features (`nn`) that depend on PyTorch: `--extra torch-cpu` will use the CPU backend and `--extra torch-cu128` will use the CUDA 12.8 backend. For a full set of extras with CPU-only PyTorch, use `uv sync --group all --extra torch-cpu`.
+By default development dependencies are included. Use the option `--extra` to install dependencies for selected optional features (`--extra foo --extra bar` for multiple extras or `--group all` for all extras). There are also special extras for selecting the PyTorch backend for those optional features (`nn`) that depend on PyTorch: `--extra torch-cpu` will use the CPU backend and `--extra torch-cu128` will use the CUDA 12.8 backend. For a full set of extras with CPU-only PyTorch, use `uv sync --group all --extra torch-cpu`.
 
 By default the virtual environment directory is `.venv` under the project directory.
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,9 @@ Create a virtual environment and install dependencies:
 
     uv sync
 
-By default development dependencies are included. Use option `--extra` to install dependencies for selected optional features (`--extra "extra1 extra2"` for multiple extras), or install all of them with `--all-extras`. By default the virtual environment directory is `.venv` under the project directory.
+By default development dependencies are included. Use the option `--extra` to install dependencies for selected optional features (`--extra foo --extra bar` for multiple extras). There are also special extras for selecting the PyTorch backend for those optional features (`nn`) that depend on PyTorch: `--extra torch-cpu` will use the CPU backend and `--extra torch-cu128` will use the CUDA 12.8 backend. For a full set of extras with CPU-only PyTorch, use `uv sync --group all --extra torch-cpu`.
+
+By default the virtual environment directory is `.venv` under the project directory.
 
 You can run Annif in one of two ways:
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Create a virtual environment and install dependencies:
 
     uv sync
 
-By default development dependencies are included. Use the option `--extra` to install dependencies for selected optional features (`--extra foo --extra bar` for multiple extras or `--group all` for all extras). There are also special extras for selecting the PyTorch backend for those optional features (`nn`) that depend on PyTorch: `--extra torch-cpu` will use the CPU backend and `--extra torch-cu128` will use the CUDA 12.8 backend. For a full set of extras with CPU-only PyTorch, use `uv sync --group all --extra torch-cpu`.
+By default development dependencies are included. Use the option `--extra` to install dependencies for selected optional features (`--extra foo --extra bar` for multiple extras or `--group all` for all extras). There are also special extras for selecting the PyTorch backend for those optional features (`nn`) that depend on PyTorch: `--extra torch-cpu` will use the CPU backend, `--extra torch-cu126` will use the CUDA 12.6 backend and `--extra torch-cu130` will use the CUDA 13.0 backend. For a full set of extras with CPU-only PyTorch, use `uv sync --group all --extra torch-cpu`.
 
 By default the virtual environment directory is `.venv` under the project directory.
 

--- a/annif/__init__.py
+++ b/annif/__init__.py
@@ -22,8 +22,6 @@ if TYPE_CHECKING:
 def create_flask_app(config_name: str | None = None) -> Flask:
     """Create a Flask app to be used by the CLI."""
 
-    _set_tensorflow_loglevel()
-
     app = Flask(__name__)
     config_name = _get_config_name(config_name)
     logger.debug(f"creating flask app with configuration {config_name}")
@@ -93,20 +91,3 @@ def _get_config_name(config_name: str | None) -> str:
         else:
             config_name = "annif.default_config.ProductionConfig"  # pragma: no cover
     return config_name
-
-
-def _set_tensorflow_loglevel():
-    """Set TensorFlow log level based on Annif log level (--verbosity/-v
-    option) using an environment variable. INFO messages by TF are shown only on
-    DEBUG (or NOTSET) level of Annif."""
-    annif_loglevel = logger.getEffectiveLevel()
-    tf_loglevel_mapping = {
-        0: "0",  # NOTSET
-        10: "0",  # DEBUG
-        20: "1",  # INFO
-        30: "1",  # WARNING
-        40: "2",  # ERROR
-        50: "3",  # CRITICAL
-    }
-    tf_loglevel = tf_loglevel_mapping[annif_loglevel]
-    os.environ.setdefault("TF_CPP_MIN_LOG_LEVEL", tf_loglevel)

--- a/annif/backend/__init__.py
+++ b/annif/backend/__init__.py
@@ -48,9 +48,7 @@ def _nn_ensemble() -> Type[AnnifBackend]:
 
         return nn_ensemble.NNEnsembleBackend
     except ImportError:
-        raise ValueError(
-            "Keras and TensorFlow not available, cannot use " + "nn_ensemble backend"
-        )
+        raise ValueError("PyTorch not available, cannot use nn_ensemble backend")
 
 
 def _omikuji() -> Type[AnnifBackend]:

--- a/annif/backend/nn_ensemble.py
+++ b/annif/backend/nn_ensemble.py
@@ -136,12 +136,14 @@ class EarlyStopping:
         self._no_improvement_count = 0
         self._stop_early = False
         self.best_state = None
+        self.best_epoch = 0
 
-    def __call__(self, model, metric):
+    def __call__(self, model, metric, epoch):
         if self._best_metric is None or metric > self._best_metric:
             self._best_metric = metric
             self._no_improvement_count = 0
             self.best_state = copy.deepcopy(model.state_dict())
+            self.best_epoch = epoch
         else:
             self._no_improvement_count += 1
             if self._no_improvement_count > self._patience:
@@ -156,7 +158,7 @@ def ndcg_batch(preds: torch.Tensor, targets: torch.Tensor):
     preds:   (B, N) float
     targets: (B, N) {0,1}
 
-    Returns: mean nDCG across the batch
+    Returns: mean NDCG across the batch
     """
     sorted_idx = torch.argsort(preds, dim=1, descending=True)
     sorted_targets = torch.gather(targets, 1, sorted_idx)
@@ -381,10 +383,11 @@ class NNEnsembleBackend(backend.AnnifLearningBackend, ensemble.BaseEnsembleBacke
                 # evaluate for early stopping
                 with torch.no_grad():
                     outputs = self._model(eval_inputs)
-                    ndcg = ndcg_batch(outputs, eval_targets)
-                print(f"Epoch {epoch + 1}/{max_epochs} - nDCG: {ndcg:.4f}")
-                if early_stopping(self._model, ndcg):
-                    print("Model no longer improving, stopping training.")
+                ndcg = ndcg_batch(outputs, eval_targets)
+                self.info(f"Epoch {epoch + 1}/{max_epochs}: NDCG={ndcg:.4f}")
+                if early_stopping(self._model, ndcg, epoch):
+                    best = early_stopping.best_epoch + 1
+                    self.info(f"Model no longer improving, using best epoch {best}.")
                     break
 
             # Restore best model weights

--- a/annif/backend/nn_ensemble.py
+++ b/annif/backend/nn_ensemble.py
@@ -88,28 +88,36 @@ class LMDBDataset(Dataset):
 
 class NNEnsembleModel(nn.Module):
     def __init__(
-        self, input_dim: int, hidden_dim: int, output_dim: int, dropout_rate: float
+        self,
+        source_dim: int,
+        input_dim: int,
+        hidden_dim: int,
+        output_dim: int,
+        dropout_rate: float,
     ):
         super().__init__()
         self.model_config = {
+            "source_dim": source_dim,
             "input_dim": input_dim,
             "hidden_dim": hidden_dim,
             "output_dim": output_dim,
             "dropout_rate": dropout_rate,
         }
+        self.conv = nn.Conv1d(source_dim, 1, 1, bias=False)
         self.flatten = nn.Flatten()
         self.dropout1 = nn.Dropout(dropout_rate)
-        self.hidden = nn.Linear(input_dim, hidden_dim)
+        self.hidden = nn.Linear(input_dim * source_dim, hidden_dim)
         self.dropout2 = nn.Dropout(dropout_rate)
         self.delta_layer = nn.Linear(hidden_dim, output_dim)
         self.reset_parameters()
 
     def reset_parameters(self):
+        self.conv.weight.data.fill_(1 / self.model_config["source_dim"])
         nn.init.zeros_(self.delta_layer.weight)
         nn.init.zeros_(self.delta_layer.bias)
 
     def forward(self, inputs):
-        mean = torch.mean(inputs, dim=1)
+        mean = self.conv(inputs)[:, 0, :]
         x = self.flatten(inputs)
         x = self.dropout1(x)
         x = F.relu(self.hidden(x))
@@ -244,12 +252,14 @@ class NNEnsembleBackend(backend.AnnifLearningBackend, ensemble.BaseEnsembleBacke
         self.info("creating NN ensemble model")
 
         # Create PyTorch model
-        input_dim = len(self.project.subjects) * len(sources)
+        source_dim = len(sources)
+        input_dim = len(self.project.subjects)
         hidden_dim = int(self.params["nodes"])
         output_dim = len(self.project.subjects)
         dropout_rate = float(self.params["dropout_rate"])
 
         self._model = NNEnsembleModel(
+            source_dim=source_dim,
             input_dim=input_dim,
             hidden_dim=hidden_dim,
             output_dim=output_dim,

--- a/annif/backend/nn_ensemble.py
+++ b/annif/backend/nn_ensemble.py
@@ -87,7 +87,7 @@ class LMDBDataset(Dataset):
 
 
 class NNEnsembleModel(nn.Module):
-    def __init__(self, n_sources: int, n_subjects: int, source_weights: list[int]):
+    def __init__(self, n_sources: int, n_subjects: int, source_weights: list[float]):
         super().__init__()
         self.model_config = {
             "n_sources": n_sources,
@@ -97,7 +97,9 @@ class NNEnsembleModel(nn.Module):
         # per-concept/source weights
         init_weights = torch.tensor(source_weights, dtype=torch.float32)
         init_weights = init_weights / init_weights.sum()
-        self.weights = nn.Parameter(init_weights[:, None].expand(-1, n_subjects).contiguous())
+        self.weights = nn.Parameter(
+            init_weights[:, None].expand(-1, n_subjects).contiguous()
+        )
         # per-concept bias
         self.bias = nn.Parameter(torch.zeros(n_subjects))
 

--- a/annif/backend/nn_ensemble.py
+++ b/annif/backend/nn_ensemble.py
@@ -151,27 +151,24 @@ class EarlyStopping:
 
 
 @torch.no_grad()
-def ndcg_batch(preds: torch.Tensor, targets: torch.Tensor, k: int = 1000):
+def ndcg_batch(preds: torch.Tensor, targets: torch.Tensor):
     """
     preds:   (B, N) float
     targets: (B, N) {0,1}
-    k:       int, cutoff for nDCG@k
 
-    Returns: mean nDCG@K across the batch
+    Returns: mean nDCG across the batch
     """
     sorted_idx = torch.argsort(preds, dim=1, descending=True)
     sorted_targets = torch.gather(targets, 1, sorted_idx)
-    sorted_targets_k = sorted_targets[:, :k]
 
-    L = min(k, sorted_targets.size(1))
+    L = sorted_targets.size(1)
     ranks = torch.arange(1, L + 1, device=preds.device)
     discounts = 1.0 / torch.log2(ranks + 1)
 
-    dcg = (sorted_targets_k * discounts).sum(dim=1)
+    dcg = (sorted_targets * discounts).sum(dim=1)
 
-    ideal_sorted = torch.sort(targets, dim=1, descending=True).values
-    ideal_sorted_k = ideal_sorted[:, :k]
-    idcg = (ideal_sorted_k * discounts).sum(dim=1)
+    ideal_sorted = torch.sort(targets, dim=1, descending=True).values[:, :L]
+    idcg = (ideal_sorted * discounts).sum(dim=1)
 
     ndcg = dcg / torch.clamp(idcg, min=1e-8)
 
@@ -382,7 +379,7 @@ class NNEnsembleBackend(backend.AnnifLearningBackend, ensemble.BaseEnsembleBacke
                 with torch.no_grad():
                     outputs = self._model(eval_inputs)
                     ndcg = ndcg_batch(outputs, eval_targets)
-                print(f"Epoch {epoch + 1}/{max_epochs} - nDCG@1000: {ndcg:.4f}")
+                print(f"Epoch {epoch + 1}/{max_epochs} - nDCG: {ndcg:.4f}")
                 if early_stopping(self._model, ndcg):
                     print("Model no longer improving, stopping training.")
                     break

--- a/annif/backend/nn_ensemble.py
+++ b/annif/backend/nn_ensemble.py
@@ -186,6 +186,7 @@ class NNEnsembleBackend(backend.AnnifLearningBackend, ensemble.BaseEnsembleBacke
 
     EVAL_BATCH_SIZE = 512
     EARLY_STOPPING_PATIENCE = 2
+    PRED_SCALE = 20
 
     DEFAULT_PARAMETERS = {
         "lr": 0.003,
@@ -239,11 +240,13 @@ class NNEnsembleBackend(backend.AnnifLearningBackend, ensemble.BaseEnsembleBacke
             torch.from_numpy(score_vectors.swapaxes(0, 1))
         )
         with torch.no_grad():
-            prediction = torch.sigmoid(self._model(score_vector_tensor))
+            prediction = self._model(score_vector_tensor)
+        # use sigmoid to ensure [0..1] range, scaled to spread out values
+        scaled_pred = torch.sigmoid(prediction * self.PRED_SCALE)
         return SuggestionBatch.from_sequence(
             [
                 vector_to_suggestions(row, limit=int(params["limit"]))
-                for row in prediction.detach().numpy()
+                for row in scaled_pred.detach().numpy()
             ],
             self.project.subjects,
         )

--- a/annif/backend/nn_ensemble.py
+++ b/annif/backend/nn_ensemble.py
@@ -103,6 +103,13 @@ class NNEnsembleModel(nn.Module):
         self.hidden = nn.Linear(input_dim, hidden_dim)
         self.dropout2 = nn.Dropout(dropout_rate)
         self.delta_layer = nn.Linear(hidden_dim, output_dim)
+        self.reset_parameters()
+
+    def reset_parameters(self):
+        nn.init.xavier_uniform_(self.hidden.weight)
+        nn.init.zeros_(self.hidden.bias)
+        nn.init.zeros_(self.delta_layer.weight)
+        nn.init.zeros_(self.delta_layer.bias)
 
     def forward(self, inputs):
         mean = torch.mean(inputs, dim=1)
@@ -147,7 +154,6 @@ class NNEnsembleBackend(backend.AnnifLearningBackend, ensemble.BaseEnsembleBacke
     DEFAULT_PARAMETERS = {
         "nodes": 100,
         "dropout_rate": 0.2,
-        "optimizer": "adam",
         "lr": 0.001,
         "epochs": 10,
         "learn-epochs": 1,
@@ -315,13 +321,16 @@ class NNEnsembleBackend(backend.AnnifLearningBackend, ensemble.BaseEnsembleBacke
 
             # Training loop
             optimizer = torch.optim.Adam(
-                self._model.parameters(), lr=float(self.params["lr"]), weight_decay=0
+                self._model.parameters(),
+                lr=float(self.params["lr"]),
+                weight_decay=0,
+                eps=1e-08,
             )
             criterion = nn.BCEWithLogitsLoss()
             ndcg_metric = RetrievalNormalizedDCG(top_k=None)
 
-            self._model.train()
             for epoch in range(epochs):
+                self._model.train()
                 ndcg_metric.reset()
                 total_loss = 0.0
                 total_samples = 0

--- a/annif/backend/nn_ensemble.py
+++ b/annif/backend/nn_ensemble.py
@@ -164,9 +164,10 @@ class NNEnsembleBackend(backend.AnnifLearningBackend, ensemble.BaseEnsembleBacke
     LMDB_FILE = "nn-train.mdb"
 
     DEFAULT_PARAMETERS = {
-        "lr": 0.001,
-        "epochs": 10,
+        "lr": 0.003,
+        "max-epochs": 20,
         "learn-epochs": 1,
+        "batch-size": 256,
         "lmdb_map_size": 1024 * 1024 * 1024,
     }
 
@@ -243,7 +244,9 @@ class NNEnsembleBackend(backend.AnnifLearningBackend, ensemble.BaseEnsembleBacke
         self._create_model(sources)
         self._fit_model(
             corpus,
-            epochs=int(params["epochs"]),
+            max_epochs=int(params["max-epochs"]),
+            batch_size=int(params["batch-size"]),
+            lr=float(params["lr"]),
             lmdb_map_size=int(params["lmdb_map_size"]),
             n_jobs=jobs,
         )
@@ -294,7 +297,9 @@ class NNEnsembleBackend(backend.AnnifLearningBackend, ensemble.BaseEnsembleBacke
     def _fit_model(
         self,
         corpus: DocumentCorpus,
-        epochs: int,
+        max_epochs: int,
+        batch_size: int,
+        lr: float,
         lmdb_map_size: int,
         n_jobs: int = 1,
     ) -> None:
@@ -311,29 +316,32 @@ class NNEnsembleBackend(backend.AnnifLearningBackend, ensemble.BaseEnsembleBacke
             self.info("Reusing cached training data from previous run.")
 
         # fit the model using a read-only view of the LMDB
-        self.info("Training neural network model...")
+        self.info("Training model...")
         with env.begin(buffers=True) as txn:
             dataset = LMDBDataset(txn)
-            dataloader = DataLoader(dataset, batch_size=32, shuffle=True, num_workers=0)
+            dataloader = DataLoader(
+                dataset, batch_size=batch_size, shuffle=True, num_workers=0
+            )
+            # Evaluation batch, used for early stopping
+            eval_dataloader = DataLoader(
+                dataset, batch_size=512, shuffle=True, num_workers=0
+            )
+            eval_inputs, eval_targets = next(iter(eval_dataloader))
 
             # Training loop
             optimizer = torch.optim.AdamW(
                 self._model.parameters(),
-                lr=float(self.params["lr"]),
-                weight_decay=0.01,
+                lr=lr,
+                weight_decay=0.0,
                 eps=1e-08,
             )
             criterion = nn.BCEWithLogitsLoss()
 
-            for epoch in range(epochs):
+            for epoch in range(max_epochs):
                 self._model.train()
-                total_loss = 0.0
-                total_ndcg = 0.0
-                total_samples = 0
                 tqdm_loader = tqdm(
                     dataloader,
-                    desc=f"Epoch {epoch + 1}/{epochs}",
-                    postfix={"loss": "0.000"},
+                    desc=f"Epoch {epoch + 1}/{max_epochs}",
                 )
                 for inputs, targets in tqdm_loader:
                     optimizer.zero_grad()
@@ -341,26 +349,11 @@ class NNEnsembleBackend(backend.AnnifLearningBackend, ensemble.BaseEnsembleBacke
                     loss = criterion(outputs, targets)
                     loss.backward()
                     optimizer.step()
-
-                    batch_size = outputs.shape[0]
-
-                    batch_ndcg = ndcg_batch(outputs, targets)
-
-                    # Update stats
-                    total_loss += loss.item() * batch_size
-                    total_ndcg += batch_ndcg.item() * batch_size
-                    total_samples += batch_size
-
-                    # Update progress bar with batch loss
-                    tqdm_loader.set_postfix(loss=loss.item())
-
-                epoch_loss = total_loss / total_samples
-                epoch_ndcg = total_ndcg / total_samples
-                print(
-                    f"Epoch {epoch + 1}/{epochs} "
-                    f"- loss: {epoch_loss:.4f} "
-                    f"- nDCG: {epoch_ndcg:.4f}"
-                )
+                # evaluate for early stopping
+                with torch.no_grad():
+                    outputs = self._model(eval_inputs)
+                    ndcg = ndcg_batch(outputs, eval_targets)
+                print(f"Epoch {epoch + 1}/{max_epochs} " f"- nDCG: {ndcg:.4f}")
 
         annif.util.atomic_save(self._model, self.datadir, self.MODEL_FILE)
 
@@ -371,5 +364,9 @@ class NNEnsembleBackend(backend.AnnifLearningBackend, ensemble.BaseEnsembleBacke
     ) -> None:
         self.initialize()
         self._fit_model(
-            corpus, int(params["learn-epochs"]), int(params["lmdb_map_size"])
+            corpus,
+            max_epochs=int(params["learn-epochs"]),
+            batch_size=int(params["batch-size"]),
+            lr=float(params["lr"]),
+            lmdb_map_size=int(params["lmdb_map_size"]),
         )

--- a/annif/backend/nn_ensemble.py
+++ b/annif/backend/nn_ensemble.py
@@ -215,7 +215,7 @@ class NNEnsembleBackend(backend.AnnifLearningBackend, ensemble.BaseEnsembleBacke
             torch.from_numpy(score_vectors.swapaxes(0, 1))
         )
         with torch.no_grad():
-            prediction = self._model(score_vector_tensor)
+            prediction = torch.sigmoid(self._model(score_vector_tensor))
         return SuggestionBatch.from_sequence(
             [
                 vector_to_suggestions(row, limit=int(params["limit"]))
@@ -323,7 +323,7 @@ class NNEnsembleBackend(backend.AnnifLearningBackend, ensemble.BaseEnsembleBacke
                 weight_decay=0.01,
                 eps=1e-08,
             )
-            criterion = nn.BCELoss()
+            criterion = nn.BCEWithLogitsLoss()
 
             for epoch in range(epochs):
                 self._model.train()

--- a/annif/backend/nn_ensemble.py
+++ b/annif/backend/nn_ensemble.py
@@ -77,7 +77,7 @@ class LMDBDataset(Dataset):
         cursor.set_key(idx_to_key(idx))
         value = cursor.value()
         input_csr, target_csr = joblib.load(BytesIO(value))
-        input_tensor = torch.from_numpy(input_csr.toarray())
+        input_tensor = torch.log1p(torch.from_numpy(input_csr.toarray()))
         target_tensor = torch.from_numpy(target_csr.toarray()[0]).float()
         return input_tensor, target_tensor
 
@@ -227,23 +227,20 @@ class NNEnsembleBackend(backend.AnnifLearningBackend, ensemble.BaseEnsembleBacke
         src_weight = dict(sources)
         score_vectors = np.array(
             [
-                [
-                    np.sqrt(suggestions.as_vector())
-                    * src_weight[project_id]
-                    * len(batch_by_source)
-                    for suggestions in batch
-                ]
+                [suggestions.as_vector() for suggestions in batch]
                 for project_id, batch in batch_by_source.items()
             ],
             dtype=np.float32,
         )
-        score_vector_tensor = torch.from_numpy(score_vectors.swapaxes(0, 1))
+        score_vector_tensor = torch.log1p(
+            torch.from_numpy(score_vectors.swapaxes(0, 1))
+        )
         with torch.no_grad():
             prediction = self._model(score_vector_tensor)
         return SuggestionBatch.from_sequence(
             [
                 vector_to_suggestions(row, limit=int(params["limit"]))
-                for row in prediction
+                for row in prediction.detach().numpy()
             ],
             self.project.subjects,
         )
@@ -311,13 +308,10 @@ class NNEnsembleBackend(backend.AnnifLearningBackend, ensemble.BaseEnsembleBacke
             for hits, subject_set in pool.imap_unordered(
                 psmap.suggest, corpus.documents
             ):
-                doc_scores = []
-                for project_id, p_hits in hits.items():
-                    vector = p_hits.as_vector()
-                    doc_scores.append(
-                        np.sqrt(vector) * sources[project_id] * len(sources)
-                    )
-                score_vector = np.array(doc_scores, dtype=np.float32)
+                score_vector = np.array(
+                    [p_hits.as_vector() for project_id, p_hits in hits.items()],
+                    dtype=np.float32,
+                )
                 true_vector = subject_set.as_vector(len(self.project.subjects))
                 seq.add_sample(score_vector, true_vector)
 

--- a/annif/backend/nn_ensemble.py
+++ b/annif/backend/nn_ensemble.py
@@ -227,10 +227,6 @@ class NNEnsembleBackend(backend.AnnifLearningBackend, ensemble.BaseEnsembleBacke
             dropout_rate=dropout_rate,
         )
 
-    #        summary = []
-    #        self._model.summary(print_fn=summary.append)
-    #        self.debug("Created model: \n" + "\n".join(summary))
-
     def _train(
         self,
         corpus: DocumentCorpus,

--- a/annif/backend/nn_ensemble.py
+++ b/annif/backend/nn_ensemble.py
@@ -3,11 +3,9 @@ projects."""
 
 from __future__ import annotations
 
-import importlib
-import json
 import os.path
 import shutil
-import zipfile
+import sys
 from io import BytesIO
 from typing import TYPE_CHECKING, Any
 
@@ -117,8 +115,10 @@ class NNEnsembleModel(nn.Module):
         torch.save(
             {
                 "model_state_dict": self.state_dict(),
-                "model_config": self.model_config,
                 "model_class": self.__class__.__name__,
+                "model_config": self.model_config,
+                "pytorch_version": str(torch.__version__),
+                "python_version": sys.version,
             },
             filepath,
         )
@@ -173,11 +173,9 @@ class NNEnsembleBackend(backend.AnnifLearningBackend, ensemble.BaseEnsembleBacke
         try:
             self._model = NNEnsembleModel.load(model_filename)
         except Exception as err:
-            metadata = self.get_model_metadata(model_filename)
             message = (
                 f"loading model from {model_filename}; "
-                f"model metadata: {metadata}; "
-                f'Original error message: "{err}"'
+                f'original error message: "{err}"'
             )
             raise OperationFailedException(message, backend_id=self.backend_id)
 
@@ -343,16 +341,3 @@ class NNEnsembleBackend(backend.AnnifLearningBackend, ensemble.BaseEnsembleBacke
         self._fit_model(
             corpus, int(params["learn-epochs"]), int(params["lmdb_map_size"])
         )
-
-    def get_model_metadata(self, model_filename: str) -> dict | None:
-        """Read metadata from Keras model files."""
-
-        try:
-            with zipfile.ZipFile(model_filename, "r") as zip:
-                with zip.open("metadata.json") as metadata_file:
-                    metadata_str = metadata_file.read().decode("utf-8")
-                    metadata = json.loads(metadata_str)
-                    return metadata
-        except Exception:
-            self.warning(f"Failed to read metadata from {model_filename}")
-            return None

--- a/annif/backend/nn_ensemble.py
+++ b/annif/backend/nn_ensemble.py
@@ -118,7 +118,8 @@ class NNEnsembleModel(nn.Module):
         x = F.relu(self.hidden(x))
         x = self.dropout2(x)
         delta = self.delta_layer(x)
-        return mean + delta
+        corrected = mean + delta
+        return torch.clamp(corrected, min=0.0, max=1.0)
 
     def save(self, filepath):
         torch.save(
@@ -326,7 +327,7 @@ class NNEnsembleBackend(backend.AnnifLearningBackend, ensemble.BaseEnsembleBacke
                 weight_decay=0,
                 eps=1e-08,
             )
-            criterion = nn.BCEWithLogitsLoss()
+            criterion = nn.BCELoss()
             ndcg_metric = RetrievalNormalizedDCG(top_k=None)
 
             for epoch in range(epochs):

--- a/annif/backend/nn_ensemble.py
+++ b/annif/backend/nn_ensemble.py
@@ -368,7 +368,7 @@ class NNEnsembleBackend(backend.AnnifLearningBackend, ensemble.BaseEnsembleBacke
                     loss.backward()
                     optimizer.step()
 
-                    batch_size, n_labels = outputs.shape
+                    batch_size = outputs.shape[0]
 
                     batch_ndcg = ndcg_batch(outputs, targets)
 

--- a/annif/backend/nn_ensemble.py
+++ b/annif/backend/nn_ensemble.py
@@ -14,7 +14,6 @@ import lmdb
 import numpy as np
 import torch
 import torch.nn as nn
-import torch.nn.functional as F
 from scipy.sparse import csc_matrix, csr_matrix
 from torch.utils.data import DataLoader, Dataset
 from tqdm import tqdm
@@ -355,7 +354,7 @@ class NNEnsembleBackend(backend.AnnifLearningBackend, ensemble.BaseEnsembleBacke
                 with torch.no_grad():
                     outputs = self._model(eval_inputs)
                     ndcg = ndcg_batch(outputs, eval_targets)
-                print(f"Epoch {epoch + 1}/{max_epochs} " f"- nDCG@1000: {ndcg:.4f}")
+                print(f"Epoch {epoch + 1}/{max_epochs} - nDCG@1000: {ndcg:.4f}")
 
         annif.util.atomic_save(self._model, self.datadir, self.MODEL_FILE)
 

--- a/annif/backend/nn_ensemble.py
+++ b/annif/backend/nn_ensemble.py
@@ -162,7 +162,7 @@ class EarlyStopping:
             self.best_epoch = epoch
         else:
             self._no_improvement_count += 1
-            if self._no_improvement_count > self._patience:
+            if self._no_improvement_count >= self._patience:
                 self._stop_early = True
 
         return self._stop_early

--- a/annif/backend/nn_ensemble.py
+++ b/annif/backend/nn_ensemble.py
@@ -17,6 +17,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 from scipy.sparse import csc_matrix, csr_matrix
 from torch.utils.data import DataLoader, Dataset
+from torchmetrics.retrieval import RetrievalNormalizedDCG
 from tqdm import tqdm
 
 import annif.corpus
@@ -321,9 +322,13 @@ class NNEnsembleBackend(backend.AnnifLearningBackend, ensemble.BaseEnsembleBacke
                 self._model.parameters(), lr=float(self.params["lr"])
             )
             criterion = nn.BCEWithLogitsLoss()
+            ndcg_metric = RetrievalNormalizedDCG(top_k=None)
 
             self._model.train()
             for epoch in range(epochs):
+                ndcg_metric.reset()
+                total_loss = 0.0
+                total_samples = 0
                 tqdm_loader = tqdm(
                     dataloader,
                     desc=f"Epoch {epoch + 1}/{epochs}",
@@ -335,8 +340,31 @@ class NNEnsembleBackend(backend.AnnifLearningBackend, ensemble.BaseEnsembleBacke
                     loss = criterion(outputs, targets)
                     loss.backward()
                     optimizer.step()
+
+                    batch_size, n_labels = outputs.shape
+
+                    # Build indexes; each sample is a separate query for nDCG
+                    indexes = torch.repeat_interleave(
+                        torch.arange(batch_size, device=outputs.device), n_labels
+                    )
+                    ndcg_metric.update(
+                        outputs.reshape(-1), targets.reshape(-1), indexes=indexes
+                    )
+
+                    # Update loss stats
+                    total_loss += loss.item() * batch_size
+                    total_samples += batch_size
+
+                    # Update progress bar with batch loss
                     tqdm_loader.set_postfix(loss=loss.item())
-                    tqdm_loader.update()
+
+                epoch_loss = total_loss / total_samples
+                epoch_ndcg = ndcg_metric.compute().item()
+                print(
+                    f"Epoch {epoch + 1}/{epochs} "
+                    f"- loss: {epoch_loss:.4f} "
+                    f"- nDCG: {epoch_ndcg:.4f}"
+                )
 
         annif.util.atomic_save(self._model, self.datadir, self.MODEL_FILE)
 

--- a/annif/backend/nn_ensemble.py
+++ b/annif/backend/nn_ensemble.py
@@ -15,7 +15,7 @@ import lmdb
 import numpy as np
 import torch
 import torch.nn as nn
-from scipy.sparse import csc_matrix, csr_matrix
+from scipy.sparse import csr_matrix
 from torch.utils.data import DataLoader, Dataset
 from tqdm import tqdm
 
@@ -65,7 +65,7 @@ class LMDBDataset(Dataset):
         key = idx_to_key(self._counter)
         self._counter += 1
         # convert the sample into a sparse matrix and serialize it as bytes
-        sample = (csc_matrix(inputs), csr_matrix(targets))
+        sample = (csr_matrix(inputs), csr_matrix(targets))
         buf = BytesIO()
         joblib.dump(sample, buf)
         buf.seek(0)

--- a/annif/backend/nn_ensemble.py
+++ b/annif/backend/nn_ensemble.py
@@ -87,19 +87,17 @@ class LMDBDataset(Dataset):
 
 
 class NNEnsembleModel(nn.Module):
-    def __init__(
-        self,
-        n_sources: int,
-        n_subjects: int,
-    ):
+    def __init__(self, n_sources: int, n_subjects: int, source_weights: list[int]):
         super().__init__()
         self.model_config = {
             "n_sources": n_sources,
             "n_subjects": n_subjects,
+            "source_weights": source_weights,
         }
         # per-concept/source weights
-        init_weights = torch.full((n_sources,), 1.0 / n_sources, dtype=torch.float32)
-        self.weights = nn.Parameter(init_weights[:, None].repeat(1, n_subjects))
+        init_weights = torch.tensor(source_weights, dtype=torch.float32)
+        init_weights = init_weights / init_weights.sum()
+        self.weights = nn.Parameter(init_weights[:, None].expand(-1, n_subjects).contiguous())
         # per-concept bias
         self.bias = nn.Parameter(torch.zeros(n_subjects))
 
@@ -257,7 +255,9 @@ class NNEnsembleBackend(backend.AnnifLearningBackend, ensemble.BaseEnsembleBacke
         # Create PyTorch model
 
         self._model = NNEnsembleModel(
-            n_sources=len(sources), n_subjects=len(self.project.subjects)
+            n_sources=len(sources),
+            n_subjects=len(self.project.subjects),
+            source_weights=[src[1] for src in sources],
         )
 
     def _train(

--- a/annif/backend/nn_ensemble.py
+++ b/annif/backend/nn_ensemble.py
@@ -172,7 +172,7 @@ class EarlyStopping:
 def ndcg_batch(preds: torch.Tensor, targets: torch.Tensor) -> float:
     """
     preds:   (B, N) float
-    targets: (B, N) {0,1}
+    targets: (B, N) binary {0, 1} relevance labels
 
     Returns: mean NDCG across the batch (float)
     """
@@ -402,7 +402,7 @@ class NNEnsembleBackend(backend.AnnifLearningBackend, ensemble.BaseEnsembleBacke
                 # evaluate for early stopping
                 with torch.no_grad():
                     outputs = self._model(eval_inputs)
-                ndcg = ndcg_batch(outputs, eval_targets)
+                ndcg = ndcg_batch(outputs, eval_targets.round())
                 self.info(f"Epoch {epoch + 1}/{max_epochs}: NDCG={ndcg:.4f}")
                 if early_stopping(self._model, ndcg, epoch):
                     best = early_stopping.best_epoch + 1

--- a/annif/backend/nn_ensemble.py
+++ b/annif/backend/nn_ensemble.py
@@ -17,7 +17,6 @@ import torch.nn as nn
 import torch.nn.functional as F
 from scipy.sparse import csc_matrix, csr_matrix
 from torch.utils.data import DataLoader, Dataset
-from torchmetrics.retrieval import RetrievalNormalizedDCG
 from tqdm import tqdm
 
 import annif.corpus
@@ -141,6 +140,33 @@ class NNEnsembleModel(nn.Module):
         model.load_state_dict(checkpoint["model_state_dict"])
         model.eval()
         return model
+
+
+@torch.no_grad()
+def ndcg_batch(preds: torch.Tensor, targets: torch.Tensor):
+    """
+    preds:   (B, N) float
+    targets: (B, N) {0,1}
+
+    Returns: mean nDCG across the batch
+    """
+    B, N = preds.shape
+
+    sorted_idx = torch.argsort(preds, dim=1, descending=True)
+    sorted_targets = torch.gather(targets, 1, sorted_idx)
+
+    L = sorted_targets.size(1)
+    ranks = torch.arange(1, L + 1, device=preds.device)
+    discounts = 1.0 / torch.log2(ranks + 1)
+
+    dcg = (sorted_targets * discounts).sum(dim=1)
+
+    ideal_sorted = torch.sort(targets, dim=1, descending=True)
+    idcg = (ideal_sorted * discounts).sum(dim=1)
+
+    ndcg = dcg / torch.clamp(idcg, min=1e-8)
+
+    return ndcg.mean()
 
 
 class NNEnsembleBackend(backend.AnnifLearningBackend, ensemble.BaseEnsembleBackend):
@@ -328,12 +354,11 @@ class NNEnsembleBackend(backend.AnnifLearningBackend, ensemble.BaseEnsembleBacke
                 eps=1e-08,
             )
             criterion = nn.BCELoss()
-            ndcg_metric = RetrievalNormalizedDCG(top_k=None)
 
             for epoch in range(epochs):
                 self._model.train()
-                ndcg_metric.reset()
                 total_loss = 0.0
+                total_ndcg = 0.0
                 total_samples = 0
                 tqdm_loader = tqdm(
                     dataloader,
@@ -349,23 +374,18 @@ class NNEnsembleBackend(backend.AnnifLearningBackend, ensemble.BaseEnsembleBacke
 
                     batch_size, n_labels = outputs.shape
 
-                    # Build indexes; each sample is a separate query for nDCG
-                    indexes = torch.repeat_interleave(
-                        torch.arange(batch_size, device=outputs.device), n_labels
-                    )
-                    ndcg_metric.update(
-                        outputs.reshape(-1), targets.reshape(-1), indexes=indexes
-                    )
+                    batch_ndcg = ndcg_batch(outputs, targets)
 
-                    # Update loss stats
+                    # Update stats
                     total_loss += loss.item() * batch_size
+                    total_ndcg += batch_ndcg.item() * batch_size
                     total_samples += batch_size
 
                     # Update progress bar with batch loss
                     tqdm_loader.set_postfix(loss=loss.item())
 
                 epoch_loss = total_loss / total_samples
-                epoch_ndcg = ndcg_metric.compute().item()
+                epoch_ndcg = total_ndcg / total_samples
                 print(
                     f"Epoch {epoch + 1}/{epochs} "
                     f"- loss: {epoch_loss:.4f} "

--- a/annif/backend/nn_ensemble.py
+++ b/annif/backend/nn_ensemble.py
@@ -105,8 +105,6 @@ class NNEnsembleModel(nn.Module):
         self.reset_parameters()
 
     def reset_parameters(self):
-        nn.init.xavier_uniform_(self.hidden.weight)
-        nn.init.zeros_(self.hidden.bias)
         nn.init.zeros_(self.delta_layer.weight)
         nn.init.zeros_(self.delta_layer.bias)
 
@@ -161,7 +159,7 @@ def ndcg_batch(preds: torch.Tensor, targets: torch.Tensor):
 
     dcg = (sorted_targets * discounts).sum(dim=1)
 
-    ideal_sorted = torch.sort(targets, dim=1, descending=True)
+    ideal_sorted = torch.sort(targets, dim=1, descending=True).values[:, :L]
     idcg = (ideal_sorted * discounts).sum(dim=1)
 
     ndcg = dcg / torch.clamp(idcg, min=1e-8)

--- a/annif/backend/nn_ensemble.py
+++ b/annif/backend/nn_ensemble.py
@@ -89,42 +89,23 @@ class LMDBDataset(Dataset):
 class NNEnsembleModel(nn.Module):
     def __init__(
         self,
-        source_dim: int,
-        input_dim: int,
-        hidden_dim: int,
-        output_dim: int,
-        dropout_rate: float,
+        n_sources: int,
+        n_subjects: int,
     ):
         super().__init__()
         self.model_config = {
-            "source_dim": source_dim,
-            "input_dim": input_dim,
-            "hidden_dim": hidden_dim,
-            "output_dim": output_dim,
-            "dropout_rate": dropout_rate,
+            "n_sources": n_sources,
+            "n_subjects": n_subjects,
         }
-        self.conv = nn.Conv1d(source_dim, 1, 1, bias=False)
-        self.flatten = nn.Flatten()
-        self.dropout1 = nn.Dropout(dropout_rate)
-        self.hidden = nn.Linear(input_dim * source_dim, hidden_dim)
-        self.dropout2 = nn.Dropout(dropout_rate)
-        self.delta_layer = nn.Linear(hidden_dim, output_dim)
-        self.reset_parameters()
+        # per-concept/source weights
+        init_weights = torch.full((n_sources,), 1.0 / n_sources, dtype=torch.float32)
+        self.weights = nn.Parameter(init_weights[:, None].repeat(1, n_subjects))
+        # per-concept bias
+        self.bias = nn.Parameter(torch.zeros(n_subjects))
 
-    def reset_parameters(self):
-        self.conv.weight.data.fill_(1 / self.model_config["source_dim"])
-        nn.init.zeros_(self.delta_layer.weight)
-        nn.init.zeros_(self.delta_layer.bias)
-
-    def forward(self, inputs):
-        mean = self.conv(inputs)[:, 0, :]
-        x = self.flatten(inputs)
-        x = self.dropout1(x)
-        x = F.relu(self.hidden(x))
-        x = self.dropout2(x)
-        delta = self.delta_layer(x)
-        corrected = mean + delta
-        return torch.clamp(corrected, min=0.0, max=1.0)
+    def forward(self, inputs: torch.Tensor):
+        weighted = inputs * self.weights.unsqueeze(0)
+        return weighted.sum(1) + self.bias
 
     def save(self, filepath):
         torch.save(
@@ -183,8 +164,6 @@ class NNEnsembleBackend(backend.AnnifLearningBackend, ensemble.BaseEnsembleBacke
     LMDB_FILE = "nn-train.mdb"
 
     DEFAULT_PARAMETERS = {
-        "nodes": 100,
-        "dropout_rate": 0.2,
         "lr": 0.001,
         "epochs": 10,
         "learn-epochs": 1,
@@ -249,18 +228,9 @@ class NNEnsembleBackend(backend.AnnifLearningBackend, ensemble.BaseEnsembleBacke
         self.info("creating NN ensemble model")
 
         # Create PyTorch model
-        source_dim = len(sources)
-        input_dim = len(self.project.subjects)
-        hidden_dim = int(self.params["nodes"])
-        output_dim = len(self.project.subjects)
-        dropout_rate = float(self.params["dropout_rate"])
 
         self._model = NNEnsembleModel(
-            source_dim=source_dim,
-            input_dim=input_dim,
-            hidden_dim=hidden_dim,
-            output_dim=output_dim,
-            dropout_rate=dropout_rate,
+            n_sources=len(sources), n_subjects=len(self.project.subjects)
         )
 
     def _train(

--- a/annif/backend/nn_ensemble.py
+++ b/annif/backend/nn_ensemble.py
@@ -148,8 +148,6 @@ def ndcg_batch(preds: torch.Tensor, targets: torch.Tensor):
 
     Returns: mean nDCG across the batch
     """
-    B, N = preds.shape
-
     sorted_idx = torch.argsort(preds, dim=1, descending=True)
     sorted_targets = torch.gather(targets, 1, sorted_idx)
 

--- a/annif/backend/nn_ensemble.py
+++ b/annif/backend/nn_ensemble.py
@@ -187,6 +187,9 @@ class NNEnsembleBackend(backend.AnnifLearningBackend, ensemble.BaseEnsembleBacke
     MODEL_FILE = "nn-model.pt"
     LMDB_FILE = "nn-train.mdb"
 
+    EVAL_BATCH_SIZE = 512
+    EARLY_STOPPING_PATIENCE = 2
+
     DEFAULT_PARAMETERS = {
         "lr": 0.003,
         "max-epochs": 20,
@@ -347,7 +350,7 @@ class NNEnsembleBackend(backend.AnnifLearningBackend, ensemble.BaseEnsembleBacke
             )
             # Evaluation batch, used for early stopping
             eval_dataloader = DataLoader(
-                dataset, batch_size=512, shuffle=True, num_workers=0
+                dataset, batch_size=self.EVAL_BATCH_SIZE, shuffle=True, num_workers=0
             )
             eval_inputs, eval_targets = next(iter(eval_dataloader))
 
@@ -359,7 +362,7 @@ class NNEnsembleBackend(backend.AnnifLearningBackend, ensemble.BaseEnsembleBacke
                 eps=1e-08,
             )
             criterion = nn.BCEWithLogitsLoss()
-            early_stopping = EarlyStopping(patience=2)
+            early_stopping = EarlyStopping(patience=self.EARLY_STOPPING_PATIENCE)
 
             for epoch in range(max_epochs):
                 self._model.train()

--- a/annif/backend/nn_ensemble.py
+++ b/annif/backend/nn_ensemble.py
@@ -100,12 +100,13 @@ class NNEnsembleModel(nn.Module):
         self.weights = nn.Parameter(
             init_weights[:, None].expand(-1, n_subjects).contiguous()
         )
-        # per-concept bias
-        self.bias = nn.Parameter(torch.zeros(n_subjects))
+        # bias decomposition: global + per-label delta
+        self.bias_global = nn.Parameter(torch.tensor(0.0, dtype=torch.float32))
+        self.bias_delta = nn.Parameter(torch.zeros(n_subjects, dtype=torch.float32))
 
     def forward(self, inputs: torch.Tensor):
         weighted = inputs * self.weights.unsqueeze(0)
-        return weighted.sum(1) + self.bias
+        return weighted.sum(1) + self.bias_global + self.bias_delta
 
     def save(self, filepath):
         torch.save(

--- a/annif/backend/nn_ensemble.py
+++ b/annif/backend/nn_ensemble.py
@@ -71,7 +71,7 @@ class LMDBDataset(Dataset):
         buf.seek(0)
         self._txn.put(key, buf.read())
 
-    def __getitem__(self, idx: int) -> tuple[np.ndarray, np.ndarray]:
+    def __getitem__(self, idx: int) -> tuple[torch.Tensor, torch.Tensor]:
         """get a particular sample"""
         cursor = self._txn.cursor()
         cursor.set_key(idx_to_key(idx))
@@ -81,10 +81,11 @@ class LMDBDataset(Dataset):
         target_tensor = torch.log1p(torch.from_numpy(target_csr.toarray()[0]).float())
         return input_tensor, target_tensor
 
-    def get_subset(self, indices: list[int]) -> tuple[np.ndarray, np.ndarray]:
+    def get_subset(self, indices: list[int]) -> tuple[torch.Tensor, torch.Tensor]:
         """Fetch a fixed set of samples by index and stack into batch tensors.
 
-        Returns (inputs, targets) where inputs is (B, M, N) and targets is (B, N).
+        Returns (inputs, targets) where inputs is ``torch.Tensor`` of shape (B, M, N)
+        and targets is ``torch.Tensor`` of shape (B, N).
         """
         inputs_list, targets_list = [], []
         for idx in indices:

--- a/annif/backend/nn_ensemble.py
+++ b/annif/backend/nn_ensemble.py
@@ -12,14 +12,13 @@ from io import BytesIO
 from typing import TYPE_CHECKING, Any
 
 import joblib
-import keras
 import lmdb
 import numpy as np
-from keras.layers import Add, Dense, Dropout, Flatten, Input, Layer
-from keras.models import Model
-from keras.saving import load_model
-from keras.utils import Sequence
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
 from scipy.sparse import csc_matrix, csr_matrix
+from torch.utils.data import DataLoader, Dataset
 
 import annif.corpus
 import annif.parallel
@@ -34,8 +33,6 @@ from annif.suggestion import SuggestionBatch, vector_to_suggestions
 from . import backend, ensemble
 
 if TYPE_CHECKING:
-    from tensorflow.python.framework.ops import EagerTensor
-
     from annif.corpus.document import DocumentCorpus
 
 logger = annif.logger
@@ -51,10 +48,10 @@ def key_to_idx(key: memoryview | bytes) -> int:
     return int(key)
 
 
-class LMDBSequence(Sequence):
+class LMDBDataset(Dataset):
     """A sequence of samples stored in a LMDB database."""
 
-    def __init__(self, txn, batch_size):
+    def __init__(self, txn):
         super().__init__()
         self._txn = txn
         cursor = txn.cursor()
@@ -63,7 +60,6 @@ class LMDBSequence(Sequence):
             self._counter = key_to_idx(cursor.key()) + 1
         else:  # empty database
             self._counter = 0
-        self._batch_size = batch_size
 
     def add_sample(self, inputs: np.ndarray, targets: np.ndarray) -> None:
         # use zero-padded 8-digit key
@@ -77,30 +73,64 @@ class LMDBSequence(Sequence):
         self._txn.put(key, buf.read())
 
     def __getitem__(self, idx: int) -> tuple[np.ndarray, np.ndarray]:
-        """get a particular batch of samples"""
+        """get a particular sample"""
         cursor = self._txn.cursor()
-        first_key = idx * self._batch_size
-        cursor.set_key(idx_to_key(first_key))
-        input_arrays = []
-        target_arrays = []
-        for key, value in cursor.iternext():
-            if key_to_idx(key) >= (first_key + self._batch_size):
-                break
-            input_csr, target_csr = joblib.load(BytesIO(value))
-            input_arrays.append(input_csr.toarray())
-            target_arrays.append(target_csr.toarray().flatten())
-        return np.array(input_arrays), np.array(target_arrays)
+        cursor.set_key(idx_to_key(idx))
+        value = cursor.value()
+        input_csr, target_csr = joblib.load(BytesIO(value))
+        input_tensor = torch.from_numpy(input_csr.toarray())
+        target_tensor = torch.from_numpy(target_csr.toarray()[0]).float()
+        return input_tensor, target_tensor
 
     def __len__(self) -> int:
-        """return the number of available batches"""
-        return int(np.ceil(self._counter / self._batch_size))
+        """return the number of available samples"""
+        return self._counter
 
 
-class MeanLayer(Layer):
-    """Custom Keras layer that calculates mean values along the 2nd axis."""
+class NNEnsembleModel(nn.Module):
+    def __init__(
+        self, input_dim: int, hidden_dim: int, output_dim: int, dropout_rate: float
+    ):
+        super().__init__()
+        self.model_config = {
+            "input_dim": input_dim,
+            "hidden_dim": hidden_dim,
+            "output_dim": output_dim,
+            "dropout_rate": dropout_rate,
+        }
+        self.flatten = nn.Flatten()
+        self.dropout1 = nn.Dropout(dropout_rate)
+        self.hidden = nn.Linear(input_dim, hidden_dim)
+        self.dropout2 = nn.Dropout(dropout_rate)
+        self.delta_layer = nn.Linear(hidden_dim, output_dim)
 
-    def call(self, inputs: EagerTensor) -> EagerTensor:
-        return keras.ops.mean(inputs, axis=2)
+    def forward(self, inputs):
+        mean = torch.mean(inputs, dim=1)
+        x = self.flatten(inputs)
+        x = self.dropout1(x)
+        x = F.relu(self.hidden(x))
+        x = self.dropout2(x)
+        delta = self.delta_layer(x)
+        return mean + delta
+
+    def save(self, filepath):
+        torch.save(
+            {
+                "model_state_dict": self.state_dict(),
+                "model_config": self.model_config,
+                "model_class": self.__class__.__name__,
+            },
+            filepath,
+        )
+
+    @classmethod
+    def load(cls, filepath, map_location="cpu"):
+        checkpoint = torch.load(filepath, map_location=map_location, weights_only=True)
+        config = checkpoint["model_config"]
+        model = cls(**config)
+        model.load_state_dict(checkpoint["model_state_dict"])
+        model.eval()
+        return model
 
 
 class NNEnsembleBackend(backend.AnnifLearningBackend, ensemble.BaseEnsembleBackend):
@@ -109,13 +139,14 @@ class NNEnsembleBackend(backend.AnnifLearningBackend, ensemble.BaseEnsembleBacke
 
     name = "nn_ensemble"
 
-    MODEL_FILE = "nn-model.keras"
+    MODEL_FILE = "nn-model.pt"
     LMDB_FILE = "nn-train.mdb"
 
     DEFAULT_PARAMETERS = {
         "nodes": 100,
         "dropout_rate": 0.2,
         "optimizer": "adam",
+        "lr": 0.001,
         "epochs": 10,
         "learn-epochs": 1,
         "lmdb_map_size": 1024 * 1024 * 1024,
@@ -129,7 +160,7 @@ class NNEnsembleBackend(backend.AnnifLearningBackend, ensemble.BaseEnsembleBacke
         if self._model is not None:
             return  # already initialized
         if parallel:
-            # Don't load TF model just before parallel execution,
+            # Don't load model just before parallel execution,
             # since it won't work after forking worker processes
             return
         model_filename = os.path.join(self.datadir, self.MODEL_FILE)
@@ -138,18 +169,14 @@ class NNEnsembleBackend(backend.AnnifLearningBackend, ensemble.BaseEnsembleBacke
                 "model file {} not found".format(model_filename),
                 backend_id=self.backend_id,
             )
-        self.debug("loading Keras model from {}".format(model_filename))
+        self.debug("loading model from {}".format(model_filename))
         try:
-            self._model = load_model(
-                model_filename, custom_objects={"MeanLayer": MeanLayer}
-            )
+            self._model = NNEnsembleModel.load(model_filename)
         except Exception as err:
             metadata = self.get_model_metadata(model_filename)
-            keras_version = importlib.metadata.version("keras")
             message = (
-                f"loading Keras model from {model_filename}; "
+                f"loading model from {model_filename}; "
                 f"model metadata: {metadata}; "
-                f"you have Keras version {keras_version}. "
                 f'Original error message: "{err}"'
             )
             raise OperationFailedException(message, backend_id=self.backend_id)
@@ -172,8 +199,10 @@ class NNEnsembleBackend(backend.AnnifLearningBackend, ensemble.BaseEnsembleBacke
                 for project_id, batch in batch_by_source.items()
             ],
             dtype=np.float32,
-        ).transpose(1, 2, 0)
-        prediction = self._model(score_vectors).numpy()
+        )
+        score_vector_tensor = torch.from_numpy(score_vectors.swapaxes(0, 1))
+        with torch.no_grad():
+            prediction = self._model(score_vector_tensor)
         return SuggestionBatch.from_sequence(
             [
                 vector_to_suggestions(row, limit=int(params["limit"]))
@@ -185,34 +214,22 @@ class NNEnsembleBackend(backend.AnnifLearningBackend, ensemble.BaseEnsembleBacke
     def _create_model(self, sources: list[tuple[str, float]]) -> None:
         self.info("creating NN ensemble model")
 
-        inputs = Input(shape=(len(self.project.subjects), len(sources)))
+        # Create PyTorch model
+        input_dim = len(self.project.subjects) * len(sources)
+        hidden_dim = int(self.params["nodes"])
+        output_dim = len(self.project.subjects)
+        dropout_rate = float(self.params["dropout_rate"])
 
-        flat_input = Flatten()(inputs)
-        drop_input = Dropout(rate=float(self.params["dropout_rate"]))(flat_input)
-        hidden = Dense(int(self.params["nodes"]), activation="relu")(drop_input)
-        drop_hidden = Dropout(rate=float(self.params["dropout_rate"]))(hidden)
-        delta = Dense(
-            len(self.project.subjects),
-            kernel_initializer="zeros",
-            bias_initializer="zeros",
-        )(drop_hidden)
-
-        mean = MeanLayer()(inputs)
-
-        predictions = Add()([mean, delta])
-
-        self._model = Model(inputs=inputs, outputs=predictions)
-        self._model.compile(
-            optimizer=self.params["optimizer"],
-            loss="binary_crossentropy",
-            metrics=["top_k_categorical_accuracy"],
+        self._model = NNEnsembleModel(
+            input_dim=input_dim,
+            hidden_dim=hidden_dim,
+            output_dim=output_dim,
+            dropout_rate=dropout_rate,
         )
-        if "lr" in self.params:
-            self._model.optimizer.learning_rate.assign(float(self.params["lr"]))
 
-        summary = []
-        self._model.summary(print_fn=summary.append)
-        self.debug("Created model: \n" + "\n".join(summary))
+    #        summary = []
+    #        self._model.summary(print_fn=summary.append)
+    #        self.debug("Created model: \n" + "\n".join(summary))
 
     def _train(
         self,
@@ -232,7 +249,7 @@ class NNEnsembleBackend(backend.AnnifLearningBackend, ensemble.BaseEnsembleBacke
     def _corpus_to_vectors(
         self,
         corpus: DocumentCorpus,
-        seq: LMDBSequence,
+        seq: LMDBDataset,
         n_jobs: int,
     ) -> None:
         # pass corpus through all source projects
@@ -265,7 +282,7 @@ class NNEnsembleBackend(backend.AnnifLearningBackend, ensemble.BaseEnsembleBacke
                     doc_scores.append(
                         np.sqrt(vector) * sources[project_id] * len(sources)
                     )
-                score_vector = np.array(doc_scores, dtype=np.float32).transpose()
+                score_vector = np.array(doc_scores, dtype=np.float32)
                 true_vector = subject_set.as_vector(len(self.project.subjects))
                 seq.add_sample(score_vector, true_vector)
 
@@ -289,15 +306,31 @@ class NNEnsembleBackend(backend.AnnifLearningBackend, ensemble.BaseEnsembleBacke
                     "Cannot train nn_ensemble project with no documents"
                 )
             with env.begin(write=True, buffers=True) as txn:
-                seq = LMDBSequence(txn, batch_size=32)
+                seq = LMDBDataset(txn)
                 self._corpus_to_vectors(corpus, seq, n_jobs)
         else:
             self.info("Reusing cached training data from previous run.")
+
         # fit the model using a read-only view of the LMDB
         self.info("Training neural network model...")
         with env.begin(buffers=True) as txn:
-            seq = LMDBSequence(txn, batch_size=32)
-            self._model.fit(seq, verbose=True, epochs=epochs)
+            dataset = LMDBDataset(txn)
+            dataloader = DataLoader(dataset, batch_size=32, shuffle=True)
+
+            # Training loop
+            optimizer = torch.optim.Adam(
+                self._model.parameters(), lr=float(self.params["lr"])
+            )
+            criterion = nn.BCEWithLogitsLoss()
+
+            self._model.train()
+            for epoch in range(epochs):
+                for inputs, targets in dataloader:
+                    optimizer.zero_grad()
+                    outputs = self._model(inputs)
+                    loss = criterion(outputs, targets)
+                    loss.backward()
+                    optimizer.step()
 
         annif.util.atomic_save(self._model, self.datadir, self.MODEL_FILE)
 

--- a/annif/backend/nn_ensemble.py
+++ b/annif/backend/nn_ensemble.py
@@ -202,7 +202,6 @@ class NNEnsembleBackend(backend.AnnifLearningBackend, ensemble.BaseEnsembleBacke
     MODEL_FILE = "nn-model.pt"
     LMDB_FILE = "nn-train.mdb"
 
-    EVAL_BATCH_SIZE = 512
     EARLY_STOPPING_PATIENCE = 2
     EARLY_STOP_EVAL_ROWS = 512
     EARLY_STOP_SEED = 1337

--- a/annif/backend/nn_ensemble.py
+++ b/annif/backend/nn_ensemble.py
@@ -190,7 +190,7 @@ class NNEnsembleBackend(backend.AnnifLearningBackend, ensemble.BaseEnsembleBacke
 
     DEFAULT_PARAMETERS = {
         "lr": 0.003,
-        "max-epochs": 20,
+        "max-epochs": 50,
         "learn-epochs": 1,
         "batch-size": 256,
         "lmdb_map_size": 1024 * 1024 * 1024,

--- a/annif/backend/nn_ensemble.py
+++ b/annif/backend/nn_ensemble.py
@@ -3,6 +3,7 @@ projects."""
 
 from __future__ import annotations
 
+import copy
 import os.path
 import shutil
 import sys
@@ -126,6 +127,27 @@ class NNEnsembleModel(nn.Module):
         model.load_state_dict(checkpoint["model_state_dict"])
         model.eval()
         return model
+
+
+class EarlyStopping:
+    def __init__(self, patience: int):
+        self._patience = patience
+        self._best_metric = None
+        self._no_improvement_count = 0
+        self._stop_early = False
+        self.best_state = None
+
+    def __call__(self, model, metric):
+        if self._best_metric is None or metric > self._best_metric:
+            self._best_metric = metric
+            self._no_improvement_count = 0
+            self.best_state = copy.deepcopy(model.state_dict())
+        else:
+            self._no_improvement_count += 1
+            if self._no_improvement_count > self._patience:
+                self._stop_early = True
+
+        return self._stop_early
 
 
 @torch.no_grad()
@@ -337,6 +359,7 @@ class NNEnsembleBackend(backend.AnnifLearningBackend, ensemble.BaseEnsembleBacke
                 eps=1e-08,
             )
             criterion = nn.BCEWithLogitsLoss()
+            early_stopping = EarlyStopping(patience=2)
 
             for epoch in range(max_epochs):
                 self._model.train()
@@ -355,6 +378,12 @@ class NNEnsembleBackend(backend.AnnifLearningBackend, ensemble.BaseEnsembleBacke
                     outputs = self._model(eval_inputs)
                     ndcg = ndcg_batch(outputs, eval_targets)
                 print(f"Epoch {epoch + 1}/{max_epochs} - nDCG@1000: {ndcg:.4f}")
+                if early_stopping(self._model, ndcg):
+                    print("Model no longer improving, stopping training.")
+                    break
+
+            # Restore best model weights
+            self._model.load_state_dict(early_stopping.best_state)
 
         annif.util.atomic_save(self._model, self.datadir, self.MODEL_FILE)
 

--- a/annif/backend/nn_ensemble.py
+++ b/annif/backend/nn_ensemble.py
@@ -81,6 +81,20 @@ class LMDBDataset(Dataset):
         target_tensor = torch.log1p(torch.from_numpy(target_csr.toarray()[0]).float())
         return input_tensor, target_tensor
 
+    def get_subset(self, indices: list[int]) -> tuple[np.ndarray, np.ndarray]:
+        """Fetch a fixed set of samples by index and stack into batch tensors.
+
+        Returns (inputs, targets) where inputs is (B, M, N) and targets is (B, N).
+        """
+        inputs_list, targets_list = [], []
+        for idx in indices:
+            inp, tgt = self[idx]
+            inputs_list.append(inp)
+            targets_list.append(tgt)
+        inputs = torch.stack(inputs_list, dim=0)
+        targets = torch.stack(targets_list, dim=0)
+        return inputs, targets
+
     def __len__(self) -> int:
         """return the number of available samples"""
         return self._counter
@@ -189,6 +203,8 @@ class NNEnsembleBackend(backend.AnnifLearningBackend, ensemble.BaseEnsembleBacke
 
     EVAL_BATCH_SIZE = 512
     EARLY_STOPPING_PATIENCE = 2
+    EARLY_STOP_EVAL_ROWS = 512
+    EARLY_STOP_SEED = 1337
     PRED_SCALE = 20
 
     DEFAULT_PARAMETERS = {
@@ -353,11 +369,12 @@ class NNEnsembleBackend(backend.AnnifLearningBackend, ensemble.BaseEnsembleBacke
             dataloader = DataLoader(
                 dataset, batch_size=batch_size, shuffle=True, num_workers=0
             )
-            # Evaluation batch, used for early stopping
-            eval_dataloader = DataLoader(
-                dataset, batch_size=self.EVAL_BATCH_SIZE, shuffle=True, num_workers=0
-            )
-            eval_inputs, eval_targets = next(iter(eval_dataloader))
+            # Deterministic eval subset for early stopping
+            rng = np.random.default_rng(self.EARLY_STOP_SEED)
+            n_samples = len(dataset)
+            n_eval = min(self.EARLY_STOP_EVAL_ROWS, n_samples)
+            eval_indices = rng.choice(n_samples, size=n_eval, replace=False)
+            eval_inputs, eval_targets = dataset.get_subset(eval_indices.tolist())
 
             # Training loop
             optimizer = torch.optim.AdamW(

--- a/annif/backend/nn_ensemble.py
+++ b/annif/backend/nn_ensemble.py
@@ -168,12 +168,12 @@ class EarlyStopping:
 
 
 @torch.no_grad()
-def ndcg_batch(preds: torch.Tensor, targets: torch.Tensor):
+def ndcg_batch(preds: torch.Tensor, targets: torch.Tensor) -> float:
     """
     preds:   (B, N) float
     targets: (B, N) {0,1}
 
-    Returns: mean NDCG across the batch
+    Returns: mean NDCG across the batch (float)
     """
     sorted_idx = torch.argsort(preds, dim=1, descending=True)
     sorted_targets = torch.gather(targets, 1, sorted_idx)
@@ -189,7 +189,7 @@ def ndcg_batch(preds: torch.Tensor, targets: torch.Tensor):
 
     ndcg = dcg / torch.clamp(idcg, min=1e-8)
 
-    return ndcg.mean()
+    return ndcg.mean().item()
 
 
 class NNEnsembleBackend(backend.AnnifLearningBackend, ensemble.BaseEnsembleBackend):

--- a/annif/backend/nn_ensemble.py
+++ b/annif/backend/nn_ensemble.py
@@ -345,10 +345,10 @@ class NNEnsembleBackend(backend.AnnifLearningBackend, ensemble.BaseEnsembleBacke
             dataloader = DataLoader(dataset, batch_size=32, shuffle=True, num_workers=0)
 
             # Training loop
-            optimizer = torch.optim.Adam(
+            optimizer = torch.optim.AdamW(
                 self._model.parameters(),
                 lr=float(self.params["lr"]),
-                weight_decay=0,
+                weight_decay=0.01,
                 eps=1e-08,
             )
             criterion = nn.BCELoss()

--- a/annif/backend/nn_ensemble.py
+++ b/annif/backend/nn_ensemble.py
@@ -315,11 +315,11 @@ class NNEnsembleBackend(backend.AnnifLearningBackend, ensemble.BaseEnsembleBacke
         self.info("Training neural network model...")
         with env.begin(buffers=True) as txn:
             dataset = LMDBDataset(txn)
-            dataloader = DataLoader(dataset, batch_size=32, shuffle=True)
+            dataloader = DataLoader(dataset, batch_size=32, shuffle=True, num_workers=0)
 
             # Training loop
             optimizer = torch.optim.Adam(
-                self._model.parameters(), lr=float(self.params["lr"])
+                self._model.parameters(), lr=float(self.params["lr"]), weight_decay=0
             )
             criterion = nn.BCEWithLogitsLoss()
             ndcg_metric = RetrievalNormalizedDCG(top_k=None)

--- a/annif/backend/nn_ensemble.py
+++ b/annif/backend/nn_ensemble.py
@@ -130,24 +130,27 @@ class NNEnsembleModel(nn.Module):
 
 
 @torch.no_grad()
-def ndcg_batch(preds: torch.Tensor, targets: torch.Tensor):
+def ndcg_batch(preds: torch.Tensor, targets: torch.Tensor, k: int = 1000):
     """
     preds:   (B, N) float
     targets: (B, N) {0,1}
+    k:       int, cutoff for nDCG@k
 
-    Returns: mean nDCG across the batch
+    Returns: mean nDCG@K across the batch
     """
     sorted_idx = torch.argsort(preds, dim=1, descending=True)
     sorted_targets = torch.gather(targets, 1, sorted_idx)
+    sorted_targets_k = sorted_targets[:, :k]
 
-    L = sorted_targets.size(1)
+    L = min(k, sorted_targets.size(1))
     ranks = torch.arange(1, L + 1, device=preds.device)
     discounts = 1.0 / torch.log2(ranks + 1)
 
-    dcg = (sorted_targets * discounts).sum(dim=1)
+    dcg = (sorted_targets_k * discounts).sum(dim=1)
 
-    ideal_sorted = torch.sort(targets, dim=1, descending=True).values[:, :L]
-    idcg = (ideal_sorted * discounts).sum(dim=1)
+    ideal_sorted = torch.sort(targets, dim=1, descending=True).values
+    ideal_sorted_k = ideal_sorted[:, :k]
+    idcg = (ideal_sorted_k * discounts).sum(dim=1)
 
     ndcg = dcg / torch.clamp(idcg, min=1e-8)
 
@@ -204,7 +207,6 @@ class NNEnsembleBackend(backend.AnnifLearningBackend, ensemble.BaseEnsembleBacke
         sources: list[tuple[str, float]],
         params: dict[str, Any],
     ) -> SuggestionBatch:
-        src_weight = dict(sources)
         score_vectors = np.array(
             [
                 [suggestions.as_vector() for suggestions in batch]
@@ -353,7 +355,7 @@ class NNEnsembleBackend(backend.AnnifLearningBackend, ensemble.BaseEnsembleBacke
                 with torch.no_grad():
                     outputs = self._model(eval_inputs)
                     ndcg = ndcg_batch(outputs, eval_targets)
-                print(f"Epoch {epoch + 1}/{max_epochs} " f"- nDCG: {ndcg:.4f}")
+                print(f"Epoch {epoch + 1}/{max_epochs} " f"- nDCG@1000: {ndcg:.4f}")
 
         annif.util.atomic_save(self._model, self.datadir, self.MODEL_FILE)
 

--- a/annif/backend/nn_ensemble.py
+++ b/annif/backend/nn_ensemble.py
@@ -78,7 +78,7 @@ class LMDBDataset(Dataset):
         value = cursor.value()
         input_csr, target_csr = joblib.load(BytesIO(value))
         input_tensor = torch.log1p(torch.from_numpy(input_csr.toarray()))
-        target_tensor = torch.from_numpy(target_csr.toarray()[0]).float()
+        target_tensor = torch.log1p(torch.from_numpy(target_csr.toarray()[0]).float())
         return input_tensor, target_tensor
 
     def __len__(self) -> int:

--- a/annif/backend/nn_ensemble.py
+++ b/annif/backend/nn_ensemble.py
@@ -17,6 +17,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 from scipy.sparse import csc_matrix, csr_matrix
 from torch.utils.data import DataLoader, Dataset
+from tqdm import tqdm
 
 import annif.corpus
 import annif.parallel
@@ -323,12 +324,19 @@ class NNEnsembleBackend(backend.AnnifLearningBackend, ensemble.BaseEnsembleBacke
 
             self._model.train()
             for epoch in range(epochs):
-                for inputs, targets in dataloader:
+                tqdm_loader = tqdm(
+                    dataloader,
+                    desc=f"Epoch {epoch + 1}/{epochs}",
+                    postfix={"loss": "0.000"},
+                )
+                for inputs, targets in tqdm_loader:
                     optimizer.zero_grad()
                     outputs = self._model(inputs)
                     loss = criterion(outputs, targets)
                     loss.backward()
                     optimizer.step()
+                    tqdm_loader.set_postfix(loss=loss.item())
+                    tqdm_loader.update()
 
         annif.util.atomic_save(self._model, self.datadir, self.MODEL_FILE)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,11 +49,13 @@ dependencies = [
 fasttext = ["fasttext-numpy2==0.10.4"]
 estnltk = ["estnltk==1.7.4"]
 nn = [
-    "torch~=2.10.0",
-    "lmdb~=1.7.3",
+    "torch~=2.12.0",
+    "tqdm~=4.67.3",
+    "lmdb~=2.2.0",
 ]
 torch-cpu = ["torch"]
-torch-cu128 = ["torch"]
+torch-cu126 = ["torch"]
+torch-cu130 = ["torch"]
 omikuji = ["omikuji==0.5.*"]
 spacy = [
     "spacy~=3.8.4",
@@ -99,14 +101,16 @@ addopts = "-m 'not slow'"
 conflicts = [
   [
     { extra = "torch-cpu" },
-    { extra = "torch-cu128" },
+    { extra = "torch-cu126" },
+    { extra = "torch-cu130" },
   ],
 ]
 
 [tool.uv.sources]
 torch = [
   { index = "pytorch-cpu",    extra = "torch-cpu" },
-  { index = "pytorch-cu128",  extra = "torch-cu128" },
+  { index = "pytorch-cu126",  extra = "torch-cu126" },
+  { index = "pytorch-cu130",  extra = "torch-cu130" },
 ]
 
 [[tool.uv.index]]
@@ -115,8 +119,13 @@ url = "https://download.pytorch.org/whl/cpu"
 explicit = true
 
 [[tool.uv.index]]
-name = "pytorch-cu128"
-url = "https://download.pytorch.org/whl/cu128"
+name = "pytorch-cu126"
+url = "https://download.pytorch.org/whl/cu126"
+explicit = true
+
+[[tool.uv.index]]
+name = "pytorch-cu130"
+url = "https://download.pytorch.org/whl/cu130"
 explicit = true
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,6 @@ fasttext = ["fasttext-numpy2==0.10.4"]
 estnltk = ["estnltk==1.7.4"]
 nn = [
     "torch~=2.9.1",
-    "torchmetrics~=1.8.2",
     "lmdb~=1.7.3",
 ]
 torch-cpu = ["torch"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,7 @@ dev = [
     "isort",
     "schemathesis==3.*",
 ]
+all = ["annif[fasttext,estnltk,nn,torch-cpu,omikuji,spacy,stwfsa,voikko,yake]"]
 
 [tool.isort]
 profile = "black"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,7 @@ dev = [
     "isort",
     "schemathesis==3.*",
 ]
-all = ["annif[fasttext,estnltk,nn,torch-cpu,omikuji,spacy,stwfsa,voikko,yake]"]
+all = ["annif[fasttext,estnltk,nn,omikuji,spacy,stwfsa,voikko,yake]"]
 
 [tool.isort]
 profile = "black"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ fasttext = ["fasttext-numpy2==0.10.4"]
 estnltk = ["estnltk==1.7.4"]
 nn = [
     "torch~=2.9.1",
+    "torchmetrics~=1.8.2",
     "lmdb~=1.7.3",
 ]
 torch-cpu = ["torch"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ dependencies = [
 fasttext = ["fasttext-numpy2==0.10.4"]
 estnltk = ["estnltk==1.7.4"]
 nn = [
-    "tensorflow-cpu~=2.20.0",
+    "torch~=2.9.1",
     "lmdb~=1.7.3",
 ]
 omikuji = ["omikuji==0.5.*"]
@@ -91,6 +91,16 @@ skip_gitignore = true
 [tool.pytest.ini_options]
 markers = ["slow: marks tests as slow (deselect with '-m \"not slow\"')"]
 addopts = "-m 'not slow'"
+
+[tool.uv.sources]
+torch = [
+    { index = "pytorch-cpu" },
+]
+
+[[tool.uv.index]]
+name = "pytorch-cpu"
+url = "https://download.pytorch.org/whl/cpu"
+explicit = true
 
 [build-system]
 requires = ["hatchling"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ dependencies = [
 fasttext = ["fasttext-numpy2==0.10.4"]
 estnltk = ["estnltk==1.7.4"]
 nn = [
-    "torch~=2.9.1",
+    "torch~=2.10.0",
     "lmdb~=1.7.3",
 ]
 torch-cpu = ["torch"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,8 @@ nn = [
     "torch~=2.9.1",
     "lmdb~=1.7.3",
 ]
+torch-cpu = ["torch"]
+torch-cu128 = ["torch"]
 omikuji = ["omikuji==0.5.*"]
 spacy = [
     "spacy~=3.8.4",
@@ -92,14 +94,28 @@ skip_gitignore = true
 markers = ["slow: marks tests as slow (deselect with '-m \"not slow\"')"]
 addopts = "-m 'not slow'"
 
+[tool.uv]
+conflicts = [
+  [
+    { extra = "torch-cpu" },
+    { extra = "torch-cu128" },
+  ],
+]
+
 [tool.uv.sources]
 torch = [
-    { index = "pytorch-cpu" },
+  { index = "pytorch-cpu",    extra = "torch-cpu" },
+  { index = "pytorch-cu128",  extra = "torch-cu128" },
 ]
 
 [[tool.uv.index]]
 name = "pytorch-cpu"
 url = "https://download.pytorch.org/whl/cpu"
+explicit = true
+
+[[tool.uv.index]]
+name = "pytorch-cu128"
+url = "https://download.pytorch.org/whl/cu128"
 explicit = true
 
 [build-system]

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -66,13 +66,13 @@ def test_get_backend_fasttext_not_installed():
 
 
 @pytest.mark.skipif(
-    importlib.util.find_spec("tensorflow") is not None,
-    reason="test requires that TensorFlow is NOT installed",
+    importlib.util.find_spec("torch") is not None,
+    reason="test requires that PyTorch is NOT installed",
 )
 def test_get_backend_nn_ensemble_not_installed():
     with pytest.raises(ValueError) as excinfo:
         annif.backend.get_backend("nn_ensemble")
-    assert "TensorFlow not available" in str(excinfo.value)
+    assert "PyTorch not available" in str(excinfo.value)
 
 
 @pytest.mark.skipif(

--- a/tests/test_backend_nn_ensemble.py
+++ b/tests/test_backend_nn_ensemble.py
@@ -142,7 +142,6 @@ def test_nn_ensemble_train_cached(registry):
     assert datadir.join("nn-model.pt").size() > 0
 
 
-@pytest.mark.skip
 def test_nn_ensemble_train_and_learn_params(registry, tmpdir, capfd):
     project = registry.get_project("dummy-en")
     nn_ensemble_type = annif.backend.get_backend("nn_ensemble")
@@ -162,13 +161,13 @@ def test_nn_ensemble_train_and_learn_params(registry, tmpdir, capfd):
 
     train_params = {"epochs": 3}
     nn_ensemble.train(document_corpus, train_params)
-    out, _ = capfd.readouterr()
-    assert "Epoch 3/3" in out
+    _, err = capfd.readouterr()
+    assert "Epoch 3/3" in err
 
     learn_params = {"learn-epochs": 2}
     nn_ensemble.learn(document_corpus, learn_params)
-    out, _ = capfd.readouterr()
-    assert "Epoch 2/2" in out
+    _, err = capfd.readouterr()
+    assert "Epoch 2/2" in err
 
 
 def test_nn_ensemble_is_trained(app_project):

--- a/tests/test_backend_nn_ensemble.py
+++ b/tests/test_backend_nn_ensemble.py
@@ -59,18 +59,6 @@ def test_nn_ensemble_is_not_trained(app_project):
     assert not nn_ensemble.is_trained
 
 
-def test_nn_ensemble_can_set_lr(registry):
-    project = registry.get_project("dummy-en")
-    nn_ensemble_type = annif.backend.get_backend("nn_ensemble")
-    nn_ensemble = nn_ensemble_type(
-        backend_id="nn_ensemble",
-        config_params={"epochs": 1, "lr": 0.002},
-        project=project,
-    )
-    nn_ensemble._create_model(["dummy-en"])
-    assert nn_ensemble._model.optimizer.learning_rate.value == 0.002
-
-
 def test_set_lmdb_map_size(registry, tmpdir):
     project = registry.get_project("dummy-en")
     nn_ensemble_type = annif.backend.get_backend("nn_ensemble")
@@ -117,14 +105,11 @@ def test_nn_ensemble_train_and_learn(registry, tmpdir):
         assert datadir.join("nn-train.mdb/data.mdb").exists()
         assert datadir.join("nn-train.mdb/data.mdb").stat().mode & 0o777 == 0o660
 
-    # check adam default learning_rate:
-    assert nn_ensemble._model.optimizer.learning_rate.value == 0.001
-
-    assert datadir.join("nn-model.keras").exists()
-    assert datadir.join("nn-model.keras").size() > 0
+    assert datadir.join("nn-model.pt").exists()
+    assert datadir.join("nn-model.pt").size() > 0
 
     # test online learning
-    modelfile = datadir.join("nn-model.keras")
+    modelfile = datadir.join("nn-model.pt")
 
     old_size = modelfile.size()
     old_mtime = modelfile.mtime()
@@ -144,7 +129,7 @@ def test_nn_ensemble_train_cached(registry):
     datadir = py.path.local(project.datadir)
     assert datadir.join("nn-train.mdb").exists()
 
-    datadir.join("nn-model.keras").remove()
+    datadir.join("nn-model.pt").remove()
 
     nn_ensemble_type = annif.backend.get_backend("nn_ensemble")
     nn_ensemble = nn_ensemble_type(
@@ -155,10 +140,11 @@ def test_nn_ensemble_train_cached(registry):
 
     nn_ensemble.train("cached")
 
-    assert datadir.join("nn-model.keras").exists()
-    assert datadir.join("nn-model.keras").size() > 0
+    assert datadir.join("nn-model.pt").exists()
+    assert datadir.join("nn-model.pt").size() > 0
 
 
+@pytest.mark.skip
 def test_nn_ensemble_train_and_learn_params(registry, tmpdir, capfd):
     project = registry.get_project("dummy-en")
     nn_ensemble_type = annif.backend.get_backend("nn_ensemble")
@@ -207,6 +193,7 @@ def test_nn_ensemble_modification_time(app_project):
     assert datetime.now(timezone.utc) - nn_ensemble.modification_time < timedelta(1)
 
 
+@pytest.mark.skip
 def test_nn_ensemble_get_model_metadata(app_project):
     nn_ensemble_type = annif.backend.get_backend("nn_ensemble")
     nn_ensemble = nn_ensemble_type(
@@ -216,11 +203,11 @@ def test_nn_ensemble_get_model_metadata(app_project):
     )
     model_filename = os.path.join(nn_ensemble.datadir, nn_ensemble.MODEL_FILE)
 
-    expected_version = importlib.metadata.version("keras")
+    expected_version = importlib.metadata.version("torch")
     expected_date_saved = datetime.now(timezone.utc)
     actual_metadata = nn_ensemble.get_model_metadata(model_filename)
 
-    assert actual_metadata["keras_version"] == expected_version
+    assert actual_metadata["torch_version"] == expected_version
     datetime_format = "%Y-%m-%d@%H:%M:%S"
     actual_datetime = datetime.strptime(actual_metadata["date_saved"], datetime_format)
     assert expected_date_saved - actual_datetime.astimezone(

--- a/tests/test_backend_nn_ensemble.py
+++ b/tests/test_backend_nn_ensemble.py
@@ -132,7 +132,7 @@ def test_nn_ensemble_train_cached(registry):
     nn_ensemble_type = annif.backend.get_backend("nn_ensemble")
     nn_ensemble = nn_ensemble_type(
         backend_id="nn_ensemble",
-        config_params={"sources": "dummy-en", "max-epochs": 2},
+        config_params={"sources": "dummy-en"},
         project=project,
     )
 

--- a/tests/test_backend_nn_ensemble.py
+++ b/tests/test_backend_nn_ensemble.py
@@ -62,7 +62,7 @@ def test_set_lmdb_map_size(registry, tmpdir):
     nn_ensemble_type = annif.backend.get_backend("nn_ensemble")
     nn_ensemble = nn_ensemble_type(
         backend_id="nn_ensemble",
-        config_params={"sources": "dummy-en", "epochs": 1, "lmdb_map_size": 1},
+        config_params={"sources": "dummy-en", "max-epochs": 1, "lmdb_map_size": 1},
         project=project,
     )
     tmpfile = tmpdir.join("document.tsv")
@@ -82,7 +82,7 @@ def test_nn_ensemble_train_and_learn(registry, tmpdir):
     nn_ensemble_type = annif.backend.get_backend("nn_ensemble")
     nn_ensemble = nn_ensemble_type(
         backend_id="nn_ensemble",
-        config_params={"sources": "dummy-en", "epochs": 1},
+        config_params={"sources": "dummy-en", "max-epochs": 1},
         project=project,
     )
 
@@ -132,7 +132,7 @@ def test_nn_ensemble_train_cached(registry):
     nn_ensemble_type = annif.backend.get_backend("nn_ensemble")
     nn_ensemble = nn_ensemble_type(
         backend_id="nn_ensemble",
-        config_params={"sources": "dummy-en", "epochs": 2},
+        config_params={"sources": "dummy-en", "max-epochs": 2},
         project=project,
     )
 
@@ -147,7 +147,7 @@ def test_nn_ensemble_train_and_learn_params(registry, tmpdir, capfd):
     nn_ensemble_type = annif.backend.get_backend("nn_ensemble")
     nn_ensemble = nn_ensemble_type(
         backend_id="nn_ensemble",
-        config_params={"sources": "dummy-en", "epochs": 3},
+        config_params={"sources": "dummy-en", "max-epochs": 3},
         project=project,
     )
 
@@ -159,7 +159,7 @@ def test_nn_ensemble_train_and_learn_params(registry, tmpdir, capfd):
     )
     document_corpus = DocumentFileTSV(str(tmpfile), project.subjects)
 
-    train_params = {"epochs": 3}
+    train_params = {"max-epochs": 3}
     nn_ensemble.train(document_corpus, train_params)
     _, err = capfd.readouterr()
     assert "Epoch 3/3" in err
@@ -231,7 +231,7 @@ def test_nn_ensemble_default_params(app_project):
     )
 
     expected_default_params = {
-        "lr": 0.001,
+        "lr": 0.003,
         "limit": 100,
     }
     actual_params = nn_ensemble.params

--- a/tests/test_backend_nn_ensemble.py
+++ b/tests/test_backend_nn_ensemble.py
@@ -231,7 +231,7 @@ def test_nn_ensemble_default_params(app_project):
     )
 
     expected_default_params = {
-        "optimizer": "adam",
+        "lr": 0.001,
         "limit": 100,
     }
     actual_params = nn_ensemble.params

--- a/tests/test_backend_nn_ensemble.py
+++ b/tests/test_backend_nn_ensemble.py
@@ -1,7 +1,5 @@
 """Unit tests for the nn_ensemble backend in Annif"""
 
-import importlib
-import os.path
 import time
 from datetime import datetime, timedelta, timezone
 from unittest import mock
@@ -193,44 +191,8 @@ def test_nn_ensemble_modification_time(app_project):
     assert datetime.now(timezone.utc) - nn_ensemble.modification_time < timedelta(1)
 
 
-@pytest.mark.skip
-def test_nn_ensemble_get_model_metadata(app_project):
-    nn_ensemble_type = annif.backend.get_backend("nn_ensemble")
-    nn_ensemble = nn_ensemble_type(
-        backend_id="nn_ensemble",
-        config_params={"sources": "dummy-en"},
-        project=app_project,
-    )
-    model_filename = os.path.join(nn_ensemble.datadir, nn_ensemble.MODEL_FILE)
-
-    expected_version = importlib.metadata.version("torch")
-    expected_date_saved = datetime.now(timezone.utc)
-    actual_metadata = nn_ensemble.get_model_metadata(model_filename)
-
-    assert actual_metadata["torch_version"] == expected_version
-    datetime_format = "%Y-%m-%d@%H:%M:%S"
-    actual_datetime = datetime.strptime(actual_metadata["date_saved"], datetime_format)
-    assert expected_date_saved - actual_datetime.astimezone(
-        tz=timezone.utc
-    ) < timedelta(1)
-
-
-def test_nn_ensemble_get_model_metadata_nonexistent_file(app_project):
-    nn_ensemble_type = annif.backend.get_backend("nn_ensemble")
-    nn_ensemble = nn_ensemble_type(
-        backend_id="nn_ensemble",
-        config_params={"sources": "dummy-en"},
-        project=app_project,
-    )
-    nonexistent_model_file = "nonexistent.zip"
-    model_filename = os.path.join(nn_ensemble.datadir, nonexistent_model_file)
-
-    actual_metadata = nn_ensemble.get_model_metadata(model_filename)
-    assert actual_metadata is None
-
-
-@mock.patch("annif.backend.nn_ensemble.load_model", side_effect=Exception)
-def test_nn_ensemble_initialize_error(load_model, app_project):
+@mock.patch("annif.backend.nn_ensemble.NNEnsembleModel.load", side_effect=Exception)
+def test_nn_ensemble_initialize_error(load, app_project):
     nn_ensemble_type = annif.backend.get_backend("nn_ensemble")
     nn_ensemble = nn_ensemble_type(
         backend_id="nn_ensemble",
@@ -240,10 +202,10 @@ def test_nn_ensemble_initialize_error(load_model, app_project):
     assert nn_ensemble._model is None
     with pytest.raises(
         OperationFailedException,
-        match=r"loading Keras model from .*; model metadata: .*",
+        match=r"loading model from .*; original error message: .*",
     ):
         nn_ensemble.initialize()
-    assert load_model.called
+    assert load.called
 
 
 def test_nn_ensemble_initialize(app_project):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -28,27 +28,6 @@ TEMP_PROJECT = "".join(random.choice("abcdefghiklmnopqrstuvwxyz") for _ in range
 PROJECTS_CONFIG_PATH = "tests/projects_for_config_path_option.cfg"
 
 
-@mock.patch.dict(os.environ, clear=True)
-def test_tensorflow_loglevel():
-    tf_env = "TF_CPP_MIN_LOG_LEVEL"
-
-    runner.invoke(annif.cli.cli, ["list-projects", "-v", "DEBUG"])
-    assert os.environ[tf_env] == "0"  # Show INFO, WARNING and ERROR messages by TF
-    os.environ.pop(tf_env)
-    runner.invoke(annif.cli.cli, ["list-projects"])  # INFO level by default
-    assert os.environ[tf_env] == "1"  # Show WARNING and ERROR messages by TF
-    os.environ.pop(tf_env)
-    runner.invoke(annif.cli.cli, ["list-projects", "-v", "WARN"])
-    assert os.environ[tf_env] == "1"  # Show WARNING and ERROR messages by TF
-    os.environ.pop(tf_env)
-    runner.invoke(annif.cli.cli, ["list-projects", "-v", "ERROR"])
-    assert os.environ[tf_env] == "2"  # Show ERROR messages by TF
-    os.environ.pop(tf_env)
-    runner.invoke(annif.cli.cli, ["list-projects", "-v", "CRITICAL"])
-    assert os.environ[tf_env] == "3"  # Show no messages by TF
-    os.environ.pop(tf_env)
-
-
 def test_list_projects():
     result = runner.invoke(annif.cli.cli, ["list-projects"])
     assert not result.exception


### PR DESCRIPTION
This PR reimplements the NN ensemble using PyTorch instead of Keras/TensorFlow.

To test this, you will have to use `uv sync --group all --extra torch-cpu` or similar (see comments below).

Some notes about the implementation:

- the neural network architecture has been radically simplified; it turned out that a much simpler model (separate linear models for each concept) gives better results than the old MLP-based model
- the old code displayed `top_k_categorical_accuracy`, but this was not easily available in PyTorch, so I switched to using the nDCG metric computed for a random subset (n=512 documents) of the given train set and this metric is used for early stopping
- the progress bar shown during training now uses tdqm, so it looks a bit different than the Keras one; it is also displayed on stderr and not stdout as the old one used to be
- the code implements early stopping; it could train up to 50 epochs (can be set with `max-epochs` parameter), but tracks nDCG on a small sample (n=512) of the train set and stops when scores start to decline (with patience=2)
- the old code showed a detailed error message when model loading failed; I couldn't figure out (yet) how to do that with PyTorch models, but the model is stored with metadata (python version, torch version etc.) that may be helpful in implementing such an error message later on if it turns out to be necessary. In general, the models should be pretty much PyTorch-version-agnostic so there may not be a need for this.
- This PR sets up a dependency group `all` for installing all extras (a substitute for `--all-extras` which won't work anymore) as well as special extras for selecting the PyTorch variant. There are now `torch-cu126` and `torch-cu130` extras for now (for CUDA 12.6 and 13.0, respectively), but I think the setup could quite easily be extended to other PyTorch variants such as CUDA 13.2, ROCm or Intel XPU, though obviously these would require more configuration in `pyproject.toml`.
- This NN ensemble **will not make use of a GPU anyway**; the model is trained and inference is performed using CPU only. The model is so small that using GPU computation would not bring any practical benefit. But the infrastructure for GPU use is now in place for other PyTorch based backends such as EBM or XTransformer that would benefit from GPU computing.

Fixes #895