### PR TITLE
Fix REST API 500 error and schemathesis flaky test

### DIFF
--- a/annif/rest.py
+++ b/annif/rest.py
@@ -200,10 +200,9 @@ def _suggest(
 
     try:
         suggestion_results = project.suggest_corpus(corpus).filter(limit, threshold)
+        return suggestion_results_to_list(suggestion_results, project.subjects, lang)
     except AnnifException as err:
         return server_error(err)
-
-    return suggestion_results_to_list(suggestion_results, project.subjects, lang)
 
 
 def _documents_to_corpus(

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -22,7 +22,7 @@ def filter_path_parameters(context, path_parameters):
 @schema.parametrize()
 @settings(max_examples=10)
 def test_openapi_fuzzy(case):
-    case.call_and_validate()
+    case.call_and_validate(excluded_checks=("not_a_server_error",))
 
 
 @pytest.mark.slow

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -3,6 +3,7 @@
 import pytest
 import schemathesis
 from hypothesis import settings
+from hypothesis import strategies as st
 
 import annif
 
@@ -10,13 +11,20 @@ cxapp = annif.create_app(config_name="annif.default_config.TestingConfig")
 schema = schemathesis.from_path("annif/openapi/annif.yaml", app=cxapp)
 
 
-@schemathesis.hook("filter_path_parameters")
-def filter_path_parameters(context, path_parameters):
-    # Exclude path parameters containing newline which crashes application
-    # https://github.com/spec-first/connexion/issues/1908
-    if path_parameters is not None and "project_id" in path_parameters:
-        return "%0A" not in path_parameters["project_id"]
-    return True
+# Whitelist of project IDs that are valid for OpenAPI fuzzy testing
+# Only projects that work without training (dummy backend) are included
+PROJECTS_TO_TEST = (
+    "dummy-fi",
+    "dummy-en",
+)
+
+
+@schemathesis.hook("before_generate_path_parameters")
+def before_generate_path_parameters(context, strategy):
+    """Replace the path parameter generation strategy with a whitelist."""
+    if context.operation and "project_id" in context.operation.path:
+        return st.fixed_dictionaries({"project_id": st.sampled_from(PROJECTS_TO_TEST)})
+    return strategy
 
 
 @schema.parametrize()

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -30,7 +30,7 @@ def before_generate_path_parameters(context, strategy):
 @schema.parametrize()
 @settings(max_examples=10)
 def test_openapi_fuzzy(case):
-    case.call_and_validate(excluded_checks=("not_a_server_error",))
+    case.call_and_validate()
 
 
 @pytest.mark.slow


### PR DESCRIPTION
While working on #926 I had problems with a failing schemathesis test under GitHub Actions CI. Investigating it revealed two problems:

1. The REST API can return 500 errors for untrained projects, even though the response should be 503 with a proper error message.
2. The schemathesis test fails when the API returns a 503 response, even though it is correct and documented in the schema.

This PR fixes the two errors above.