### PR TITLE
Limit API request size via Flask

### DIFF
--- a/annif/default_config.py
+++ b/annif/default_config.py
@@ -34,6 +34,7 @@ class TestingConfig(Config):
     TESTING = True
     PROJECTS_CONFIG_PATH = "tests/projects.cfg"
     DATADIR = "tests/data"
+    MAX_CONTENT_LENGTH = int(os.environ.get("ANNIF_MAX_CONTENT_LENGTH", default=1_000))
 
 
 class TestingInitializeConfig(TestingConfig):

--- a/annif/default_config.py
+++ b/annif/default_config.py
@@ -14,8 +14,12 @@ class Config(object):
     PROJECTS_CONFIG_PATH = os.environ.get("ANNIF_PROJECTS", default="")
     DATADIR = os.environ.get("ANNIF_DATADIR", default="data")
     INITIALIZE_PROJECTS = False
-    MAX_FORM_MEMORY_SIZE = int(os.environ.get("ANNIF_MAX_FORM_MEMORY_SIZE", default=20_000_000))
-    MAX_CONTENT_LENGTH = int(os.environ.get("ANNIF_MAX_CONTENT_LENGTH", default=20_000_000))
+    MAX_FORM_MEMORY_SIZE = int(
+        os.environ.get("ANNIF_MAX_FORM_MEMORY_SIZE", default=20_000_000)
+    )
+    MAX_CONTENT_LENGTH = int(
+        os.environ.get("ANNIF_MAX_CONTENT_LENGTH", default=20_000_000)
+    )
 
 
 class ProductionConfig(Config):

--- a/annif/default_config.py
+++ b/annif/default_config.py
@@ -34,7 +34,7 @@ class TestingConfig(Config):
     TESTING = True
     PROJECTS_CONFIG_PATH = "tests/projects.cfg"
     DATADIR = "tests/data"
-    MAX_CONTENT_LENGTH = int(os.environ.get("ANNIF_MAX_CONTENT_LENGTH", default=1_000))
+    MAX_CONTENT_LENGTH = int(os.environ.get("ANNIF_MAX_CONTENT_LENGTH", default=2_000))
 
 
 class TestingInitializeConfig(TestingConfig):

--- a/annif/default_config.py
+++ b/annif/default_config.py
@@ -15,6 +15,7 @@ class Config(object):
     DATADIR = os.environ.get("ANNIF_DATADIR", default="data")
     INITIALIZE_PROJECTS = False
     MAX_FORM_MEMORY_SIZE = 20_000_000  # Increase from Flask's default limit
+    MAX_CONTENT_LENGTH = 20_000_000
 
 
 class ProductionConfig(Config):

--- a/annif/default_config.py
+++ b/annif/default_config.py
@@ -14,8 +14,8 @@ class Config(object):
     PROJECTS_CONFIG_PATH = os.environ.get("ANNIF_PROJECTS", default="")
     DATADIR = os.environ.get("ANNIF_DATADIR", default="data")
     INITIALIZE_PROJECTS = False
-    MAX_FORM_MEMORY_SIZE = 20_000_000  # Increase from Flask's default limit
-    MAX_CONTENT_LENGTH = 20_000_000
+    MAX_FORM_MEMORY_SIZE = int(os.environ.get("ANNIF_MAX_FORM_MEMORY_SIZE", default=20_000_000))
+    MAX_CONTENT_LENGTH = int(os.environ.get("ANNIF_MAX_CONTENT_LENGTH", default=20_000_000))
 
 
 class ProductionConfig(Config):

--- a/annif/default_config.py
+++ b/annif/default_config.py
@@ -34,7 +34,7 @@ class TestingConfig(Config):
     TESTING = True
     PROJECTS_CONFIG_PATH = "tests/projects.cfg"
     DATADIR = "tests/data"
-    MAX_CONTENT_LENGTH = int(os.environ.get("ANNIF_MAX_CONTENT_LENGTH", default=2_000))
+    MAX_CONTENT_LENGTH = 2_000
 
 
 class TestingInitializeConfig(TestingConfig):

--- a/annif/openapi/annif.yaml
+++ b/annif/openapi/annif.yaml
@@ -115,6 +115,8 @@ paths:
           $ref: '#/components/responses/BadRequest'
         "404":
           $ref: '#/components/responses/NotFound'
+        "413":
+          $ref: '#/components/responses/PayloadTooLarge'
         "503":
           $ref: '#/components/responses/ServiceUnavailable'
   /projects/{project_id}/suggest-batch:
@@ -175,6 +177,8 @@ paths:
           $ref: '#/components/responses/BadRequest'
         "404":
           $ref: '#/components/responses/NotFound'
+        "413":
+          $ref: '#/components/responses/PayloadTooLarge'
         "503":
           $ref: '#/components/responses/ServiceUnavailable'
       x-codegen-request-body-name: documents
@@ -205,6 +209,8 @@ paths:
           $ref: '#/components/responses/NotAllowed'
         "404":
           $ref: '#/components/responses/NotFound'
+        "413":
+          $ref: '#/components/responses/PayloadTooLarge'
         "503":
           $ref: '#/components/responses/ServiceUnavailable'
       x-codegen-request-body-name: documents
