### PR TITLE
Raise a readable error when a vocabulary file fails to parse

### DIFF
--- a/annif/vocab/skos.py
+++ b/annif/vocab/skos.py
@@ -12,6 +12,7 @@ import rdflib.util
 from rdflib.namespace import OWL, RDF, RDFS, SKOS
 
 import annif.util
+from annif.exception import OperationFailedException
 
 from .types import Subject, VocabSource
 
@@ -67,7 +68,12 @@ class VocabFileSKOS(VocabSource):
             self.graph = joblib.load(path)
         else:
             self.graph = rdflib.Graph()
-            self.graph.parse(self.path, format=rdflib.util.guess_format(self.path))
+            try:
+                self.graph.parse(self.path, format=rdflib.util.guess_format(self.path))
+            except Exception as err:
+                raise OperationFailedException(
+                    f"Cannot parse vocabulary file {self.path}: {err}"
+                ) from err
 
     @property
     def languages(self) -> set[str]:

--- a/tests/test_vocab_skos.py
+++ b/tests/test_vocab_skos.py
@@ -141,3 +141,4 @@ yso:p8993
     with pytest.raises(OperationFailedException) as excinfo:
         VocabFileSKOS(tmpfile_path)
     assert "Cannot parse vocabulary file" in str(excinfo.value)
+    assert tmpfile_path in str(excinfo.value)

--- a/tests/test_vocab_skos.py
+++ b/tests/test_vocab_skos.py
@@ -137,6 +137,7 @@ yso:p8993
     """  # missing closing period -> invalid Turtle
     )
 
+    tmpfile_path = str(tmpfile)
     with pytest.raises(OperationFailedException) as excinfo:
-        VocabFileSKOS(str(tmpfile))
+        VocabFileSKOS(tmpfile_path)
     assert "Cannot parse vocabulary file" in str(excinfo.value)

--- a/tests/test_vocab_skos.py
+++ b/tests/test_vocab_skos.py
@@ -2,6 +2,9 @@
 
 import os.path
 
+import pytest
+
+from annif.exception import OperationFailedException
 from annif.vocab import VocabFileSKOS
 
 
@@ -119,3 +122,21 @@ def test_load_turtle_get_languages(testdatadir):
     assert "fi" in langs
     assert "sv" in langs
     assert "en" in langs
+
+
+def test_load_vocab_corrupt(tmpdir):
+    tmpfile = tmpdir.join("subjects.ttl")
+    tmpfile.write(
+        """
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix yso: <http://www.yso.fi/onto/yso/> .
+
+yso:p8993
+    a skos:Concept ;
+    skos:prefLabel "hylyt"@fi
+    """  # missing closing period -> invalid Turtle
+    )
+
+    with pytest.raises(OperationFailedException) as excinfo:
+        VocabFileSKOS(str(tmpfile))
+    assert "Cannot parse vocabulary file" in str(excinfo.value)


### PR DESCRIPTION
Fixes #861.

When `load-vocab` is given a corrupt or malformed SKOS/RDF file, the raw rdflib traceback surfaces instead of a readable message. This wraps the `graph.parse()` call in `VocabFileSKOS.__init__` and raises `OperationFailedException` with the file path and the underlying error.

I wrapped only the `graph.parse()` call per your steer and left `joblib.load()` untouched, since that path loads Annif's own stored dump, not user-supplied input. I used a broad `except Exception` because rdflib's parse surface (ParserError, BadSyntax, SAXParseException, plus format guessing) is large and unpredictable for arbitrary user files; happy to narrow it to an explicit exception tuple if you'd prefer.

I added a `test_load_vocab_corrupt` test in `tests/test_vocab_skos.py` covering an invalid Turtle file.
