### PR TITLE
Mock requests in test for uploading project to nonexistent HF repo

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14,7 +14,7 @@ from unittest import mock
 import pytest
 from click.shell_completion import ShellComplete
 from click.testing import CliRunner
-from huggingface_hub.utils import HFValidationError
+from huggingface_hub.utils import HfHubHTTPError, HFValidationError
 
 import annif.cli
 import annif.cli_util
@@ -1618,7 +1618,11 @@ def test_upload_no_modelcard_upsert(
     assert upsert_modelcard.call_count == 0
 
 
-def test_upload_nonexistent_repo():
+@mock.patch(
+    "huggingface_hub.preupload_lfs_files",
+    side_effect=HfHubHTTPError("Repository Not Found for url:"),
+)
+def test_upload_nonexistent_repo(mock_preupload_lfs_files):
     failed_result = runner.invoke(annif.cli.cli, ["upload", "dummy-fi", "nonexistent"])
     assert failed_result.exception
     assert failed_result.exit_code != 0


### PR DESCRIPTION
The unit test for uploading projects to a nonexistent Hugging Face repository was performing a real network request to huggingface.co, while the intention in tests was that all requests/responses are mocked. This PR simply adds the missing mocking.

The network request was noticed by [Step Security's monitoring](https://github.com/NatLibFi/Annif/actions/runs/23286723592):
<img width="1057" height="462" alt="image" src="https://github.com/user-attachments/assets/e8527c87-2045-4e96-a848-cd09cdcb2598" />
