### PR TITLE
Expose project metadata fields via REST API

### DIFF
--- a/annif/openapi/annif.yaml
+++ b/annif/openapi/annif.yaml
@@ -353,6 +353,14 @@ components:
           format: date-time
           example: 2020-05-19T16:42:42Z
           nullable: true
+        metadata:
+          type: array
+          items:
+            type: string
+          example:
+          - title
+          - description
+          - text
       description: A project definition
     ProjectList:
       type: object

--- a/annif/project.py
+++ b/annif/project.py
@@ -340,11 +340,15 @@ class AnnifProject(DatadirMixin):
                 fields.extend(trans.fields)
         return fields
 
-    def metadata_fields(self) -> list[str]:
-        """return the metadata fields this project uses during suggest. For
-        ensemble projects, the fields of the source projects are gathered in
-        addition to the project's own fields. The result is a flat, order-
-        preserving, de-duplicated list."""
+    def _gather_metadata_fields(self, seen: set[str]) -> list[str]:
+        """collect the select(...) fields of this project and, recursively, of
+        its source projects. The recursion mirrors suggest(), which delegates
+        to each source project's own suggest(). `seen` guards against cyclic
+        sources configurations, which are not rejected elsewhere."""
+
+        if self.project_id in seen:
+            return []
+        seen.add(self.project_id)
 
         fields = list(self._select_fields())
 
@@ -359,10 +363,18 @@ class AnnifProject(DatadirMixin):
                     source = self.registry.get_project(source_id)
                 except ValueError:
                     continue  # source project not loadable - skip best-effort
-                fields.extend(source._select_fields())
+                fields.extend(source._gather_metadata_fields(seen))
+
+        return fields
+
+    def metadata_fields(self) -> list[str]:
+        """return the metadata fields this project uses during suggest. For
+        ensemble projects, the fields of the source projects are gathered
+        recursively, in addition to the project's own fields. The result is a
+        flat, order-preserving, de-duplicated list."""
 
         # de-duplicate while preserving first-seen order
-        return list(dict.fromkeys(fields))
+        return list(dict.fromkeys(self._gather_metadata_fields(set())))
 
     def dump(self) -> dict[str, str | list | dict | bool | datetime | None]:
         """return this project as a dict"""

--- a/annif/project.py
+++ b/annif/project.py
@@ -22,7 +22,7 @@ from annif.exception import (
     NotInitializedException,
     NotSupportedException,
 )
-from annif.util import parse_args
+from annif.util import parse_args, parse_sources
 from annif.vocab import SubjectIndexFilter, kwargs_to_exclude_uris
 
 if TYPE_CHECKING:
@@ -326,7 +326,45 @@ class AnnifProject(DatadirMixin):
             project_id=self.project_id,
         )
 
-    def dump(self) -> dict[str, str | dict | bool | datetime | None]:
+    def _select_fields(self) -> list[str]:
+        """return the metadata field names that this project's own transform
+        chain selects via select(...) transforms, in configured order"""
+
+        try:
+            transforms = self.transform.transforms
+        except ConfigurationException:
+            return []
+        fields: list[str] = []
+        for trans in transforms:
+            if isinstance(trans, annif.transform.select.SelectTransform):
+                fields.extend(trans.fields)
+        return fields
+
+    def metadata_fields(self) -> list[str]:
+        """return the metadata fields this project uses during suggest. For
+        ensemble projects, the fields of the source projects are gathered in
+        addition to the project's own fields. The result is a flat, order-
+        preserving, de-duplicated list."""
+
+        fields = list(self._select_fields())
+
+        sources_spec = self.config.get("sources")
+        if sources_spec:
+            try:
+                sources = parse_sources(sources_spec)
+            except (ValueError, ZeroDivisionError):
+                sources = []
+            for source_id, _ in sources:
+                try:
+                    source = self.registry.get_project(source_id)
+                except ValueError:
+                    continue  # source project not loadable - skip best-effort
+                fields.extend(source._select_fields())
+
+        # de-duplicate while preserving first-seen order
+        return list(dict.fromkeys(fields))
+
+    def dump(self) -> dict[str, str | list | dict | bool | datetime | None]:
         """return this project as a dict"""
 
         try:
@@ -345,6 +383,7 @@ class AnnifProject(DatadirMixin):
             "vocab_language": vocab_lang,
             "is_trained": self.is_trained,
             "modification_time": self.modification_time,
