### PR TITLE
Limit API request size via Starlette/Connexion

### DIFF
--- a/annif/__init__.py
+++ b/annif/__init__.py
@@ -36,6 +36,7 @@ def create_cx_app(config_name: str | None = None) -> FlaskApp:
     from connexion.datastructures import MediaTypeDict
     from connexion.middleware import MiddlewarePosition
     from connexion.validators import FormDataValidator, MultiPartFormDataValidator
+    from starlette.middleware.body_limit import RequestBodyLimitMiddleware
     from starlette.middleware.cors import CORSMiddleware
 
     import annif.registry
@@ -64,6 +65,11 @@ def create_cx_app(config_name: str | None = None) -> FlaskApp:
         CORSMiddleware,
         position=MiddlewarePosition.BEFORE_EXCEPTION,
         allow_origins=["*"],
+    )
+    cxapp.add_middleware(
+        RequestBodyLimitMiddleware,
+        position=MiddlewarePosition.BEFORE_EXCEPTION,
+        max_body_size=cxapp.app.config["MAX_CONTENT_LENGTH"],
     )
 
     if cxapp.app.config["INITIALIZE_PROJECTS"]:

--- a/annif/openapi/annif.yaml
+++ b/annif/openapi/annif.yaml
@@ -262,9 +262,9 @@ paths:
         413:
           description: Payload Too Large
           content:
-            application/problem+json:
+            text/plain:
               schema:
-                $ref: '#/components/schemas/Problem'
+                type: string
 components:
   schemas:
     ApiInfo:
@@ -536,6 +536,6 @@ components:
     PayloadTooLarge:
       description: Payload Too Large
       content:
-        application/problem+json:
+        text/plain:
           schema:
-            $ref: '#/components/schemas/Problem'
+            type: string

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
     "simplemma~=1.1.1",
     "scikit-learn~=1.7.1",
     "scipy~=1.15.3",
+    "starlette~=1.6.0",
     "requests~=2.32.3",
     "rdflib~=7.1.3",
     "tomli~=2.2.1; python_version<'3.11'",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,7 @@ markers = ["slow: marks tests as slow (deselect with '-m \"not slow\"')"]
 addopts = "-m 'not slow'"
 
 [tool.uv]
-exclude-newer = "1 week"
+exclude-newer = "5 days"
 conflicts = [
   [
     { extra = "torch-cpu" },

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -10,6 +10,9 @@ import annif
 cxapp = annif.create_app(config_name="annif.default_config.TestingConfig")
 schema = schemathesis.openapi.from_asgi("/v1/openapi.json", app=cxapp)
 schema.config.checks.positive_data_acceptance.enabled = False
+# Allow 413 as a valid rejection — oversized invalid payloads hit
+# MAX_CONTENT_LENGTH before Connexion can validate the schema.
+schema.config.checks.negative_data_rejection.expected_statuses.append("413")
 schema.config.generation.allow_extra_parameters = False
 
 


### PR DESCRIPTION
Use Starlette's RequestBodyLimitMiddleware to limit API request size when Annif is serving REST API via Connexion.

A follow-up to #948.