@@ -247,6 +253,12 @@ paths:
                 $ref: '#/components/schemas/DetectedLanguages'
         400:
           description: Bad Request
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+        413:
+          description: Payload Too Large
           content:
             application/problem+json:
               schema:
@@ -515,6 +527,12 @@ components:
             $ref: '#/components/schemas/Problem'
     ServiceUnavailable:
       description: Service Unavailable
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/Problem'
+    PayloadTooLarge:
+      description: Payload Too Large
       content:
         application/problem+json:
           schema:

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -151,7 +151,7 @@ def test_rest_detect_language_too_many_candidates(app_client):
 
 def test_rest_suggest_payload_exceeds_max_content_length(app_client):
     # Create a payload that exceeds the MAX_CONTENT_LENGTH limit
-    large_text = "A" * 2_000
+    large_text = "A" * 3_000
     data = {"text": large_text}
     req = app_client.post(
         "http://localhost:8000/v1/projects/dummy-fi/suggest",
@@ -162,7 +162,7 @@ def test_rest_suggest_payload_exceeds_max_content_length(app_client):
 
 def test_rest_suggest_batch_payload_exceeds_max_content_length(app_client):
     # Create a payload that exceeds the MAX_CONTENT_LENGTH limit
-    large_text = "A" * 2_000
+    large_text = "A" * 3_000
     data = {"documents": [{"text": large_text}]}
     req = app_client.post(
         "http://localhost:8000/v1/projects/dummy-fi/suggest-batch",
@@ -185,7 +185,7 @@ def test_rest_suggest_payload_within_max_content_length(app_client):
 
 def test_rest_detect_language_payload_exceeds_max_content_length(app_client):
     # Create a payload that exceeds the MAX_CONTENT_LENGTH limit
-    large_text = "A" * 2_000
+    large_text = "A" * 3_000
     data = {"text": large_text, "languages": ["en", "fi"]}
     req = app_client.post(
         "http://localhost:8000/v1/detect-language",

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -147,3 +147,63 @@ def test_rest_detect_language_too_many_candidates(app_client):
     data = {"text": "example text", "languages": ["en", "fr", "de", "it", "es", "nl"]}
     req = app_client.post("http://localhost:8000/v1/detect-language", json=data)
     assert req.status_code == 400
+
+
+def test_rest_suggest_payload_exceeds_max_content_length(app_client):
+    """Test that requests exceeding MAX_CONTENT_LENGTH are rejected."""
+    large_text = "A" * 21_000_000
+    data = {"text": large_text}
+    req = app_client.post(
+        "http://localhost:8000/v1/projects/dummy-fi/suggest",
+        data=data,
+    )
+    assert req.status_code == 413  # Request Entity Too Large
+
+
+def test_rest_suggest_batch_payload_exceeds_max_content_length(app_client):
+    """Test that batch requests exceeding MAX_CONTENT_LENGTH are rejected."""
+    # Create a payload that exceeds the MAX_CONTENT_LENGTH limit (21 MB)
+    large_text = "A" * 21_000_000
+    data = {"documents": [{"text": large_text}]}
+    req = app_client.post(
+        "http://localhost:8000/v1/projects/dummy-fi/suggest-batch",
+        json=data,
+    )
+    assert req.status_code == 413  # Request Entity Too Large
+
+
+def test_rest_suggest_payload_within_max_content_length(app_client):
+    """Test that requests within MAX_CONTENT_LENGTH limit are accepted."""
+    # Create a payload well within the 20 MB limit (5 MB)
+    moderate_text = "A" * 5_000_000
+    data = {"text": moderate_text}
+    req = app_client.post(
+        "http://localhost:8000/v1/projects/dummy-fi/suggest",
+        data=data,
+    )
+    assert req.status_code == 200
+    assert "results" in req.json()
+
+
+def test_rest_detect_language_payload_exceeds_max_content_length(app_client):
+    """Test that detect-language requests exceeding MAX_CONTENT_LENGTH are rejected."""
+    # Create a payload that exceeds the MAX_CONTENT_LENGTH limit (21 MB)
+    large_text = "A" * 21_000_000
+    data = {"text": large_text, "languages": ["en", "fi"]}
+    req = app_client.post(
+        "http://localhost:8000/v1/detect-language",
+        json=data,
+    )
+    assert req.status_code == 413  # Request Entity Too Large
+
+
+def test_rest_detect_language_payload_within_max_content_length(app_client):
+    """Test that detect-language requests within MAX_CONTENT_LENGTH limit are accepted."""
+    small_text = "A" * 5_000
+    data = {"text": small_text, "languages": ["en", "fi"]}
+    req = app_client.post(
+        "http://localhost:8000/v1/detect-language",
+        json=data,
+    )
+    assert req.status_code == 200
+    assert "results" in req.json()

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -150,7 +150,8 @@ def test_rest_detect_language_too_many_candidates(app_client):
 
 
 def test_rest_suggest_payload_exceeds_max_content_length(app_client):
-    large_text = "A" * 21_000_000
+    # Create a payload that exceeds the MAX_CONTENT_LENGTH limit
+    large_text = "A" * 2_000
     data = {"text": large_text}
     req = app_client.post(
         "http://localhost:8000/v1/projects/dummy-fi/suggest",
@@ -160,8 +161,8 @@ def test_rest_suggest_payload_exceeds_max_content_length(app_client):
 
 
 def test_rest_suggest_batch_payload_exceeds_max_content_length(app_client):
-    # Create a payload that exceeds the MAX_CONTENT_LENGTH limit (21 MB)
-    large_text = "A" * 21_000_000
+    # Create a payload that exceeds the MAX_CONTENT_LENGTH limit
+    large_text = "A" * 2_000
     data = {"documents": [{"text": large_text}]}
     req = app_client.post(
         "http://localhost:8000/v1/projects/dummy-fi/suggest-batch",
@@ -171,8 +172,8 @@ def test_rest_suggest_batch_payload_exceeds_max_content_length(app_client):
 
 
 def test_rest_suggest_payload_within_max_content_length(app_client):
-    # Create a payload well within the 20 MB limit (5 MB)
-    moderate_text = "A" * 5_000_000
+    # Create a payload well within the limit
+    moderate_text = "A" * 500
     data = {"text": moderate_text}
     req = app_client.post(
         "http://localhost:8000/v1/projects/dummy-fi/suggest",
@@ -183,8 +184,8 @@ def test_rest_suggest_payload_within_max_content_length(app_client):
 
 
 def test_rest_detect_language_payload_exceeds_max_content_length(app_client):
-    # Create a payload that exceeds the MAX_CONTENT_LENGTH limit (21 MB)
-    large_text = "A" * 21_000_000
+    # Create a payload that exceeds the MAX_CONTENT_LENGTH limit
+    large_text = "A" * 2_000
     data = {"text": large_text, "languages": ["en", "fi"]}
     req = app_client.post(
         "http://localhost:8000/v1/detect-language",
@@ -194,7 +195,7 @@ def test_rest_detect_language_payload_exceeds_max_content_length(app_client):
 
 
 def test_rest_detect_language_payload_within_max_content_length(app_client):
-    small_text = "A" * 5_000
+    small_text = "A" * 500
     data = {"text": small_text, "languages": ["en", "fi"]}
     req = app_client.post(
         "http://localhost:8000/v1/detect-language",

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -150,7 +150,6 @@ def test_rest_detect_language_too_many_candidates(app_client):
 
 
 def test_rest_suggest_payload_exceeds_max_content_length(app_client):
-    """Test that requests exceeding MAX_CONTENT_LENGTH are rejected."""
     large_text = "A" * 21_000_000
     data = {"text": large_text}
     req = app_client.post(
@@ -161,7 +160,6 @@ def test_rest_suggest_payload_exceeds_max_content_length(app_client):
 
 
 def test_rest_suggest_batch_payload_exceeds_max_content_length(app_client):
-    """Test that batch requests exceeding MAX_CONTENT_LENGTH are rejected."""
     # Create a payload that exceeds the MAX_CONTENT_LENGTH limit (21 MB)
     large_text = "A" * 21_000_000
     data = {"documents": [{"text": large_text}]}
@@ -173,7 +171,6 @@ def test_rest_suggest_batch_payload_exceeds_max_content_length(app_client):
 
 
 def test_rest_suggest_payload_within_max_content_length(app_client):
-    """Test that requests within MAX_CONTENT_LENGTH limit are accepted."""
     # Create a payload well within the 20 MB limit (5 MB)
     moderate_text = "A" * 5_000_000
     data = {"text": moderate_text}
@@ -186,7 +183,6 @@ def test_rest_suggest_payload_within_max_content_length(app_client):
 
 
 def test_rest_detect_language_payload_exceeds_max_content_length(app_client):
-    """Test that detect-language requests exceeding MAX_CONTENT_LENGTH are rejected."""
     # Create a payload that exceeds the MAX_CONTENT_LENGTH limit (21 MB)
     large_text = "A" * 21_000_000
     data = {"text": large_text, "languages": ["en", "fi"]}
@@ -198,7 +194,6 @@ def test_rest_detect_language_payload_exceeds_max_content_length(app_client):
 
 
 def test_rest_detect_language_payload_within_max_content_length(app_client):
-    """Test that detect-language requests within MAX_CONTENT_LENGTH limit are accepted."""
     small_text = "A" * 5_000
     data = {"text": small_text, "languages": ["en", "fi"]}
     req = app_client.post(


### PR DESCRIPTION
- Add Flask's setting [MAX_CONTENT_LENGTH](https://flask.palletsprojects.com/en/stable/config/#MAX_CONTENT_LENGTH) to limit request payloads.
  - Use 20 MB value in production config by default.
  - Use 2 kB value in testing config (to avoid unnecessary memory consumption and faster runs in tests).
- Allow setting the value via env `ANNIF_MAX_CONTENT_LENGTH` and the value for the existing Flask's MAX_FORM_MEMORY_SIZE via env `ANNIF_MAX_FORM_MEMORY_SIZE`.
- Add 413 responses to OpenAPI spec.

