### PR TITLE
Remove unused environment variables from CICD 

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -8,8 +8,6 @@ on:
   pull_request:
   workflow_dispatch:
 env:
-  PIPX_HOME: "/home/runner/.cache/pipx"
-  PIPX_BIN_DIR: "/home/runner/.local/bin"
   UV_VERSION: "0.9.*"
 permissions:
   contents: read


### PR DESCRIPTION
This removes `PIPX_HOME` and `PIPX_BIN_DIR` environment variables, which became obsolete when migrating from poetry to uv (#923).