### PR TITLE
Add parallel candidate generation for MLLM hyperopt

### DIFF
--- a/annif/backend/mllm.py
+++ b/annif/backend/mllm.py
@@ -10,6 +10,7 @@ import numpy as np
 
 import annif.eval
 import annif.util
+import annif.parallel
 from annif.exception import NotInitializedException, NotSupportedException
 from annif.lexical.mllm import (
     MLLMModel,
@@ -72,6 +73,17 @@ class MLLMHPObjective(hyperopt.HPObjective):
         return results[args["metric"]]
 
 
+class MLLMCandidateGenerator(annif.parallel.BaseWorker):
+    """Worker class for generating candidates in parallel"""
+
+    @classmethod
+    def generate_for_doc(cls, doc) -> tuple[list, Any]:
+        """Generate candidates for a single document"""
+        backend = cls.args["backend"]
+        candidates = backend._generate_candidates(doc.text)
+        return (candidates, doc.subject_set)
+
+
 class MLLMOptimizer(hyperopt.HyperparameterOptimizer):
     """Hyperparameter optimizer for the MLLM backend"""
 
@@ -81,11 +93,27 @@ class MLLMOptimizer(hyperopt.HyperparameterOptimizer):
         all_candidates = []
         gold_subjects = []
 
-        # TODO parallelize generation of candidates
-        for doc in self._corpus.documents:
-            candidates = self._backend._generate_candidates(doc.text)
+        # Parallelize generation of candidates
+        n_jobs, pool_constructor = annif.parallel.get_pool(n_jobs)
+
+        # Create a list of documents to process
+        documents = list(self._corpus.documents)
+
+        # Generate candidates in parallel
+        with pool_constructor(
+            n_jobs,
+            initializer=MLLMCandidateGenerator.init,
+            initargs=({"backend": self._backend},),
+        ) as pool:
+            candidate_subject_pairs = pool.map(
+                MLLMCandidateGenerator.generate_for_doc,
+                documents,
+            )
+
+        # Unpack the results
+        for candidates, subject_set in candidate_subject_pairs:
             all_candidates.append(candidates)
-            gold_subjects.append(doc.subject_set)
+            gold_subjects.append(subject_set)
 
         return {
             "train_x": train_x,

--- a/tests/test_backend_mllm.py
+++ b/tests/test_backend_mllm.py
@@ -121,6 +121,22 @@ def test_mllm_hyperopt(project, fulltext_corpus):
     optimizer.optimize(n_trials=3, n_jobs=1, results_file=None)
 
 
+def test_mllm_hyperopt_parallel_n_jobs_2(project, fulltext_corpus):
+    """Test MLLM hyperopt with n_jobs=2 (parallel processing with 2 workers)"""
+    mllm_type = annif.backend.get_backend("mllm")
+    mllm = mllm_type(
+        backend_id="mllm",
+        config_params={"limit": 10, "language": "fi"},
+        project=project,
+    )
+
+    optimizer = mllm.get_hp_optimizer(fulltext_corpus, metric="NDCG")
+    result = optimizer.optimize(n_trials=3, n_jobs=2, results_file=None)
+
+    # Verify result is a valid HPRecommendation with expected structure
+    assert len(result.lines) == 3
+
+
 def test_mllm_train_cached_no_data(datadir, project):
     modelfile = datadir.join("mllm-model.gz")
     assert modelfile.exists()


### PR DESCRIPTION
`mllm.py` has a note on [L84](https://github.com/NatLibFi/Annif/blob/3b1ca51200ae93c062b04311f719cdc7a885a467/annif/backend/mllm.py#L84):
> TODO parallelize generation of candidates

So I implemented it in this PR.  Results look good:

```
time uv run annif hyperopt -j 1 --metric F1@5 --trials 10 wikicore_en_mllm_core fulltext/core-test.tsv;  
...
Got best F1@5 score 0.3124 with:
---
min_samples_leaf=23
max_leaf_nodes=1457
max_samples=0.7497
---
      715.53 real       701.82 user        13.34 sys
          1981104128  maximum resident set size
           298602741  instructions retired
           111497540  cycles elapsed
            21168536  peak memory footprint
```

```
time uv run annif hyperopt -j 10 --metric F1@5 --trials 10 wikicore_en_mllm_core fulltext/core-test.tsv; 
...
Got best F1@5 score 0.3142 with:
---
min_samples_leaf=26
max_leaf_nodes=1847
max_samples=0.6447
---
      199.12 real      1426.45 user        19.38 sys
          1395228672  maximum resident set size
           288509498  instructions retired
            90011185  cycles elapsed
            20529536  peak memory footprint
```