+            "metadata": self.metadata_fields(),
         }
 
     def remove_model_data(self) -> None:

--- a/tests/projects.cfg
+++ b/tests/projects.cfg
@@ -142,3 +142,11 @@ backend=ensemble
 sources=select-meta,dummy-en
 vocab=dummy
 transform=select(description)
+
+[ensemble-meta-nested]
+name=Ensemble whose source is itself an ensemble
+language=en
+backend=ensemble
+sources=ensemble-meta
+vocab=dummy
+transform=select(subtitle)

--- a/tests/projects.cfg
+++ b/tests/projects.cfg
@@ -126,3 +126,19 @@ backend=tfidf
 analyzer=snowball(english)
 limit=10
 vocab=yso
+
+[select-meta]
+name=Dummy with select transform
+language=fi
+backend=dummy
+analyzer=snowball(finnish)
+vocab=dummy
+transform=select(title,description,text)
+
+[ensemble-meta]
+name=Ensemble gathering source metadata fields
+language=en
+backend=ensemble
+sources=select-meta,dummy-en
+vocab=dummy
+transform=select(description)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1885,6 +1885,7 @@ def test_completion_show_project_project_ids_all():
         "tfidf-en",
         "select-meta",
         "ensemble-meta",
+        "ensemble-meta-nested",
     ]
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1883,6 +1883,8 @@ def test_completion_show_project_project_ids_all():
         "pav",
         "tfidf-fi",
         "tfidf-en",
+        "select-meta",
+        "ensemble-meta",
     ]
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -52,7 +52,7 @@ def test_find_config_not_exists_default(monkeypatch, caplog):
 def test_parse_config_cfg_nondefault():
     cfg = annif.config.parse_config("tests/projects.cfg")
     assert isinstance(cfg, annif.config.AnnifConfigCFG)
-    assert len(cfg.project_ids) == 19
+    assert len(cfg.project_ids) == 20
     assert cfg["dummy-fi"] is not None
 
 
@@ -61,7 +61,7 @@ def test_parse_config_cfg_default(monkeypatch):
     monkeypatch.chdir("tests")
     cfg = annif.config.parse_config("")
     assert isinstance(cfg, annif.config.AnnifConfigCFG)
-    assert len(cfg.project_ids) == 19
+    assert len(cfg.project_ids) == 20
     assert cfg["dummy-fi"] is not None
 
 
@@ -83,7 +83,7 @@ def test_parse_config_toml_failed(tmpdir):
 def test_parse_config_directory():
     cfg = annif.config.parse_config("tests/projects.d")
     assert isinstance(cfg, annif.config.AnnifConfigDirectory)
-    assert len(cfg.project_ids) == 2 + 19  # 0-projects.toml + 1-projects.cfg
+    assert len(cfg.project_ids) == 2 + 20  # 0-projects.toml + 1-projects.cfg
     assert cfg["dummy-fi"] is not None
     assert cfg["dummy-fi-toml"] is not None
     assert list(cfg.project_ids)[0] == "dummy-fi-toml"  # First in 0-projects.toml

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -52,7 +52,7 @@ def test_find_config_not_exists_default(monkeypatch, caplog):
 def test_parse_config_cfg_nondefault():
     cfg = annif.config.parse_config("tests/projects.cfg")
     assert isinstance(cfg, annif.config.AnnifConfigCFG)
-    assert len(cfg.project_ids) == 17
+    assert len(cfg.project_ids) == 19
     assert cfg["dummy-fi"] is not None
 
 
@@ -61,7 +61,7 @@ def test_parse_config_cfg_default(monkeypatch):
     monkeypatch.chdir("tests")
     cfg = annif.config.parse_config("")
     assert isinstance(cfg, annif.config.AnnifConfigCFG)
-    assert len(cfg.project_ids) == 17
+    assert len(cfg.project_ids) == 19
     assert cfg["dummy-fi"] is not None
 
 
@@ -83,7 +83,7 @@ def test_parse_config_toml_failed(tmpdir):
 def test_parse_config_directory():
     cfg = annif.config.parse_config("tests/projects.d")
     assert isinstance(cfg, annif.config.AnnifConfigDirectory)
