### PR TITLE
Configure cool-down period for uv-handled dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,6 +98,7 @@ markers = ["slow: marks tests as slow (deselect with '-m \"not slow\"')"]
 addopts = "-m 'not slow'"
 
 [tool.uv]
+exclude-newer = "1 week"
 conflicts = [
   [
     { extra = "torch-cpu" },


### PR DESCRIPTION
uv can be configured to not update any dependency whose artifact has been uploaded in a given period of time: https://docs.astral.sh/uv/reference/settings/#exclude-newer

This PR adds config for this "cool-down" period of one week, which can help in preveventing supply-chain attacks: https://pydevtools.com/handbook/how-to/how-to-protect-against-python-supply-chain-attacks-with-uv/