### PR TITLE
Upgrade to schemathesis~=4.25.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ dev = [
     "bumpversion",
     "black==25.*",
     "isort",
-    "schemathesis~=4.24.3",
+    "schemathesis~=4.25.2",
 ]
 all = ["annif[fasttext,estnltk,nn,omikuji,spacy,stwfsa,voikko,yake]"]
 


### PR DESCRIPTION
This resolves AttributeError on unit tests collection (see below), which originate from a change in [jsonschema-rs v0.50](https://github.com/Stranger6667/jsonschema/releases/tag/rust-v0.50.0) :
> CanonicalSchema::is_satisfiable is now CanonicalSchema::satisfiability, answering Yes, No, or Unknown - Yes wherever a value can be exhibited, not only for the forms listing their members.


```
================================================================================================================= test session starts =================================================================================================================
platform linux -- Python 3.13.12, pytest-9.1.1, pluggy-1.6.0
rootdir: /home/jmminkin/git/Annif
configfile: pyproject.toml
plugins: anyio-4.14.2, cov-7.1.0, hypothesis-6.165.10, flask-1.3.0, schemathesis-4.24.3
collected 0 items / 1 error                                                                                                                                                                                                                           

======================================================================================================================= ERRORS ========================================================================================================================
_______________________________________________________________________________________________________ ERROR collecting tests/test_openapi.py ________________________________________________________________________________________________________
<clip>
.venv/lib/python3.13/site-packages/schemathesis/specs/openapi/_hypothesis.py:1187: in make_positive_strategy
    strategy = _canonical_strategy_or_none(schema, generation_config, validator_cls)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.13/site-packages/schemathesis/specs/openapi/_hypothesis.py:1209: in _canonical_strategy_or_none
    if not canonical.is_satisfiable():
           ^^^^^^^^^^^^^^^^^^^^^^^^
E   AttributeError: 'builtins.CanonicalSchema' object has no attribute 'is_satisfiable'
E   while generating 'ex' from openapi_cases(operation=, hooks=HookDispatcher(scope=<HookScope.TEST: 3>,
E    _hooks=defaultdict(list, {}),
E    _specs={'filter_path_parameters': ,
E     'filter_query': ,
E     'filter_headers': ,
E     'filter_cookies': ,
E     'filter_body': ,
E     'filter_case': ,
E     'map_path_parameters': ,
E     'map_query': ,
E     'map_headers': ,
E     'map_cookies': ,
E     'map_body': ,
E     'map_case': ,
E     'flatmap_path_parameters': ,
E     'flatmap_query': ,
E     'flatmap_headers': ,
E     'flatmap_cookies': ,
E     'flatmap_body': ,
E     'flatmap_case': ,
E     'before_generate_path_parameters': ,
E     'before_generate_headers': ,
E     'before_generate_cookies': ,
E     'before_generate_query': ,
E     'before_generate_body': ,
E     'before_generate_case': ,
E     'before_process_path': ,
E     'before_load_schema': ,
E     'after_load_schema': ,
E     'before_add_examples': ,
E     'before_init_operation': ,
E     'before_call': ,
E     'after_call': ,
E     'after_network_error': ,
E     'after_validate': }), path_parameters={'project_id': 'dummy-fi'}, phase=<TestPhase.EXAMPLES: 'examples'>).map(serialize_components)

During handling of the above exception, another exception occurred:
.venv/lib/python3.13/site-packages/schemathesis/pytest/plugin.py:304: in collect
    pytest.fail("Error during collection")
E   Failed: Error during collection
================================================================================================================== warnings summary ===================================================================================================================
.venv/lib/python3.13/site-packages/connexion/apps/abstract.py:9
```