-    assert len(cfg.project_ids) == 2 + 17  # 0-projects.toml + 1-projects.cfg
+    assert len(cfg.project_ids) == 2 + 19  # 0-projects.toml + 1-projects.cfg
     assert cfg["dummy-fi"] is not None
     assert cfg["dummy-fi-toml"] is not None
     assert list(cfg.project_ids)[0] == "dummy-fi-toml"  # First in 0-projects.toml

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -85,7 +85,44 @@ def test_get_project_fi_dump(registry):
         "vocab_language": "fi",
         "is_trained": True,
         "modification_time": None,
+        "metadata": [],
     }
+
+
+def test_get_project_metadata_fields_select(registry):
+    # a project with a select(...) transform exposes its fields, in order
+    project = registry.get_project("select-meta")
+    assert project.dump()["metadata"] == ["title", "description", "text"]
+
+
+def test_get_project_metadata_fields_none(registry):
+    # a project without a select transform has no metadata fields
+    project = registry.get_project("dummy-fi")
+    assert project.metadata_fields() == []
+
+
+def test_get_project_metadata_fields_ensemble_union(registry):
+    # an ensemble gathers source fields in addition to its own, de-duplicated
+    # and order-preserving: own select(description) first, then the source
+    # select-meta's (title, description, text); dummy-en has no select fields
+    project = registry.get_project("ensemble-meta")
+    assert project.dump()["metadata"] == ["description", "title", "text"]
+
+
+def test_get_project_metadata_fields_skips_unloadable_source(registry, monkeypatch):
+    # a source project that cannot be loaded is skipped best-effort, mirroring
+    # the graceful degradation already used for vocab in dump()
+    project = registry.get_project("ensemble-meta")
+    real_get_project = project.registry.get_project
+
+    def fake_get_project(project_id, *args, **kwargs):
+        if project_id == "select-meta":
+            raise ValueError("source not loadable")
+        return real_get_project(project_id, *args, **kwargs)
+
+    monkeypatch.setattr(project.registry, "get_project", fake_get_project)
+    # only the ensemble's own select(description) field remains
+    assert project.metadata_fields() == ["description"]
 
 
 def test_get_project_nonexistent(registry):
@@ -324,6 +361,6 @@ def test_project_file_toml():
 def test_project_directory():
     cxapp = annif.create_app(config_name="annif.default_config.TestingDirectoryConfig")
     with cxapp.app.app_context():
-        assert len(annif.registry.get_projects()) == 17 + 2
+        assert len(annif.registry.get_projects()) == 19 + 2
         assert annif.registry.get_project("dummy-fi").project_id == "dummy-fi"
         assert annif.registry.get_project("dummy-fi-toml").project_id == "dummy-fi-toml"

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -125,6 +125,32 @@ def test_get_project_metadata_fields_skips_unloadable_source(registry, monkeypat
     assert project.metadata_fields() == ["description"]
 
 
+def test_get_project_metadata_fields_transform_error(registry, monkeypatch):
+    # if the transform chain cannot be resolved (misconfiguration), the project
+    # degrades to no metadata fields rather than raising
+    project = registry.get_project("dummy-fi")
+
+    class BrokenTransform:
+        @property
+        def transforms(self):
+            raise ConfigurationException("broken transform")
+
+    monkeypatch.setattr(project, "_transform", BrokenTransform())
+    assert project.metadata_fields() == []
+
+
+def test_get_project_metadata_fields_malformed_sources(registry, monkeypatch):
+    # if the sources spec cannot be parsed, source-field gathering is skipped
+    # best-effort and only the ensemble's own select(description) field remains
+    project = registry.get_project("ensemble-meta")
+
+    def broken_parse_sources(sources_spec):
+        raise ValueError("malformed sources spec")
+
+    monkeypatch.setattr(annif.project, "parse_sources", broken_parse_sources)
+    assert project.metadata_fields() == ["description"]
+
+
 def test_get_project_nonexistent(registry):
     with pytest.raises(ValueError):
         registry.get_project("nonexistent")

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -109,6 +109,33 @@ def test_get_project_metadata_fields_ensemble_union(registry):
     assert project.dump()["metadata"] == ["description", "title", "text"]
 
 
+def test_get_project_metadata_fields_nested_ensemble(registry):
+    # gathering is recursive: an ensemble whose source is itself an ensemble
+    # must also pick up the fields of that source's own sources, because
+    # suggest() recurses the same way. Own select(subtitle), then
+    # ensemble-meta's select(description), then select-meta's
+    # (title, description, text); dummy-en contributes none.
+    project = registry.get_project("ensemble-meta-nested")
+    assert project.dump()["metadata"] == ["subtitle", "description", "title", "text"]
+
+
+def test_get_project_metadata_fields_source_cycle(registry, monkeypatch):
+    # a cyclic sources configuration must not cause unbounded recursion;
+    # each project is visited at most once
+    project = registry.get_project("ensemble-meta")
+    source = project.registry.get_project("select-meta")
+    real_get = source.config.get
+
+    def cyclic_get(key, *args, **kwargs):
+        if key == "sources":
+            return "ensemble-meta"
+        return real_get(key, *args, **kwargs)
+
+    monkeypatch.setattr(source.config, "get", cyclic_get)
+    # terminates, and still yields each field once
+    assert project.metadata_fields() == ["description", "title", "text"]
+
+
 def test_get_project_metadata_fields_skips_unloadable_source(registry, monkeypatch):
     # a source project that cannot be loaded is skipped best-effort, mirroring
     # the graceful degradation already used for vocab in dump()
@@ -387,6 +414,6 @@ def test_project_file_toml():
 def test_project_directory():
     cxapp = annif.create_app(config_name="annif.default_config.TestingDirectoryConfig")
     with cxapp.app.app_context():
-        assert len(annif.registry.get_projects()) == 19 + 2
+        assert len(annif.registry.get_projects()) == 20 + 2
         assert annif.registry.get_project("dummy-fi").project_id == "dummy-fi"
         assert annif.registry.get_project("dummy-fi-toml").project_id == "dummy-fi-toml"

--- a/tests/test_rest.py
+++ b/tests/test_rest.py
@@ -35,6 +35,20 @@ def test_rest_show_project_public(app):
         assert result["project_id"] == "dummy-fi"
 
 
+def test_rest_show_project_metadata_fields(app):
+    # the metadata fields used by a select(...) transform are exposed via REST
+    with app.app_context():
+        result = annif.rest.show_project("select-meta")[0]
+        assert result["metadata"] == ["title", "description", "text"]
+
+
+def test_rest_show_project_metadata_fields_empty(app):
+    # projects without a select transform expose an empty metadata list
+    with app.app_context():
+        result = annif.rest.show_project("dummy-fi")[0]
+        assert result["metadata"] == []
+
+
 def test_rest_show_project_hidden(app):
     # hidden projects should be accessible if you know the project id
     with app.app_context():


### PR DESCRIPTION
Closes #893.

Exposes the document metadata fields a project uses during `suggest` via the
REST API, as requested in the issue. `GET /v1/projects` and
`GET /v1/projects/<project_id>` now return a `metadata` field — a flat list of
the field names a project consumes through `select(...)` transforms:

    "metadata": ["title", "description", "text"]

Following the issue's spec for ensemble projects ("gather the metadata fields
that the source projects use, in addition to the fields the ensemble project
itself uses"), an ensemble's `metadata` is the order-preserving, de-duplicated
union of its own select fields and those of its source projects.

One implementation note: `metadata_fields()` skips a source project that can't
be resolved (`get_project` raising `ValueError`) rather than propagating, so it
adds no new failure mode to `dump()`. This is narrower than the `vocab`
`try/except` above it — `dump()` already evaluates `is_trained` (which resolves
ensemble sources) before this point, so a genuinely missing source still
surfaces there exactly as today; the skip only keeps `metadata_fields()` itself
from being a second raise point. Happy to make it strict (raise) if you'd prefer.

## Changes
- `annif/project.py`: `metadata_fields()` + `_select_fields()` helpers; `metadata` added to `dump()`.
- `annif/openapi/annif.yaml`: `metadata` added to the `Project` schema (keeps schemathesis response validation green).
- Tests: a `select(...)` project and a metadata-gathering ensemble fixture; unit + REST coverage for own fields, ensemble union/dedup, and unloadable-source skip.

## Validation
- `pytest tests/test_project.py tests/test_rest.py tests/test_openapi.py` — green (pre-existing tfidf-training failures unrelated to this change).
- `flake8` / `black --check` / `isort --check` — clean.
